### PR TITLE
feat(auth): implement access token guard and add error handling

### DIFF
--- a/src/common/errors/error-codes.ts
+++ b/src/common/errors/error-codes.ts
@@ -82,6 +82,13 @@ export const ERROR_DEFINITIONS = {
     message: '음성 분석 중입니다. 잠시만 기다려 주세요.',
   },
 
+  // SOCIAL
+  SOCIAL_TARGET_USER_NOT_FOUND: {
+    status: HttpStatus.NOT_FOUND,
+    code: 'SOCIAL-001',
+    message: '대상 사용자를 찾을 수 없습니다. 사용자 정보를 확인해 주세요.',
+  },
+
   // PROF
   PROFILE_NOT_REGISTERED: {
     status: HttpStatus.CONFLICT,

--- a/src/modules/social/controllers/block/block.controller.ts
+++ b/src/modules/social/controllers/block/block.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Patch, Post, Query } from '@nestjs/common';
+import { Body, Controller, Get, Patch, Post, Query, UseGuards } from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiOperation,
@@ -12,9 +12,11 @@ import {
 import { BlockService } from '../../services/block/block.service';
 import { BlockDto } from '../../dtos/block.dto';
 import { RequiredUserId } from '../../../auth/decorators';
+import { AccessTokenGuard } from '../../../auth/guards/access-token.guard';
 
 @ApiTags('Block')
-@ApiBearerAuth()
+@ApiBearerAuth('access-token')
+@UseGuards(AccessTokenGuard)
 @Controller('block')
 export class BlockController {
   public constructor(private readonly blockService: BlockService) {}

--- a/src/modules/social/controllers/heart/heart.controller.ts
+++ b/src/modules/social/controllers/heart/heart.controller.ts
@@ -7,6 +7,7 @@ import {
   Patch,
   Post,
   Query,
+  UseGuards,
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
@@ -25,11 +26,13 @@ import {
   HeartSentItem,
 } from '../../dtos/heart.dto';
 import { RequiredUserId } from '../../../auth/decorators';
+import { AccessTokenGuard } from '../../../auth/guards/access-token.guard';
 import { AppException } from '../../../../common/errors/app.exception';
 import { ERROR_DEFINITIONS } from '../../../../common/errors/error-codes';
 
 @ApiTags('Heart')
-@ApiBearerAuth()
+@ApiBearerAuth('access-token')
+@UseGuards(AccessTokenGuard)
 @Controller('hearts')
 export class HeartController {
   public constructor(private readonly heartService: HeartService) {}

--- a/src/modules/social/controllers/report/report.controller.ts
+++ b/src/modules/social/controllers/report/report.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Post, UseGuards } from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiBody,
@@ -9,9 +9,11 @@ import {
 } from '@nestjs/swagger';
 import { ReportService } from '../../services/report/report.service';
 import { RequiredUserId } from '../../../auth/decorators';
+import { AccessTokenGuard } from '../../../auth/guards/access-token.guard';
 
 @ApiTags('Report')
-@ApiBearerAuth()
+@ApiBearerAuth('access-token')
+@UseGuards(AccessTokenGuard)
 @Controller('report')
 export class ReportController {
   public constructor(private readonly reportService: ReportService) {}

--- a/src/modules/social/repositories/heart.repository.ts
+++ b/src/modules/social/repositories/heart.repository.ts
@@ -26,6 +26,16 @@ export class HeartRepository {
     this.logger.debug(
       `postHeart sentById=${payload.sentById} sentToId=${payload.sentToId}`,
     );
+    const targetUser = await this.prisma.user.findUnique({
+      where: { id: payload.sentToId },
+      select: { id: true },
+    });
+    if (!targetUser) {
+      throw new AppException('SOCIAL_TARGET_USER_NOT_FOUND', {
+        message: ERROR_DEFINITIONS.SOCIAL_TARGET_USER_NOT_FOUND.message,
+        details: { targetUserId: payload.sentToId.toString() },
+      });
+    }
     const response = await this.prisma.heart.create({ data: payload });
     return {
       heartId: Number(response.id),

--- a/src/modules/social/social.module.ts
+++ b/src/modules/social/social.module.ts
@@ -8,8 +8,10 @@ import { ReportService } from './services/report/report.service';
 import { HeartRepository } from './repositories/heart.repository';
 import { BlockRepository } from './repositories/block.repository';
 import { ReportRepository } from './repositories/report.repository';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
+  imports: [AuthModule],
   controllers: [HeartController, BlockController, ReportController],
   providers: [
     BlockService,

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -16,6 +16,7 @@ export function setupSwagger(app: INestApplication) {
       },
       'access-token',
     )
+    .addSecurityRequirements('access-token')
     .build();
 
   const document = SwaggerModule.createDocument(app, config);


### PR DESCRIPTION
## 이슈 번호
closes #17

## 주요 변경사항
-  Social API 인증 이슈 수정 (Swagger / Guard)
- access-token 보안 스킴 통일
- Block / Heart / Report API 인증 헤더 정상 적용

## 테스트 결과 
- /auth/kakao/login → accessToken 발급
- Swagger Authorize(access-token)에 accessToken 입력
- /api/v1/hearts, /api/v1/block, /api/v1/report 정상 호출 확인

## 참고 및 개선사항
- 
