### PR TITLE
[fix] userMarketingAgreement, marketingAgreement 이름 바뀐 테이블 수정

### DIFF
--- a/prisma/migrations/20260115112919_modify_marketing_agreement_name/migration.sql
+++ b/prisma/migrations/20260115112919_modify_marketing_agreement_name/migration.sql
@@ -1,0 +1,66 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `agreedAt` on the `marketingagreement` table. All the data in the column will be lost.
+  - You are about to drop the column `deletedAt` on the `marketingagreement` table. All the data in the column will be lost.
+  - You are about to drop the column `isAgreed` on the `marketingagreement` table. All the data in the column will be lost.
+  - You are about to drop the column `marketingAgreementId` on the `marketingagreement` table. All the data in the column will be lost.
+  - You are about to drop the column `userId` on the `marketingagreement` table. All the data in the column will be lost.
+  - You are about to drop the column `body` on the `usermarketingagreement` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[marketingAgreementId,userId]` on the table `UserMarketingAgreement` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `body` to the `MarketingAgreement` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `marketingAgreementId` to the `UserMarketingAgreement` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `userId` to the `UserMarketingAgreement` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE `marketingagreement` DROP FOREIGN KEY `MarketingAgreement_marketingAgreementId_fkey`;
+
+-- DropForeignKey
+ALTER TABLE `marketingagreement` DROP FOREIGN KEY `MarketingAgreement_userId_fkey`;
+
+-- DropIndex
+DROP INDEX `MarketingAgreement_agreedAt_idx` ON `marketingagreement`;
+
+-- DropIndex
+DROP INDEX `MarketingAgreement_isAgreed_idx` ON `marketingagreement`;
+
+-- DropIndex
+DROP INDEX `MarketingAgreement_marketingAgreementId_userId_key` ON `marketingagreement`;
+
+-- DropIndex
+DROP INDEX `MarketingAgreement_userId_idx` ON `marketingagreement`;
+
+-- AlterTable
+ALTER TABLE `marketingagreement` DROP COLUMN `agreedAt`,
+    DROP COLUMN `deletedAt`,
+    DROP COLUMN `isAgreed`,
+    DROP COLUMN `marketingAgreementId`,
+    DROP COLUMN `userId`,
+    ADD COLUMN `body` VARCHAR(255) NOT NULL;
+
+-- AlterTable
+ALTER TABLE `usermarketingagreement` DROP COLUMN `body`,
+    ADD COLUMN `agreedAt` DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    ADD COLUMN `deletedAt` DATETIME(6) NULL,
+    ADD COLUMN `isAgreed` BOOLEAN NOT NULL DEFAULT true,
+    ADD COLUMN `marketingAgreementId` BIGINT NOT NULL,
+    ADD COLUMN `userId` BIGINT NOT NULL;
+
+-- CreateIndex
+CREATE INDEX `UserMarketingAgreement_userId_idx` ON `UserMarketingAgreement`(`userId`);
+
+-- CreateIndex
+CREATE INDEX `UserMarketingAgreement_agreedAt_idx` ON `UserMarketingAgreement`(`agreedAt`);
+
+-- CreateIndex
+CREATE INDEX `UserMarketingAgreement_isAgreed_idx` ON `UserMarketingAgreement`(`isAgreed`);
+
+-- CreateIndex
+CREATE UNIQUE INDEX `UserMarketingAgreement_marketingAgreementId_userId_key` ON `UserMarketingAgreement`(`marketingAgreementId`, `userId`);
+
+-- AddForeignKey
+ALTER TABLE `UserMarketingAgreement` ADD CONSTRAINT `UserMarketingAgreement_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `User`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `UserMarketingAgreement` ADD CONSTRAINT `UserMarketingAgreement_marketingAgreementId_fkey` FOREIGN KEY (`marketingAgreementId`) REFERENCES `MarketingAgreement`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20260115112919_modify_marketing_agreement_name/migration.sql
+++ b/prisma/migrations/20260115112919_modify_marketing_agreement_name/migration.sql
@@ -14,25 +14,25 @@
 
 */
 -- DropForeignKey
-ALTER TABLE `marketingagreement` DROP FOREIGN KEY `MarketingAgreement_marketingAgreementId_fkey`;
+ALTER TABLE `MarketingAgreement` DROP FOREIGN KEY `MarketingAgreement_marketingAgreementId_fkey`;
 
 -- DropForeignKey
-ALTER TABLE `marketingagreement` DROP FOREIGN KEY `MarketingAgreement_userId_fkey`;
+ALTER TABLE `MarketingAgreement` DROP FOREIGN KEY `MarketingAgreement_userId_fkey`;
 
 -- DropIndex
-DROP INDEX `MarketingAgreement_agreedAt_idx` ON `marketingagreement`;
+DROP INDEX `MarketingAgreement_agreedAt_idx` ON `MarketingAgreement`;
 
 -- DropIndex
-DROP INDEX `MarketingAgreement_isAgreed_idx` ON `marketingagreement`;
+DROP INDEX `MarketingAgreement_isAgreed_idx` ON `MarketingAgreement`;
 
 -- DropIndex
-DROP INDEX `MarketingAgreement_marketingAgreementId_userId_key` ON `marketingagreement`;
+DROP INDEX `MarketingAgreement_marketingAgreementId_userId_key` ON `MarketingAgreement`;
 
 -- DropIndex
-DROP INDEX `MarketingAgreement_userId_idx` ON `marketingagreement`;
+DROP INDEX `MarketingAgreement_userId_idx` ON `MarketingAgreement`;
 
 -- AlterTable
-ALTER TABLE `marketingagreement` DROP COLUMN `agreedAt`,
+ALTER TABLE `MarketingAgreement` DROP COLUMN `agreedAt`,
     DROP COLUMN `deletedAt`,
     DROP COLUMN `isAgreed`,
     DROP COLUMN `marketingAgreementId`,
@@ -40,7 +40,7 @@ ALTER TABLE `marketingagreement` DROP COLUMN `agreedAt`,
     ADD COLUMN `body` VARCHAR(255) NOT NULL;
 
 -- AlterTable
-ALTER TABLE `usermarketingagreement` DROP COLUMN `body`,
+ALTER TABLE `UserMarketingAgreement` DROP COLUMN `body`,
     ADD COLUMN `agreedAt` DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
     ADD COLUMN `deletedAt` DATETIME(6) NULL,
     ADD COLUMN `isAgreed` BOOLEAN NOT NULL DEFAULT true,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -94,7 +94,7 @@ model User {
   chatParticipations  ChatParticipant[]
   sentMessages        ChatMessage[]          @relation("ChatMessagesSentBy")
   receivedMessages    ChatMessage[]          @relation("ChatMessagesSentTo")
-  marketingAgreements MarketingAgreement[]
+  userMarketingAgreement UserMarketingAgreement[]
   refreshTokens       RefreshToken[]
   blocksInitiated     Block[]                @relation("UserBlocksBy")
   blocksReceived      Block[]                @relation("UserBlocks")
@@ -353,13 +353,13 @@ model ChatMedia {
   @@index([messageId])
 }
 
-model UserMarketingAgreement {
+model MarketingAgreement {
   id                  BigInt               @id @default(autoincrement()) @db.BigInt
   body                String               @db.VarChar(255)
-  marketingAgreements MarketingAgreement[]
+  userMarketingAgreement UserMarketingAgreement[]
 }
 
-model MarketingAgreement {
+model UserMarketingAgreement {
   id                   BigInt    @id @default(autoincrement()) @db.BigInt
   marketingAgreementId BigInt    @db.BigInt
   userId               BigInt    @db.BigInt
@@ -368,7 +368,7 @@ model MarketingAgreement {
   deletedAt            DateTime? @db.DateTime(6)
 
   user                   User                   @relation(fields: [userId], references: [id])
-  userMarketingAgreement UserMarketingAgreement @relation(fields: [marketingAgreementId], references: [id])
+  marketingAgreement     MarketingAgreement @relation(fields: [marketingAgreementId], references: [id])
 
   @@unique([marketingAgreementId, userId])
   @@index([userId])


### PR DESCRIPTION
## 이슈 번호
close #19

## 주요 변경사항
- userMarketingAgreement(유저별 동의 현황)와 MarketingAgreement(마케팅 약관 목록) 두 개의 릴레이션 이름이 바뀌어 있었는데, 알맞게 수정했습니다.

## 테스트 결과 (스크린샷)
- 
<img width="787" height="272" alt="image" src="https://github.com/user-attachments/assets/171cc825-6e04-4f9a-9bfc-0a445f3b2b1e" />
마이그레이션 잘 생성되었습니다.

## 참고 및 개선사항
- 
