### PR TITLE
Validate areaCode on user profile update

### DIFF
--- a/src/modules/app/app.module.ts
+++ b/src/modules/app/app.module.ts
@@ -6,6 +6,7 @@ import { envSchema } from '../../config/env.schema';
 import { HealthModule } from '../health/health.module';
 import { PrismaModule } from 'src/infra/prisma/prisma.module';
 import { AuthModule } from '../auth/auth.module';
+import { UserModule } from '../user/user.module';
 
 @Module({
   imports: [
@@ -26,6 +27,7 @@ import { AuthModule } from '../auth/auth.module';
     HealthModule,
     PrismaModule,
     AuthModule,
+    UserModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/modules/user/controllers/user/user.controller.spec.ts
+++ b/src/modules/user/controllers/user/user.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UserController } from './user.controller';
+import { UserService } from '../../services/user/user.service';
 
 describe('UserController', () => {
   let controller: UserController;
@@ -7,6 +8,12 @@ describe('UserController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [UserController],
+      providers: [
+        {
+          provide: UserService,
+          useValue: { getMe: jest.fn() },
+        },
+      ],
     }).compile();
 
     controller = module.get<UserController>(UserController);

--- a/src/modules/user/controllers/user/user.controller.ts
+++ b/src/modules/user/controllers/user/user.controller.ts
@@ -1,4 +1,64 @@
-import { Controller } from '@nestjs/common';
+import { Body, Controller, Get, Patch, Put, UseGuards } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiHeader,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+import { CurrentUser } from '../../../auth/decorators/current-user.decorator';
+import { AccessTokenGuard } from '../../../auth/guards/access-token.guard';
+import { UserMeResponseDto } from '../../dtos/user-me-response.dto';
+import { UserKeywordsUpdateRequestDto } from '../../dtos/user-keywords-update-request.dto';
+import { UserProfileUpdateRequestDto } from '../../dtos/user-profile-update-request.dto';
+import { UserService } from '../../services/user/user.service';
 
-@Controller('user')
-export class UserController {}
+@ApiTags('User')
+@ApiBearerAuth('access-token')
+@ApiHeader({
+  name: 'Authorization',
+  description: 'Bearer access token',
+  required: true,
+})
+@Controller('users')
+export class UserController {
+  constructor(private readonly userService: UserService) {}
+
+  @Get('me')
+  @UseGuards(AccessTokenGuard)
+  @ApiOperation({ summary: 'Get my profile' })
+  @ApiOkResponse({ type: UserMeResponseDto })
+  getMe(@CurrentUser('userId') userId: number | null) {
+    return this.userService.getMe(userId ?? 0);
+  }
+
+  @Patch('me')
+  @UseGuards(AccessTokenGuard)
+  @ApiOperation({ summary: 'Update my profile' })
+  @ApiOkResponse({ type: UserMeResponseDto })
+  updateMe(
+    @CurrentUser('userId') userId: number | null,
+    @Body() body: UserProfileUpdateRequestDto,
+  ) {
+    return this.userService.updateMe(userId ?? 0, body);
+  }
+
+  @Patch('me/deactivate')
+  @UseGuards(AccessTokenGuard)
+  @ApiOperation({ summary: 'Deactivate my profile' })
+  @ApiOkResponse({ schema: { example: null } })
+  deactivateMe(@CurrentUser('userId') userId: number | null) {
+    return this.userService.deactivateMe(userId ?? 0);
+  }
+
+  @Put('me/keywords')
+  @UseGuards(AccessTokenGuard)
+  @ApiOperation({ summary: 'Update my keywords' })
+  @ApiOkResponse({ schema: { example: null } })
+  updateKeywords(
+    @CurrentUser('userId') userId: number | null,
+    @Body() body: UserKeywordsUpdateRequestDto,
+  ) {
+    return this.userService.updateKeywords(userId ?? 0, body);
+  }
+}

--- a/src/modules/user/dtos/user-keywords-update-request.dto.ts
+++ b/src/modules/user/dtos/user-keywords-update-request.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  ArrayNotEmpty,
+  ArrayUnique,
+  IsArray,
+  IsInt,
+  Min,
+} from 'class-validator';
+
+export class UserKeywordsUpdateRequestDto {
+  @ApiProperty({ example: [1, 5, 9] })
+  @IsArray()
+  @ArrayNotEmpty()
+  @ArrayUnique()
+  @Type(() => Number)
+  @IsInt({ each: true })
+  @Min(1, { each: true })
+  interestKeywordIds: number[];
+}

--- a/src/modules/user/dtos/user-me-response.dto.ts
+++ b/src/modules/user/dtos/user-me-response.dto.ts
@@ -1,0 +1,39 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Sex } from '@prisma/client';
+
+class UserAreaDto {
+  @ApiProperty({ example: '1168000000' })
+  code: string;
+
+  @ApiProperty({ example: '강남구' })
+  name: string;
+}
+
+export class UserMeResponseDto {
+  @ApiProperty({ example: 1 })
+  userId: number;
+
+  @ApiProperty({ example: '루씨' })
+  nickname: string;
+
+  @ApiProperty({ example: 'F', enum: Sex })
+  gender: Sex;
+
+  @ApiProperty({ example: '1972-03-01' })
+  birthDate: string;
+
+  @ApiProperty({ type: UserAreaDto })
+  area: UserAreaDto;
+
+  @ApiProperty({ example: '안녕하세요 ...' })
+  introText: string;
+
+  @ApiProperty({ example: ['뜨개질', '산책', '영화', '문화생활'] })
+  keywords: string[];
+
+  @ApiProperty({ example: 'https://cdn.example.com/files/intro.m4a' })
+  introAudioUrl: string;
+
+  @ApiProperty({ example: 'https://cdn.example.com/files/profile.jpg' })
+  profileImageUrl: string;
+}

--- a/src/modules/user/dtos/user-profile-update-request.dto.ts
+++ b/src/modules/user/dtos/user-profile-update-request.dto.ts
@@ -1,0 +1,19 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
+
+export class UserProfileUpdateRequestDto {
+  @ApiPropertyOptional({ example: '루씨' })
+  @IsOptional()
+  @IsString()
+  nickname?: string;
+
+  @ApiPropertyOptional({ example: '1168000000' })
+  @IsOptional()
+  @IsString()
+  areaCode?: string;
+
+  @ApiPropertyOptional({ example: '수정된 자기소개' })
+  @IsOptional()
+  @IsString()
+  introText?: string;
+}

--- a/src/modules/user/repositories/user.repository.ts
+++ b/src/modules/user/repositories/user.repository.ts
@@ -1,0 +1,132 @@
+import { Injectable } from '@nestjs/common';
+import { ActiveStatus, Prisma } from '@prisma/client';
+import { PrismaService } from '../../../../infra/prisma/prisma.service';
+
+@Injectable()
+export class UserRepository {
+  constructor(private readonly prismaService: PrismaService) {}
+
+  findProfileById(userId: number) {
+    return this.prismaService.user.findFirst({
+      where: {
+        id: BigInt(userId),
+        deletedAt: null,
+        status: ActiveStatus.ACTIVE,
+      },
+      select: {
+        id: true,
+        nickname: true,
+        sex: true,
+        birthdate: true,
+        introText: true,
+        introVoiceUrl: true,
+        profileImageUrl: true,
+        address: {
+          select: {
+            code: true,
+            fullName: true,
+            sigunguName: true,
+          },
+        },
+        interests: {
+          where: { deletedAt: null },
+          select: {
+            interest: {
+              select: {
+                body: true,
+              },
+            },
+          },
+        },
+      },
+    });
+  }
+
+  findAddressByCode(code: string) {
+    return this.prismaService.address.findUnique({
+      where: { code },
+      select: { code: true },
+    });
+  }
+
+  updateProfile(
+    userId: number,
+    data: { nickname?: string; code?: string; introText?: string },
+  ) {
+    return this.prismaService.user.updateMany({
+      where: {
+        id: BigInt(userId),
+        deletedAt: null,
+        status: ActiveStatus.ACTIVE,
+      },
+      data,
+    });
+  }
+
+  deactivateProfile(userId: number) {
+    return this.prismaService.user.updateMany({
+      where: {
+        id: BigInt(userId),
+        deletedAt: null,
+        status: ActiveStatus.ACTIVE,
+      },
+      data: {
+        status: ActiveStatus.INACTIVE,
+        deletedAt: new Date(),
+      },
+    });
+  }
+
+  async updateKeywords(userId: number, interestKeywordIds: number[]) {
+    const now = new Date();
+    const ids = interestKeywordIds.map((id) => BigInt(id));
+
+    return this.prismaService.$transaction(async (tx) => {
+      await tx.userInterest.updateMany({
+        where: {
+          userId: BigInt(userId),
+          deletedAt: null,
+          ...(ids.length > 0 ? { interestId: { notIn: ids } } : {}),
+        },
+        data: {
+          deletedAt: now,
+        },
+      });
+
+      if (ids.length > 0) {
+        await tx.userInterest.updateMany({
+          where: {
+            userId: BigInt(userId),
+            interestId: { in: ids },
+          },
+          data: {
+            deletedAt: null,
+          },
+        });
+
+        const existing = await tx.userInterest.findMany({
+          where: {
+            userId: BigInt(userId),
+            interestId: { in: ids },
+          },
+          select: { interestId: true },
+        });
+
+        const existingIds = new Set(
+          existing.map((item) => Number(item.interestId)),
+        );
+        const createData = interestKeywordIds
+          .filter((id) => !existingIds.has(id))
+          .map((id) => ({
+            userId: BigInt(userId),
+            interestId: BigInt(id),
+            vibeVector: Prisma.JsonNull,
+          }));
+
+        if (createData.length > 0) {
+          await tx.userInterest.createMany({ data: createData });
+        }
+      }
+    });
+  }
+}

--- a/src/modules/user/services/user/user.service.ts
+++ b/src/modules/user/services/user/user.service.ts
@@ -1,4 +1,116 @@
 import { Injectable } from '@nestjs/common';
+import { AppException } from '../../../../common/errors/app.exception';
+import { UserMeResponseDto } from '../../dtos/user-me-response.dto';
+import { UserProfileUpdateRequestDto } from '../../dtos/user-profile-update-request.dto';
+import { UserKeywordsUpdateRequestDto } from '../../dtos/user-keywords-update-request.dto';
+import { UserRepository } from '../../repositories/user.repository';
 
 @Injectable()
-export class UserService {}
+export class UserService {
+  constructor(private readonly userRepository: UserRepository) {}
+
+  async getMe(userId: number): Promise<UserMeResponseDto> {
+    if (!userId) {
+      throw new AppException('AUTH_LOGIN_REQUIRED');
+    }
+
+    const user = await this.userRepository.findProfileById(userId);
+
+    if (!user) {
+      throw new AppException('AUTH_LOGIN_REQUIRED');
+    }
+
+    const areaName = user.address.sigunguName ?? user.address.fullName;
+    const keywords = user.interests
+      .map((interest) => interest.interest.body)
+      .filter((body): body is string => Boolean(body));
+    const birthDate = user.birthdate.toISOString().split('T')[0];
+
+    return {
+      userId: Number(user.id),
+      nickname: user.nickname,
+      gender: user.sex,
+      birthDate,
+      area: {
+        code: user.address.code,
+        name: areaName,
+      },
+      introText: user.introText,
+      keywords,
+      introAudioUrl: user.introVoiceUrl,
+      profileImageUrl: user.profileImageUrl,
+    };
+  }
+
+  async updateMe(
+    userId: number,
+    payload: UserProfileUpdateRequestDto,
+  ): Promise<UserMeResponseDto> {
+    if (!userId) {
+      throw new AppException('AUTH_LOGIN_REQUIRED');
+    }
+
+    const updateData: { nickname?: string; code?: string; introText?: string } =
+      {};
+
+    if (payload.nickname !== undefined) {
+      updateData.nickname = payload.nickname;
+    }
+
+    if (payload.areaCode !== undefined) {
+      const address = await this.userRepository.findAddressByCode(
+        payload.areaCode,
+      );
+      if (!address) {
+        throw new AppException('VALIDATION_INVALID_FORMAT', {
+          message: '유효하지 않은 지역 코드입니다.',
+        });
+      }
+      updateData.code = payload.areaCode;
+    }
+
+    if (payload.introText !== undefined) {
+      updateData.introText = payload.introText;
+    }
+
+    if (Object.keys(updateData).length > 0) {
+      const result = await this.userRepository.updateProfile(
+        userId,
+        updateData,
+      );
+
+      if (result.count === 0) {
+        throw new AppException('AUTH_LOGIN_REQUIRED');
+      }
+    }
+
+    return this.getMe(userId);
+  }
+
+  async deactivateMe(userId: number): Promise<null> {
+    if (!userId) {
+      throw new AppException('AUTH_LOGIN_REQUIRED');
+    }
+
+    const result = await this.userRepository.deactivateProfile(userId);
+
+    if (result.count === 0) {
+      throw new AppException('AUTH_LOGIN_REQUIRED');
+    }
+
+    return null;
+  }
+
+  async updateKeywords(
+    userId: number,
+    payload: UserKeywordsUpdateRequestDto,
+  ): Promise<null> {
+    if (!userId) {
+      throw new AppException('AUTH_LOGIN_REQUIRED');
+    }
+
+    await this.userRepository.updateKeywords(userId, payload.interestKeywordIds);
+
+    return null;
+  }
+}

--- a/src/modules/user/user.module.ts
+++ b/src/modules/user/user.module.ts
@@ -1,9 +1,12 @@
 import { Module } from '@nestjs/common';
 import { UserController } from './controllers/user/user.controller';
 import { UserService } from './services/user/user.service';
+import { UserRepository } from './repositories/user.repository';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
+  imports: [AuthModule],
   controllers: [UserController],
-  providers: [UserService],
+  providers: [UserService, UserRepository],
 })
 export class UserModule {}


### PR DESCRIPTION
### Motivation
- Prevent Prisma foreign key constraint errors when updating `User.code` by ensuring the provided `areaCode` exists in the `Address` table before performing the update.
- Provide user-facing APIs and related DTOs, repository and service support for fetching/updating the current user's profile and keywords, and register the user module so controllers/guards can be resolved.

### Description
- Add `findAddressByCode` to `UserRepository` to query `Address` by `code` and use it to validate `areaCode` inputs in `UserService` before updating the user profile.
- Update `UserService.updateMe` to check `areaCode` existence and throw `AppException('VALIDATION_INVALID_FORMAT')` with a friendly message when the code is invalid.
- Implement user APIs in `UserController` for `GET /users/me`, `PATCH /users/me`, `PATCH /users/me/deactivate`, and `PUT /users/me/keywords`, wired with `AccessTokenGuard` and `@CurrentUser`.
- Add DTOs `UserMeResponseDto`, `UserProfileUpdateRequestDto`, and `UserKeywordsUpdateRequestDto` and implement repository methods (`findProfileById`, `updateProfile`, `deactivateProfile`, `updateKeywords`) where `updateKeywords` uses a transaction and sets `vibeVector: Prisma.JsonNull` for new rows.
- Wire modules and providers by importing `UserModule` into `AppModule`, importing `AuthModule` into `UserModule`, and registering `UserRepository` in `UserModule`.
- Update `UserController` unit test to provide a mock `UserService` so the controller can be instantiated in tests.

### Testing
- No automated tests were executed for these changes.
- The controller unit spec was updated to register a mock `UserService`, but the test suite was not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969b31de474832d9dc97c330465737a)