### PR TITLE
feat(auth): implement user login restriction based on report count

### DIFF
--- a/src/common/errors/error-codes.ts
+++ b/src/common/errors/error-codes.ts
@@ -39,6 +39,11 @@ export const ERROR_DEFINITIONS = {
     message:
       '카카오 프로필 정보를 가져오지 못했습니다. 잠시 후 다시 시도해 주세요.',
   },
+  AUTH_USER_BLOCKED: {
+    status: HttpStatus.FORBIDDEN,
+    code: 'AUTH-008',
+    message: '신고 누적으로 로그인이 제한되었습니다. 고객센터에 문의해 주세요.',
+  },
 
   // VALID
   VALIDATION_INVALID_FORMAT: {

--- a/src/modules/auth/services/kakao-auth.service.ts
+++ b/src/modules/auth/services/kakao-auth.service.ts
@@ -1,6 +1,11 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { ActiveStatus, AddressLevel, AuthProvider, Prisma } from '@prisma/client';
+import {
+  ActiveStatus,
+  AddressLevel,
+  AuthProvider,
+  Prisma,
+} from '@prisma/client';
 import { createHash } from 'crypto';
 import type { SignOptions } from 'jsonwebtoken';
 import { PrismaService } from '../../../infra/prisma/prisma.service';

--- a/src/modules/auth/services/kakao-auth.service.ts
+++ b/src/modules/auth/services/kakao-auth.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { AddressLevel, AuthProvider, Prisma } from '@prisma/client';
+import { ActiveStatus, AddressLevel, AuthProvider, Prisma } from '@prisma/client';
 import { createHash } from 'crypto';
 import type { SignOptions } from 'jsonwebtoken';
 import { PrismaService } from '../../../infra/prisma/prisma.service';
@@ -79,6 +79,7 @@ export class KakaoAuthService {
     });
 
     const userId = Number(userRecord.user.id) || 0;
+    await this.ensureUserCanLogin(userId, userRecord.user.status);
 
     const payload = {
       sub: userId,
@@ -218,6 +219,34 @@ export class KakaoAuthService {
       },
       { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
     );
+  }
+
+  private async ensureUserCanLogin(
+    userId: number,
+    status: ActiveStatus,
+  ): Promise<void> {
+    if (status !== ActiveStatus.ACTIVE) {
+      throw new AppException('AUTH_USER_BLOCKED');
+    }
+
+    const reportLimit = Number(
+      this.configService.get('MAX_REPORTS_BEFORE_BLOCK', '5'),
+    );
+    if (!Number.isFinite(reportLimit) || reportLimit <= 0) {
+      return;
+    }
+
+    const reportCount = await this.prismaService.report.count({
+      where: { reportedId: BigInt(userId), deletedAt: null },
+    });
+
+    if (reportCount >= reportLimit) {
+      await this.prismaService.user.update({
+        where: { id: BigInt(userId) },
+        data: { status: ActiveStatus.INACTIVE },
+      });
+      throw new AppException('AUTH_USER_BLOCKED');
+    }
   }
 
   private isOnboardingRequired(user: {


### PR DESCRIPTION
## 이슈 번호
close #35 

## 주요 변경사항
1) 차단용 에러 코드 추가
로그인 차단 시 사용자에게 명확한 메시지를 주기 위해 AUTH_USER_BLOCKED 에러 코드 추가
(HttpStatus.FORBIDDEN(403) -  “신고 누적으로 로그인이 제한되었습니다…” 메시지)

2) 로그인 흐름에 차단 여부 검사 삽입
카카오 로그인 서비스(loginWithKakao)에서 유저를 upsert 한 직후에 로그인 가능 여부를 검사하도록 추가
status 검사 + 신고 누적 검사를 수행하고, 문제가 있으면 토큰 발급 전에 예외를 던진다. 

3) 차단 검사 로직 (ensureUserCanLogin)
핵심 차단 로직은 ensureUserCanLogin에서 수행
- 현재 status 검사
ActiveStatus.ACTIVE가 아니라면 즉시 차단 예외
- 신고 임계치 설정 읽기
환경 변수 MAX_REPORTS_BEFORE_BLOCK을 읽고(기본값 5),
유효하지 않거나 0 이하이면 제한 검사를 생략
- 신고 누적 수 집계
Report 테이블에서 reportedId 기준으로 신고 개수를 카운트
deletedAt: null 조건으로 유효한 신고만 집계
임계치 이상이면 사용자 INACTIVE 처리 + 차단 에러

요약
에러코드 추가 → 차단 사유 메시지 제공
로그인 직전에 차단 검사 수행 → 토큰 발급 전에 차단 가능
status + 신고 누적 기반으로 차단 처리 → 임계치 도달 시 INACTIVE 전환
