### PR TITLE
[Feature] 한 번이라도 동의 프로세스를 지난 적이 있는지 조회 api 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "eum-backend",
       "version": "0.0.1",
-      "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.962.0",

--- a/src/modules/agreements/controllers/agreement.controller.ts
+++ b/src/modules/agreements/controllers/agreement.controller.ts
@@ -91,4 +91,29 @@ export class AgreementController {
       );
     }
   }
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: '한 번이라도 동의한 적 있는지 조회' })
+  @ApiResponse({
+    description: '한 번이라도 동의한 적 있는지 조회',
+    schema: {
+      example: {
+        resultType: 'SUCCESS',
+        success: {
+          data: {
+            hasPassed: true,
+          },
+        },
+        error: null,
+        meta: {
+          timestamp: '2026-01-10T09:53:11.014Z',
+          path: '/api/v1/users/me/agreements',
+        },
+      },
+    },
+  })
+  @Get('me/agreements')
+  @UseGuards(AccessTokenGuard)
+  async getUserAgreementHistory(@RequiredUserId() userId: number) {
+    return this.agreementService.getUserAgreementHistory(userId);
+  }
 }

--- a/src/modules/agreements/dtos/agreement.dto.ts
+++ b/src/modules/agreements/dtos/agreement.dto.ts
@@ -3,7 +3,6 @@ import { IsNumber, IsBoolean, IsArray, ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
 
-// db이름이 서로 swap되어서 (userMarketingAgreement<->MarketingAgreement) 추후 수정 예정
 export class AgreementResponseDto {
   agreementId: string;
   body: string;
@@ -35,4 +34,10 @@ export class CreateUserAgreementRequestDto {
     description: '마케팅 동의 약관',
   })
   marketingAgreements: AgreementItemDto[];
+}
+
+export class hasPassedResponseDto {
+  @ApiProperty({ example: true })
+  @IsBoolean()
+  hasPassed: boolean;
 }

--- a/src/modules/agreements/repositories/agreement.repository.ts
+++ b/src/modules/agreements/repositories/agreement.repository.ts
@@ -41,4 +41,14 @@ export class AgreementRepository {
       },
     });
   }
+  // GET api/v1/me/agreements
+  getUserAgreementHistory(userId: number) {
+    const result = this.prisma.userMarketingAgreement.findFirst({
+      where: {
+        userId,
+      },
+    });
+    console.log(result);
+    return result;
+  }
 }

--- a/src/modules/agreements/repositories/agreement.repository.ts
+++ b/src/modules/agreements/repositories/agreement.repository.ts
@@ -48,7 +48,6 @@ export class AgreementRepository {
         userId,
       },
     });
-    console.log(result);
     return result;
   }
 }

--- a/src/modules/agreements/services/agreement.service.ts
+++ b/src/modules/agreements/services/agreement.service.ts
@@ -30,4 +30,12 @@ export class AgreementService {
       isAgreed,
     );
   }
+  async getUserAgreementHistory(userId: number) {
+    const result =
+      await this.agreementRepository.getUserAgreementHistory(userId);
+    console.log('in service');
+    console.log(result);
+    if (result) return { hasPassed: true };
+    else return { hasPassed: false };
+  }
 }

--- a/src/modules/agreements/services/agreement.service.ts
+++ b/src/modules/agreements/services/agreement.service.ts
@@ -33,8 +33,6 @@ export class AgreementService {
   async getUserAgreementHistory(userId: number) {
     const result =
       await this.agreementRepository.getUserAgreementHistory(userId);
-    console.log('in service');
-    console.log(result);
     if (result) return { hasPassed: true };
     else return { hasPassed: false };
   }


### PR DESCRIPTION

## 이슈 번호
close # 56

## 주요 변경사항
- GET api/v1/me/agreements를 구현했습니다.
한 번이라도 동의 프로세스를 거쳤으면 응답으로 hasPassed: true가 반환되고,
그렇지 않은 경우 hasPassed: false가 반환됩니다.

## 테스트 결과 (스크린샷)

<img width="1680" height="647" alt="스크린샷 2026-01-28 171656" src="https://github.com/user-attachments/assets/49ca8052-a0d4-4a22-9a9f-0a151263f13f" />
한 번도 동의 프로세스를 거치지 않은 경우-> false 반환, 프론트측에서 다시 동의 화면 띄워야 함
<img width="1356" height="771" alt="스크린샷 2026-01-28 171717" src="https://github.com/user-attachments/assets/a4185059-ef2d-4a0a-9612-037a0dd2a6a0" />
동의 프로세스를 거쳐 DB에 동의 기록이 남아 있는 경우-> true반환, 동의 프로세스는 건너뛰어도 ok

## 참고 및 개선사항
- x
