### PR TITLE
Fix CD workflow env line continuation

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -57,7 +57,7 @@ jobs:
               -e REDIS_URL='${{ secrets.PROD_REDIS_URL }}' \
               -e JWT_SECRET='${{ secrets.PROD_JWT_SECRET }}' \
               -e JWT_ACCESS_SECRET='${{ secrets.PROD_JWT_ACCESS_SECRET }}' \
-              -e JWT_ACCESS_EXPIRES_IN='${{ secrets.PROD_JWT_ACCESS_EXPIRES_IN }}'
+              -e JWT_ACCESS_EXPIRES_IN='${{ secrets.PROD_JWT_ACCESS_EXPIRES_IN }}' \
               -e JWT_REFRESH_SECRET='${{ secrets.PROD_JWT_REFRESH_SECRET }}' \
               -e KAKAO_CLIENT_ID='${{ secrets.PROD_KAKAO_CLIENT_ID }}' \
               -e KAKAO_CLIENT_SECRET='${{ secrets.PROD_KAKAO_CLIENT_SECRET }}' \


### PR DESCRIPTION
### Motivation
- Restore the missing line continuation in the CD workflow `docker run` command so the image argument and subsequent env vars are included and the remote deploy doesn't fail.

### Description
- Add a trailing backslash to the `-e JWT_ACCESS_EXPIRES_IN='${{ secrets.PROD_JWT_ACCESS_EXPIRES_IN }}'` line in `.github/workflows/cd.yml` to continue the `docker run` command onto the next line.

### Testing
- No automated tests were run because this is a workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b662135508330a97f984ebf9b92f2)