### PR TITLE
[feat] 알림 생성 로직 구현

### DIFF
--- a/src/modules/notification/controllers/notification.controller.ts
+++ b/src/modules/notification/controllers/notification.controller.ts
@@ -5,6 +5,7 @@ import {
   Patch,
   Query,
   UseGuards,
+  Body,
 } from '@nestjs/common';
 import { NotificationService } from '../services/notification.service';
 import {

--- a/src/modules/notification/dtos/notification.dto.ts
+++ b/src/modules/notification/dtos/notification.dto.ts
@@ -1,6 +1,5 @@
 import { Notification } from '@prisma/client';
 import { IsString, IsBoolean } from 'class-validator';
-
 export class NotificationResponseDto {
   @IsString()
   notificationId: string;

--- a/src/modules/notification/repositories/notification.repository.ts
+++ b/src/modules/notification/repositories/notification.repository.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../../../infra/prisma/prisma.service';
+import { NotificationType } from '@prisma/client';
 
 @Injectable()
 export class NotificationRepository {
@@ -33,6 +34,24 @@ export class NotificationRepository {
         skip: 1,
       }),
       orderBy: { id: 'desc' },
+    });
+  }
+
+  // 알림 생성 로직
+  // param: userId,type,isRead,createdAt,deletedAt,title,body
+  createNotification(
+    userId: number,
+    type: NotificationType,
+    title: string,
+    body: string,
+  ) {
+    return this.prisma.notification.create({
+      data: {
+        userId: BigInt(userId),
+        type: type,
+        title: title,
+        body: body,
+      },
     });
   }
 }

--- a/src/modules/notification/services/notification.service.ts
+++ b/src/modules/notification/services/notification.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { NotificationRepository } from '../repositories/notification.repository';
 import { NotificationResponseDto } from '../dtos/notification.dto';
 import { AppException } from '../../../common/errors/app.exception';
-
+import { NotificationType } from '@prisma/client';
 @Injectable()
 export class NotificationService {
   constructor(
@@ -34,5 +34,20 @@ export class NotificationService {
       nextCursor: nextCursor !== null ? Number(nextCursor) : null,
       items: items.map((item) => NotificationResponseDto.from(item)),
     };
+  }
+
+  async createNotification(
+    userId: number,
+    type: NotificationType,
+    title: string,
+    body: string,
+  ) {
+    const result = await this.notificationRepository.createNotification(
+      userId,
+      type,
+      title,
+      body,
+    );
+    console.log(result);
   }
 }


### PR DESCRIPTION
## 이슈 번호
close # 80

## 주요 변경사항
- notification.repository.ts와 notification.service.ts에 알림 생성 로직을 구현했습니다.

## 테스트 결과 (스크린샷)
- 임시 컨트롤러를 만들어 테스트해보았고, 정상 작동합니다.
<img width="1897" height="704" alt="스크린샷 2026-02-08 214012" src="https://github.com/user-attachments/assets/35658282-d77b-4c47-ac36-8a0b007f28ca" />
<img width="1889" height="852" alt="스크린샷 2026-02-08 214024" src="https://github.com/user-attachments/assets/49ed7232-4d45-41c0-9fbe-baa5a4df29ab" />
<img width="1722" height="138" alt="스크린샷 2026-02-08 214048" src="https://github.com/user-attachments/assets/2dc1c1a5-c2e4-4938-9d09-2b20ea0b6de7" />


## 참고 및 개선사항
- 함수이름은 createNotification이고, 파라미터는 아래 스크린샷과 같습니다.
<img width="702" height="297" alt="image" src="https://github.com/user-attachments/assets/4ca4fbd5-5c44-4a70-906e-90e467f70006" />
