### PR TITLE
[feat] 알림 관련 api 세개 추가 구현 완료

### DIFF
--- a/src/modules/notification/controllers/notification.controller.ts
+++ b/src/modules/notification/controllers/notification.controller.ts
@@ -5,7 +5,7 @@ import {
   Patch,
   Query,
   UseGuards,
-  Body,
+  Delete,
 } from '@nestjs/common';
 import { NotificationService } from '../services/notification.service';
 import {
@@ -14,9 +14,12 @@ import {
   ApiResponse,
   ApiQuery,
   ApiBearerAuth,
+  ApiOkResponse,
 } from '@nestjs/swagger';
 import { RequiredUserId } from '../../../modules/auth/decorators';
 import { AccessTokenGuard } from '../../../modules/auth/guards/access-token.guard';
+import { NotificationResponseDto } from '../dtos/notification.dto';
+import { NotificationType } from '@prisma/client';
 
 @ApiBearerAuth('access-token')
 @Controller('notifications')
@@ -101,6 +104,81 @@ export class NotificationController {
       userId,
       cursor,
       size ? Number(size) : 20,
+    );
+  }
+
+  @ApiOperation({ description: '마음 알림 목록 조회' })
+  @ApiQuery({
+    name: 'cursor',
+    required: false,
+    description: '페이지네이션 커서',
+  })
+  @ApiQuery({
+    name: 'size',
+    required: false,
+    description: '한 페이지당 보여줄 알림 개수',
+    example: 20,
+  })
+  @ApiOkResponse({ type: NotificationResponseDto })
+  @Get('hearts')
+  @UseGuards(AccessTokenGuard)
+  findHeartNotifications(
+    @RequiredUserId() userId: number,
+    @Query('cursor') cursor?: string,
+    @Query('size') size?: string,
+  ) {
+    return this.notificationService.findNotificationByFilter(
+      userId,
+      NotificationType.HEART,
+      cursor,
+      size ? Number(size) : 20,
+    );
+  }
+
+  @ApiOperation({ description: '채팅 알림 목록 조회' })
+  @ApiQuery({
+    name: 'cursor',
+    required: false,
+    description: '페이지네이션 커서',
+  })
+  @ApiQuery({
+    name: 'size',
+    required: false,
+    description: '한 페이지당 보여줄 알림 개수',
+    example: 20,
+  })
+  @ApiOkResponse({ type: NotificationResponseDto })
+  @Get('chats')
+  @UseGuards(AccessTokenGuard)
+  findChatNotifications(
+    @RequiredUserId() userId: number,
+    @Query('cursor') cursor?: string,
+    @Query('size') size?: string,
+  ) {
+    return this.notificationService.findNotificationByFilter(
+      userId,
+      NotificationType.CHAT,
+      cursor,
+      size ? Number(size) : 20,
+    );
+  }
+
+  @ApiOperation({ description: '특정 알림 삭제' })
+  @ApiParam({
+    name: 'id',
+    description: '알림ID',
+    example: 1,
+  })
+  @ApiOkResponse()
+  @Delete(':id')
+  @UseGuards(AccessTokenGuard)
+  async deleteNotificationById(
+    @RequiredUserId() userId: number,
+    @Param('id') notificationId: string,
+  ) {
+    await this.notificationService.deleteNotificationById(
+      userId,
+      notificationId,
     );
   }
 }

--- a/src/modules/notification/dtos/notification.dto.ts
+++ b/src/modules/notification/dtos/notification.dto.ts
@@ -1,16 +1,29 @@
-import { Notification } from '@prisma/client';
-import { IsString, IsBoolean } from 'class-validator';
+import { Notification, NotificationType } from '@prisma/client';
+import { IsString, IsBoolean, IsEnum } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 export class NotificationResponseDto {
+  @ApiProperty({ description: '알림 고유 ID', example: '1' })
   @IsString()
   notificationId: string;
-  @IsString()
-  type: string;
+  @ApiProperty({ description: '알림 타입', example: 'CHAT' })
+  @IsEnum(NotificationType)
+  type: NotificationType;
+  @ApiProperty({ description: '알림 읽음 여부', example: false })
   @IsBoolean()
   isRead: boolean;
+  @ApiProperty({
+    description: '생성 시각',
+    example: '2026-02-09T13:20:00.000Z',
+  })
   @IsString()
   createdAt: string;
+  @ApiProperty({ description: '알림 제목', example: '마음이 도착했어요.' })
   @IsString()
   title: string;
+  @ApiProperty({
+    description: '알림 내용',
+    example: '루씨님이 마음을 보냈어요.',
+  })
   @IsString()
   body: string;
 

--- a/src/modules/notification/repositories/notification.repository.ts
+++ b/src/modules/notification/repositories/notification.repository.ts
@@ -54,4 +54,35 @@ export class NotificationRepository {
       },
     });
   }
+
+  // GET v1/notifications/hearts & GET v1/notifications/chats
+  findNotificationByFilter(
+    userId: number,
+    type: NotificationType,
+    cursor?: string,
+    limit = 20,
+  ) {
+    return this.prisma.notification.findMany({
+      where: {
+        userId: BigInt(userId),
+        type: type,
+      },
+      take: limit,
+      ...(cursor && {
+        cursor: { id: BigInt(cursor) },
+        skip: 1,
+      }),
+      orderBy: { id: 'desc' },
+    });
+  }
+
+  // DELETE v1/notifications/{notificationId}
+  deleteNotificationById(userId: number, notificationId: string) {
+    return this.prisma.notification.delete({
+      where: {
+        userId: BigInt(userId),
+        id: BigInt(notificationId),
+      },
+    });
+  }
 }

--- a/src/modules/notification/services/notification.service.ts
+++ b/src/modules/notification/services/notification.service.ts
@@ -50,4 +50,40 @@ export class NotificationService {
     );
     console.log(result);
   }
+
+  async findNotificationByFilter(
+    userId: number,
+    type: NotificationType,
+    cursor?: string,
+    limit = 20,
+  ) {
+    const result = await this.notificationRepository.findNotificationByFilter(
+      userId,
+      type,
+      cursor,
+      limit + 1,
+    );
+    const hasNext = result.length > limit;
+    const items = hasNext ? result.slice(0, limit) : result;
+    const nextCursor = hasNext ? items[items.length - 1].id : null;
+
+    return {
+      nextCursor: nextCursor !== null ? Number(nextCursor) : null,
+      items: items.map((item) => NotificationResponseDto.from(item)),
+    };
+  }
+
+  async deleteNotificationById(userId: number, notificationId: string) {
+    const notification = await this.notificationRepository.findNotificationById(
+      notificationId,
+      userId,
+    );
+    if (!notification) {
+      throw new AppException('NOTI_DOESNOT_EXIST');
+    }
+    await this.notificationRepository.deleteNotificationById(
+      userId,
+      notificationId,
+    );
+  }
 }


### PR DESCRIPTION
## 이슈 번호
close # 89

## 주요 변경사항
- GET v1/notifications/hearts
- GET v1/notifications/chats
- DELETE v1/notifications/{notificaionId}
를 구현했습니다.

## 테스트 결과 (스크린샷)
### GET v1/notifications/hearts(마음 관련 알림만 조회)
<img width="1775" height="712" alt="스크린샷 2026-02-09 135956" src="https://github.com/user-attachments/assets/755fcc05-c232-4c4c-ab56-e678987b98cd" />

### GET v1/notifications/chats(채팅 관련 알림만 조회)
<img width="1866" height="723" alt="스크린샷 2026-02-09 135941" src="https://github.com/user-attachments/assets/7408e52f-bb8f-404a-b1a2-e25d286c0074" />

### DELETE v1/notifications/{notificationId} (알림 id로 특정 알림 삭제)
- 알림 삭제 성공 시 응답
<img width="1818" height="572" alt="스크린샷 2026-02-09 142912" src="https://github.com/user-attachments/assets/0aba3a64-fc9d-421e-8b3a-c8d2b1ea830c" />

- DB에서 잘 삭제된 모습(21번 알림 삭제)
<img width="1775" height="429" alt="스크린샷 2026-02-09 142928" src="https://github.com/user-attachments/assets/91f953eb-a16f-49cc-9d67-8d8674f0c7c6" />

- 알림이 DB에 존재하지만 로그인된 유저의 것이 아닌 알림 삭제 시도할 때 응답
<img width="1833" height="624" alt="스크린샷 2026-02-09 142949" src="https://github.com/user-attachments/assets/11161e83-5070-4888-a02e-05f60a270e99" />



## 참고 및 개선사항
- x