### PR TITLE
feat: 읽음/삭제 처리 시 실시간 이벤트 브로드캐스트로

### DIFF
--- a/src/modules/chat/repositories/message.repository.ts
+++ b/src/modules/chat/repositories/message.repository.ts
@@ -161,7 +161,8 @@ export class MessageRepository {
           type,
           text: type === 'TEXT' ? text : null,
           url: type !== 'TEXT' ? mediaUrl : null,
-          durationSec: type === 'AUDIO' ? durationSec : null,
+          durationSec:
+            type === 'AUDIO' || type === 'VIDEO' ? durationSec : null,
         },
       });
 
@@ -169,7 +170,11 @@ export class MessageRepository {
     });
   }
 
-  async markAsRead(messageId: bigint, userId: bigint): Promise<boolean> {
+  async markAsRead(
+    messageId: bigint,
+    userId: bigint,
+    readAt: Date = new Date(),
+  ): Promise<boolean> {
     const updated = await this.prisma.chatMessage.updateMany({
       where: {
         id: messageId,
@@ -177,24 +182,24 @@ export class MessageRepository {
         readAt: null,
         deletedAt: null,
       },
-      data: {
-        readAt: new Date(),
-      },
+      data: { readAt },
     });
 
     return updated.count > 0;
   }
 
-  async deleteMessage(messageId: bigint, userId: bigint): Promise<boolean> {
+  async deleteMessage(
+    messageId: bigint,
+    userId: bigint,
+    deletedAt: Date = new Date(),
+  ): Promise<boolean> {
     const updated = await this.prisma.chatMessage.updateMany({
       where: {
         id: messageId,
         OR: [{ sentById: userId }, { sentToId: userId }],
         deletedAt: null,
       },
-      data: {
-        deletedAt: new Date(),
-      },
+      data: { deletedAt },
     });
 
     return updated.count > 0;

--- a/src/modules/chat/services/message/message.service.spec.ts
+++ b/src/modules/chat/services/message/message.service.spec.ts
@@ -3,6 +3,7 @@ import { MessageService } from './message.service';
 import { MessageRepository } from '../../repositories/message.repository';
 import { ParticipantRepository } from '../../repositories/participant.repository';
 import { RoomRepository } from '../../repositories/room.repository';
+import { ChatGateway } from '../../gateways/chat.gateway';
 
 describe('MessageService', () => {
   let service: MessageService;
@@ -10,6 +11,10 @@ describe('MessageService', () => {
   const messageRepoMock: Partial<MessageRepository> = {
     getLastMessageSummary: jest.fn(),
     findMessagesByRoomId: jest.fn(),
+    findMessageById: jest.fn(),
+    markAsRead: jest.fn(),
+    deleteMessage: jest.fn(),
+    createMessage: jest.fn(),
   };
 
   const participantRepoMock: Partial<ParticipantRepository> = {
@@ -21,6 +26,11 @@ describe('MessageService', () => {
     getPeerDetail: jest.fn(),
   };
 
+  const chatGatewayMock: Partial<ChatGateway> = {
+    emitMessageRead: jest.fn(),
+    emitMessageDeleted: jest.fn(),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -28,10 +38,15 @@ describe('MessageService', () => {
         { provide: MessageRepository, useValue: messageRepoMock },
         { provide: ParticipantRepository, useValue: participantRepoMock },
         { provide: RoomRepository, useValue: roomRepoMock },
+        { provide: ChatGateway, useValue: chatGatewayMock },
       ],
     }).compile();
 
     service = module.get<MessageService>(MessageService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/test-websocket.html
+++ b/test-websocket.html
@@ -194,6 +194,24 @@
       </div>
       <div id="listMessagesResponse" class="response-box"></div>
     </div>
+
+    <div class="api-group">
+      <h3>PATCH /chats/messages/{messageId}/read - 메시지 읽음 처리</h3>
+      <div class="controls">
+        <input type="number" id="readMessageId" placeholder="메시지 ID" value="555" min="1">
+        <button onclick="markAsReadRest()">읽음 처리</button>
+      </div>
+      <div id="markAsReadResponse" class="response-box"></div>
+    </div>
+
+    <div class="api-group">
+      <h3>PATCH /chats/messages/{messageId} - 메시지 삭제</h3>
+      <div class="controls">
+        <input type="number" id="deleteMessageId" placeholder="메시지 ID" value="555" min="1">
+        <button onclick="deleteMessageRest()" class="danger">삭제</button>
+      </div>
+      <div id="deleteMessageResponse" class="response-box"></div>
+    </div>
   </div>
 
   <!-- 로그 -->
@@ -281,6 +299,24 @@
       socket.on('exception', (error) => {
         addLog(`❌ 오류: ${JSON.stringify(error)}`, 'error');
       });
+
+      socket.on('message.read', (payload) => {
+        addLog(
+          `👀 읽음: room=${payload.chatRoomId} msg=${payload.messageId} reader=${payload.readerUserId} at=${payload.readAt}`,
+          'success',
+        );
+      });
+
+      socket.on('message.deleted', (payload) => {
+        addLog(
+          `🗑️ 삭제: room=${payload.chatRoomId} msg=${payload.messageId} by=${payload.deletedByUserId} at=${payload.deletedAt}`,
+          'warning',
+        );
+      });
+
+      socket.on('notification.new', (payload) => {
+        addLog(`🔔 알림: ${payload.title} - ${payload.body}`, 'success');
+      });
     }
 
     function disconnectWebSocket() {
@@ -345,7 +381,7 @@
         type,
         text: type === 'TEXT' ? text : null,
         mediaUrl: type !== 'TEXT' ? mediaUrl : null,
-        durationSec: type === 'AUDIO' ? durationSec : null,
+        durationSec: type === 'AUDIO' || type === 'VIDEO' ? durationSec : null,
       };
 
       socket.emit('message.send', payload, (res) => {
@@ -421,6 +457,28 @@
 
       const result = await apiCall('GET', `/chats/rooms/${roomId}/messages`);
       showResponse('listMessagesResponse', result.data, !result.ok);
+    }
+
+    async function markAsReadRest() {
+      const messageId = parseInt(document.getElementById('readMessageId').value);
+      if (!messageId) {
+        addLog('❌ 메시지 ID를 입력하세요.', 'error');
+        return;
+      }
+
+      const result = await apiCall('PATCH', `/chats/messages/${messageId}/read`);
+      showResponse('markAsReadResponse', result.data, !result.ok);
+    }
+
+    async function deleteMessageRest() {
+      const messageId = parseInt(document.getElementById('deleteMessageId').value);
+      if (!messageId) {
+        addLog('❌ 메시지 ID를 입력하세요.', 'error');
+        return;
+      }
+
+      const result = await apiCall('PATCH', `/chats/messages/${messageId}`);
+      showResponse('deleteMessageResponse', result.data, !result.ok);
     }
 
     // 초기화


### PR DESCRIPTION
## 이슈 번호
close #107 

## 주요 변경사항
- 메시지 읽음 처리/삭제(REST) 성공 시 Socket.IO로 message.read, message.deleted 이벤트 브로드캐스트 추가
- MessageService에서 DB 반영 시각(readAt/deletedAt)과 소켓 payload 시각을 동일하게 유지
- MessageRepository에 readAt/deletedAt 파라미터 지원 및 idempotent 업데이트(updateMany + null 조건) 적용
- 테스트에서 ChatGateway DI를 위한 mock provider 추가 및 mock reset 처리

## 테스트 결과 (스크린샷)
- 토큰 계정이 2개 이상 필요하여 배포 후 테스트

## 참고 및 개선사항
- X
