### PR TITLE
[EUM-1] feat: 정모 생성 API 구현

### DIFF
--- a/prisma/dbml/schema.dbml
+++ b/prisma/dbml/schema.dbml
@@ -424,13 +424,17 @@ Table ClubLike {
 Table Meeting {
   id BigInt [pk, increment]
   name String [not null]
-  date DateTime [not null]
+  introText String [not null]
+  date String [not null]
+  spot String [not null]
+  capacity Int [not null]
+  cost String
+  joinPolicy MeetingJoinPolicy [not null, default: 'AUTO']
+  isRegular Boolean [not null, default: true]
   createdAt DateTime [default: `now()`, not null]
   deletedAt DateTime
   updatedAt DateTime
   clubId BigInt [not null]
-  spot String [not null]
-  isRegular Boolean [not null, default: true]
   club Club [not null]
   meetingMembers MeetingMember [not null]
 }
@@ -541,6 +545,11 @@ Enum ClubUserStatus {
   ACTIVE
   REJECTED
   KICKED
+}
+
+Enum MeetingJoinPolicy {
+  AUTO
+  APPROVAL_REQUIRED
 }
 
 Enum ReportCategory {

--- a/prisma/migrations/20260517140448_add_meeting_fields_and_change_date_to_string/migration.sql
+++ b/prisma/migrations/20260517140448_add_meeting_fields_and_change_date_to_string/migration.sql
@@ -1,0 +1,16 @@
+/*
+  Warnings:
+
+  - Added the required column `capacity` to the `Meeting` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `introText` to the `Meeting` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "MeetingJoinPolicy" AS ENUM ('AUTO', 'APPROVAL_REQUIRED');
+
+-- AlterTable
+ALTER TABLE "Meeting" ADD COLUMN     "capacity" INTEGER NOT NULL,
+ADD COLUMN     "cost" VARCHAR(50),
+ADD COLUMN     "introText" VARCHAR(200) NOT NULL,
+ADD COLUMN     "joinPolicy" "MeetingJoinPolicy" NOT NULL DEFAULT 'AUTO',
+ALTER COLUMN "date" SET DATA TYPE VARCHAR(100);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -82,6 +82,11 @@ enum ClubUserStatus {
   KICKED
 }
 
+enum MeetingJoinPolicy {
+  AUTO
+  APPROVAL_REQUIRED
+}
+
 enum ReportCategory {
   INAPPROPRIATE
   SEXUAL_HARASSMENT
@@ -599,15 +604,19 @@ model ClubLike {
 }
 
 model Meeting {
-  id        BigInt    @id @default(autoincrement()) @db.BigInt
-  name      String    @db.VarChar(50)
-  date      DateTime  @db.Timestamp(6)
-  createdAt DateTime  @default(now()) @db.Timestamp(6)
-  deletedAt DateTime? @db.Timestamp(6)
-  updatedAt DateTime? @updatedAt
-  clubId    BigInt    @db.BigInt
-  spot      String    @db.Text
-  isRegular Boolean   @default(true)
+  id         BigInt            @id @default(autoincrement()) @db.BigInt
+  name       String            @db.VarChar(50)
+  introText  String            @db.VarChar(200)
+  date       String            @db.VarChar(100)
+  spot       String            @db.Text
+  capacity   Int               @db.Integer
+  cost       String?           @db.VarChar(50)
+  joinPolicy MeetingJoinPolicy @default(AUTO)
+  isRegular  Boolean           @default(true)
+  createdAt  DateTime          @default(now()) @db.Timestamp(6)
+  deletedAt  DateTime?         @db.Timestamp(6)
+  updatedAt  DateTime?         @updatedAt
+  clubId     BigInt            @db.BigInt
 
   club           Club            @relation(fields: [clubId], references: [id], onDelete: Cascade) // 클럽 삭제 시 정기모임도 삭제
   meetingMembers MeetingMember[]

--- a/src/common/errors/error-codes.ts
+++ b/src/common/errors/error-codes.ts
@@ -176,6 +176,25 @@ export const ERROR_DEFINITIONS = {
     message: '차단 상태에서는 채팅 기능을 이용할 수 없어요.',
   },
 
+  // CLUB
+  CLUB_NOT_FOUND: {
+    status: HttpStatus.NOT_FOUND,
+    code: 'CLUB-001',
+    message: '해당 클럽을 찾을 수 없어요.',
+  },
+  CLUB_FORBIDDEN_NOT_HOST: {
+    status: HttpStatus.FORBIDDEN,
+    code: 'CLUB-002',
+    message: '호스트만 이 작업을 수행할 수 있어요.',
+  },
+
+  // MEETING
+  MEETING_VALIDATION_FAILED: {
+    status: HttpStatus.BAD_REQUEST,
+    code: 'MEETING-001',
+    message: '입력값을 확인해 주세요.',
+  },
+
   // SYSTEM
   SERVER_TEMPORARY_ERROR: {
     status: HttpStatus.SERVICE_UNAVAILABLE,

--- a/src/modules/app/app.module.ts
+++ b/src/modules/app/app.module.ts
@@ -12,6 +12,7 @@ import { ChatModule } from '../chat/chat.module';
 import { AgreementModule } from '../agreements/agreement.module';
 import { NotificationModule } from '../notification/notification.module';
 import { OnboardingModule } from '../onboarding/onboarding.module';
+import { ClubModule } from '../club/club.module';
 import { WebsocketCommonModule } from 'src/infra/websocket/websocket-common.module';
 
 @Module({
@@ -38,6 +39,7 @@ import { WebsocketCommonModule } from 'src/infra/websocket/websocket-common.modu
     AgreementModule,
     NotificationModule,
     OnboardingModule,
+    ClubModule,
     AuthModule,
     UserModule,
   ],

--- a/src/modules/club/club.module.ts
+++ b/src/modules/club/club.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module';
+import { PrismaModule } from '../../infra/prisma/prisma.module';
+import { MeetingController } from './controllers/meeting/meeting.controller';
+import { MeetingService } from './services/meeting/meeting.service';
+import { ClubRepository } from './repositories/club.repository';
+import { MeetingRepository } from './repositories/meeting.repository';
+
+@Module({
+  imports: [AuthModule, PrismaModule],
+  controllers: [MeetingController],
+  providers: [MeetingService, ClubRepository, MeetingRepository],
+})
+export class ClubModule {}

--- a/src/modules/club/controllers/meeting/meeting.controller.spec.ts
+++ b/src/modules/club/controllers/meeting/meeting.controller.spec.ts
@@ -1,0 +1,45 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { JwtTokenService } from '../../../auth/services/jwt-token.service';
+import { PrismaService } from '../../../../infra/prisma/prisma.service';
+import { AccessTokenGuard } from '../../../auth/guards/access-token.guard';
+import { MeetingService } from '../../services/meeting/meeting.service';
+import { MeetingController } from './meeting.controller';
+
+describe('MeetingController', () => {
+  let controller: MeetingController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MeetingController],
+      providers: [
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn().mockReturnValue('mock-value') },
+        },
+        {
+          provide: JwtTokenService,
+          useValue: {
+            verifyAccessToken: jest.fn(),
+            extractTokenFromHeader: jest.fn(),
+          },
+        },
+        {
+          provide: PrismaService,
+          useValue: { $connect: jest.fn(), $disconnect: jest.fn() },
+        },
+        {
+          provide: MeetingService,
+          useValue: { createMeeting: jest.fn() },
+        },
+        AccessTokenGuard,
+      ],
+    }).compile();
+
+    controller = module.get<MeetingController>(MeetingController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/modules/club/controllers/meeting/meeting.controller.ts
+++ b/src/modules/club/controllers/meeting/meeting.controller.ts
@@ -1,0 +1,66 @@
+import { Body, Controller, Param, Post, UseGuards } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiCreatedResponse,
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import { AccessTokenGuard } from '../../../auth/guards/access-token.guard';
+import { RequiredUserId } from '../../../auth/decorators';
+import { MeetingService } from '../../services/meeting/meeting.service';
+import type {
+  CreateMeetingRequestDto,
+  CreateMeetingResponseDto,
+} from '../../dtos/meeting.dto';
+
+@ApiTags('Meeting')
+@ApiBearerAuth('access-token')
+@UseGuards(AccessTokenGuard)
+@Controller('clubs/:clubId/meetings')
+export class MeetingController {
+  constructor(private readonly meetingService: MeetingService) {}
+
+  @Post()
+  @ApiOperation({ summary: '정모 생성 (호스트만)' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', example: '매주하는 새벽등산' },
+        introText: {
+          type: 'string',
+          example: '함께 새벽 산행할 분들 모집해요.',
+        },
+        date: { type: 'string', example: '매주 목요일 저녁 19시' },
+        spot: { type: 'string', example: '종로역 1번 출구 앞' },
+        capacity: { type: 'integer', example: 15 },
+        cost: { type: 'string', example: '1인 10,000원', nullable: true },
+        joinPolicy: {
+          type: 'string',
+          enum: ['AUTO', 'APPROVAL_REQUIRED'],
+          example: 'AUTO',
+        },
+      },
+      required: ['name', 'introText', 'date', 'spot', 'capacity', 'joinPolicy'],
+    },
+  })
+  @ApiCreatedResponse({ description: '정모 생성 완료' })
+  @ApiUnauthorizedResponse({ description: '로그인 필요' })
+  @ApiForbiddenResponse({ description: '호스트가 아님' })
+  @ApiNotFoundResponse({ description: '클럽을 찾을 수 없음' })
+  async createMeeting(
+    @RequiredUserId() userId: number,
+    @Param('clubId') clubId: string,
+    @Body() dto: CreateMeetingRequestDto,
+  ): Promise<CreateMeetingResponseDto> {
+    return this.meetingService.createMeeting(
+      BigInt(userId),
+      BigInt(clubId),
+      dto,
+    );
+  }
+}

--- a/src/modules/club/dtos/meeting.dto.ts
+++ b/src/modules/club/dtos/meeting.dto.ts
@@ -1,0 +1,26 @@
+import { MeetingJoinPolicy } from '@prisma/client';
+
+export interface CreateMeetingRequestDto {
+  name: string;
+  introText: string;
+  date: string;
+  spot: string;
+  capacity: number;
+  cost?: string;
+  joinPolicy: MeetingJoinPolicy;
+}
+
+export interface CreateMeetingResponseDto {
+  meetingId: number;
+  clubId: number;
+  name: string;
+  introText: string;
+  date: string;
+  spot: string;
+  capacity: number;
+  cost: string | null;
+  joinPolicy: MeetingJoinPolicy;
+  isRegular: boolean;
+  attendeeCount: number;
+  createdAt: string;
+}

--- a/src/modules/club/repositories/club.repository.ts
+++ b/src/modules/club/repositories/club.repository.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../../../infra/prisma/prisma.service';
+
+@Injectable()
+export class ClubRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findById(clubId: bigint): Promise<{
+    id: bigint;
+    hostId: bigint | null;
+    deletedAt: Date | null;
+  } | null> {
+    return this.prisma.club.findUnique({
+      where: { id: clubId },
+      select: { id: true, hostId: true, deletedAt: true },
+    });
+  }
+}

--- a/src/modules/club/repositories/meeting.repository.ts
+++ b/src/modules/club/repositories/meeting.repository.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { MeetingJoinPolicy } from '@prisma/client';
+import { PrismaService } from '../../../infra/prisma/prisma.service';
+
+@Injectable()
+export class MeetingRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(data: {
+    clubId: bigint;
+    name: string;
+    introText: string;
+    date: string;
+    spot: string;
+    capacity: number;
+    cost: string | null;
+    joinPolicy: MeetingJoinPolicy;
+  }) {
+    return this.prisma.meeting.create({ data });
+  }
+}

--- a/src/modules/club/services/meeting/meeting.service.spec.ts
+++ b/src/modules/club/services/meeting/meeting.service.spec.ts
@@ -1,0 +1,129 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MeetingJoinPolicy } from '@prisma/client';
+import { MeetingService } from './meeting.service';
+import { ClubRepository } from '../../repositories/club.repository';
+import { MeetingRepository } from '../../repositories/meeting.repository';
+import { AppException } from '../../../../common/errors/app.exception';
+import { CreateMeetingRequestDto } from '../../dtos/meeting.dto';
+
+describe('MeetingService', () => {
+  let service: MeetingService;
+  const findById = jest.fn();
+  const create = jest.fn();
+
+  const validDto: CreateMeetingRequestDto = {
+    name: '매주하는 새벽등산',
+    introText: '함께 새벽 산행할 분들 모집',
+    date: '매주 목요일 저녁 19시',
+    spot: '종로역 1번 출구 앞',
+    capacity: 15,
+    cost: '1인 10000원',
+    joinPolicy: MeetingJoinPolicy.AUTO,
+  };
+
+  const hostUserId = 100n;
+  const clubId = 7n;
+
+  beforeEach(async () => {
+    findById.mockReset();
+    create.mockReset();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MeetingService,
+        { provide: ClubRepository, useValue: { findById } },
+        { provide: MeetingRepository, useValue: { create } },
+      ],
+    }).compile();
+
+    service = module.get<MeetingService>(MeetingService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('호스트가 만들면 정모가 생성된다', async () => {
+    findById.mockResolvedValue({
+      id: clubId,
+      hostId: hostUserId,
+      deletedAt: null,
+    });
+    create.mockResolvedValue({
+      id: 1n,
+      clubId,
+      name: validDto.name,
+      introText: validDto.introText,
+      date: validDto.date,
+      spot: validDto.spot,
+      capacity: validDto.capacity,
+      cost: validDto.cost ?? null,
+      joinPolicy: validDto.joinPolicy,
+      isRegular: true,
+      createdAt: new Date('2026-05-17T12:00:00.000Z'),
+      deletedAt: null,
+      updatedAt: null,
+    });
+
+    const result = await service.createMeeting(hostUserId, clubId, validDto);
+
+    expect(result.meetingId).toBe(1);
+    expect(result.clubId).toBe(Number(clubId));
+    expect(result.attendeeCount).toBe(0);
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  it('호스트가 아니면 CLUB_FORBIDDEN_NOT_HOST', async () => {
+    findById.mockResolvedValue({
+      id: clubId,
+      hostId: 999n,
+      deletedAt: null,
+    });
+
+    await expect(
+      service.createMeeting(hostUserId, clubId, validDto),
+    ).rejects.toMatchObject({
+      internalCode: 'CLUB_FORBIDDEN_NOT_HOST',
+    } satisfies Partial<AppException>);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('클럽이 없으면 CLUB_NOT_FOUND', async () => {
+    findById.mockResolvedValue(null);
+
+    await expect(
+      service.createMeeting(hostUserId, clubId, validDto),
+    ).rejects.toMatchObject({
+      internalCode: 'CLUB_NOT_FOUND',
+    });
+  });
+
+  it('soft-deleted 클럽이면 CLUB_NOT_FOUND', async () => {
+    findById.mockResolvedValue({
+      id: clubId,
+      hostId: hostUserId,
+      deletedAt: new Date(),
+    });
+
+    await expect(
+      service.createMeeting(hostUserId, clubId, validDto),
+    ).rejects.toMatchObject({
+      internalCode: 'CLUB_NOT_FOUND',
+    });
+  });
+
+  it('capacity가 0 이하면 MEETING_VALIDATION_FAILED', async () => {
+    findById.mockResolvedValue({
+      id: clubId,
+      hostId: hostUserId,
+      deletedAt: null,
+    });
+
+    await expect(
+      service.createMeeting(hostUserId, clubId, { ...validDto, capacity: 0 }),
+    ).rejects.toMatchObject({
+      internalCode: 'MEETING_VALIDATION_FAILED',
+    });
+    expect(create).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/club/services/meeting/meeting.service.ts
+++ b/src/modules/club/services/meeting/meeting.service.ts
@@ -1,0 +1,79 @@
+import { Injectable } from '@nestjs/common';
+import { MeetingJoinPolicy } from '@prisma/client';
+import { AppException } from '../../../../common/errors/app.exception';
+import { ClubRepository } from '../../repositories/club.repository';
+import { MeetingRepository } from '../../repositories/meeting.repository';
+import {
+  CreateMeetingRequestDto,
+  CreateMeetingResponseDto,
+} from '../../dtos/meeting.dto';
+
+@Injectable()
+export class MeetingService {
+  constructor(
+    private readonly clubRepository: ClubRepository,
+    private readonly meetingRepository: MeetingRepository,
+  ) {}
+
+  async createMeeting(
+    userId: bigint,
+    clubId: bigint,
+    dto: CreateMeetingRequestDto,
+  ): Promise<CreateMeetingResponseDto> {
+    const club = await this.clubRepository.findById(clubId);
+    if (!club || club.deletedAt) {
+      throw new AppException('CLUB_NOT_FOUND');
+    }
+    if (club.hostId !== userId) {
+      throw new AppException('CLUB_FORBIDDEN_NOT_HOST');
+    }
+
+    this.validateDto(dto);
+
+    const created = await this.meetingRepository.create({
+      clubId,
+      name: dto.name,
+      introText: dto.introText,
+      date: dto.date,
+      spot: dto.spot,
+      capacity: dto.capacity,
+      cost: dto.cost ?? null,
+      joinPolicy: dto.joinPolicy,
+    });
+
+    return {
+      meetingId: Number(created.id),
+      clubId: Number(created.clubId),
+      name: created.name,
+      introText: created.introText,
+      date: created.date,
+      spot: created.spot,
+      capacity: created.capacity,
+      cost: created.cost,
+      joinPolicy: created.joinPolicy,
+      isRegular: created.isRegular,
+      attendeeCount: 0,
+      createdAt: created.createdAt.toISOString(),
+    };
+  }
+
+  private validateDto(dto: CreateMeetingRequestDto): void {
+    const violations: string[] = [];
+    if (!dto.name || dto.name.length > 50) violations.push('name');
+    if (!dto.introText || dto.introText.length > 200)
+      violations.push('introText');
+    if (!dto.date || dto.date.length > 100) violations.push('date');
+    if (!dto.spot) violations.push('spot');
+    if (!Number.isInteger(dto.capacity) || dto.capacity <= 0)
+      violations.push('capacity');
+    if (dto.cost !== undefined && dto.cost.length > 50) violations.push('cost');
+    if (!Object.values(MeetingJoinPolicy).includes(dto.joinPolicy))
+      violations.push('joinPolicy');
+
+    if (violations.length > 0) {
+      throw new AppException('MEETING_VALIDATION_FAILED', {
+        details: { fields: violations },
+      });
+    }
+  }
+}


### PR DESCRIPTION
## 이슈 번호
close #180 

## 주요 변경사항
- 신규 ClubModule + 정모 생성 endpoint (`POST /api/v1/clubs/:clubId/meetings`)              
  - 호스트(`Club.hostId === userId`)만 생성 가능
  - 요청 body: `name`, `introText`, `date`, `spot`, `capacity`, `cost?`, `joinPolicy`         
  - 응답 DTO에 `meetingId`, `attendeeCount(=0)`, `isRegular`, `createdAt` 포함
- Meeting schema 확장 (migration 포함)                                                        
  - 추가 필드: `introText(VarChar 200)`, `capacity(Int)`, `cost(VarChar 50?)`,                
`joinPolicy(MeetingJoinPolicy)`                                                               
  - `date` 타입 변경: `DateTime → VarChar 100` (자연어 입력 허용, 예 "매주 목요일 저녁 19시") 
  - 신규 enum `MeetingJoinPolicy { AUTO, APPROVAL_REQUIRED }`                                 
- 에러 코드 신규: `CLUB-001` (NOT_FOUND), `CLUB-002` (FORBIDDEN_NOT_HOST), `MEETING-001`      
(VALIDATION_FAILED)                         

## 테스트 결과 (스크린샷)
- 

## 참고 및 개선사항
- **D-day 미구현**: 디자인 우측 화면의 "D-4" 표시는 일단 보류. `date`를 자연어 String으로만 받기 때문에 backend에서 D-day 계산이 어렵습니다. 관련해서 논의 후 요구사항을 확정해야할 것 같습니다!                                                                                                    
