### PR TITLE
[EUM-5] chore: workflows 재정비

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -76,6 +76,7 @@ jobs:
           image: ${{ steps.tag.outputs.image }}
 
       - name: Run Prisma migrate (ECS one-off task)
+        id: migrate
         env:
           RENDERED_TASK_DEF: ${{ steps.render.outputs.task-definition }}
         run: |
@@ -84,6 +85,7 @@ jobs:
           TD_ARN=$(aws ecs register-task-definition \
             --cli-input-json "file://$RENDERED_TASK_DEF" \
             --query 'taskDefinition.taskDefinitionArn' --output text)
+          echo "td_arn=$TD_ARN" >> "$GITHUB_OUTPUT"
           echo "Registered task def: $TD_ARN"
 
           OVERRIDES=$(jq -nc \
@@ -111,12 +113,18 @@ jobs:
           echo "Prisma migrate completed"
 
       - name: Deploy to ECS service
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
-        with:
-          task-definition: ${{ steps.render.outputs.task-definition }}
-          cluster: ${{ env.ECS_CLUSTER }}
-          service: ${{ env.ECS_SERVICE }}
-          wait-for-service-stability: true
+        # migrate 스텝에서 등록한 동일 TD 리비전을 재사용 (중복 register 방지)
+        env:
+          TD_ARN: ${{ steps.migrate.outputs.td_arn }}
+        run: |
+          set -euo pipefail
+          aws ecs update-service \
+            --cluster ${{ env.ECS_CLUSTER }} \
+            --service ${{ env.ECS_SERVICE }} \
+            --task-definition "$TD_ARN"
+          aws ecs wait services-stable \
+            --cluster ${{ env.ECS_CLUSTER }} \
+            --services ${{ env.ECS_SERVICE }}
 
       - name: Smoke test (ALB health)
         run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,13 +12,9 @@ jobs:
   deploy:
     name: Deploy to Staging ECS
     runs-on: ubuntu-latest
-    # TODO(staging-enable): 다음 셋이 모두 끝나면 `if: ${{ false }}`를 제거하여 활성화
-    #   1) staging RDS가 PostgreSQL 17 + pgvector로 교체됨
-    #   2) Secrets Manager `eum-backend/DATABASE_URL`이 새 PG URL로 갱신됨
-    #   3) GitHub OIDC IAM role ARN이 secret `AWS_OIDC_ROLE_STAGING`에 등록됨
-    if: ${{ false }}
+    # 인증: OIDC 대신 임시로 IAM 액세스 키 사용 (secrets AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY).
+    #       추후 GitHub OIDC role로 교체 권장.
     permissions:
-      id-token: write
       contents: read
 
     env:
@@ -35,10 +31,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Configure AWS credentials (OIDC)
+      - name: Configure AWS credentials (access key)
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_STAGING }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR

--- a/.github/workflows/notion-sync.yml
+++ b/.github/workflows/notion-sync.yml
@@ -2,12 +2,15 @@ name: Sync to Notion
 
 on:
   issues:
-    types: [opened, closed, reopened, assigned]
+    types: [opened, closed, reopened]
   pull_request:
-    types: [opened, ready_for_review, review_requested, closed, reopened]
+    types: [opened, ready_for_review, closed, reopened]
+  push:
+    branches:
+      - '**'
 
 concurrency:
-  group: notion-sync-${{ github.event.issue.number || github.event.pull_request.number }}
+  group: notion-sync-${{ github.event.issue.number || github.event.pull_request.number || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -148,22 +151,17 @@ jobs:
       NOTION_DB_ID: ${{ secrets.NOTION_DB_ID }}
       NOTION_VERSION: "2022-06-28"
       PR_BRANCH: ${{ github.head_ref }}
-      PR_TITLE: ${{ github.event.pull_request.title }}
-      PR_BODY: ${{ github.event.pull_request.body }}
       PR_URL: ${{ github.event.pull_request.html_url }}
       PR_ACTION: ${{ github.event.action }}
       PR_MERGED: ${{ github.event.pull_request.merged }}
 
     steps:
-      - name: Extract EUM ticket number from branch/title
+      - name: Extract EUM ticket from branch name
         id: extract
         run: |
-          # Search branch name first, then PR title, then body
-          SEARCH_TEXT="$PR_BRANCH $PR_TITLE $PR_BODY"
-          TICKET=$(echo "$SEARCH_TEXT" | grep -oE 'EUM-[0-9]+' | head -1)
+          TICKET=$(echo "$PR_BRANCH" | grep -oE 'EUM-[0-9]+' | head -1)
           if [ -z "$TICKET" ]; then
-            echo "::warning::No EUM-N ticket found in branch/title/body. Skipping Notion sync."
-            echo "Searched in: $SEARCH_TEXT"
+            echo "::warning::No EUM-N in branch '$PR_BRANCH'. Skipping Notion sync."
             exit 0
           fi
           NUM=$(echo "$TICKET" | grep -oE '[0-9]+')
@@ -178,10 +176,8 @@ jobs:
           STATUS=""
           if [ "$PR_ACTION" = "closed" ] && [ "$PR_MERGED" = "true" ]; then
             STATUS="완료"
-          elif [ "$PR_ACTION" = "review_requested" ] || [ "$PR_ACTION" = "ready_for_review" ]; then
+          elif [ "$PR_ACTION" = "opened" ] || [ "$PR_ACTION" = "reopened" ] || [ "$PR_ACTION" = "ready_for_review" ]; then
             STATUS="리뷰 중"
-          elif [ "$PR_ACTION" = "opened" ] || [ "$PR_ACTION" = "reopened" ]; then
-            STATUS="진행 중"
           fi
           if [ -z "$STATUS" ]; then
             echo "No status mapping for action=$PR_ACTION (merged=$PR_MERGED). Skipping."
@@ -228,3 +224,61 @@ jobs:
             -H "Content-Type: application/json" \
             -d "$BODY"
           echo "Updated $PAGE_ID → 상태: $STATUS"
+
+  sync-push:
+    name: Sync Push → Notion
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    env:
+      NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+      NOTION_DB_ID: ${{ secrets.NOTION_DB_ID }}
+      NOTION_VERSION: "2022-06-28"
+      REF_NAME: ${{ github.ref_name }}
+
+    steps:
+      - name: Extract EUM ticket from branch name
+        id: extract
+        run: |
+          TICKET=$(echo "$REF_NAME" | grep -oE 'EUM-[0-9]+' | head -1)
+          if [ -z "$TICKET" ]; then
+            echo "No EUM-N in branch '$REF_NAME'. Skipping."
+            exit 0
+          fi
+          NUM=$(echo "$TICKET" | grep -oE '[0-9]+')
+          echo "ticket=$TICKET" >> "$GITHUB_OUTPUT"
+          echo "num=$NUM" >> "$GITHUB_OUTPUT"
+          echo "Matched ticket: $TICKET"
+
+      - name: Find Notion page + current status
+        id: find
+        if: steps.extract.outputs.ticket != ''
+        env:
+          NUM: ${{ steps.extract.outputs.num }}
+        run: |
+          RESP=$(curl -s -X POST \
+            "https://api.notion.com/v1/databases/$NOTION_DB_ID/query" \
+            -H "Authorization: Bearer $NOTION_TOKEN" \
+            -H "Notion-Version: $NOTION_VERSION" \
+            -H "Content-Type: application/json" \
+            -d "{\"filter\":{\"property\":\"ID\",\"unique_id\":{\"equals\":$NUM}}}")
+          PAGE_ID=$(echo "$RESP" | jq -r '.results[0].id // empty')
+          CUR=$(echo "$RESP" | jq -r '.results[0].properties["상태"].status.name // empty')
+          if [ -z "$PAGE_ID" ]; then
+            echo "::warning::No Notion page found for ${{ steps.extract.outputs.ticket }}"
+            exit 0
+          fi
+          echo "page_id=$PAGE_ID" >> "$GITHUB_OUTPUT"
+          echo "current=$CUR" >> "$GITHUB_OUTPUT"
+          echo "Current status: ${CUR:-<none>}"
+
+      - name: Promote to 진행 중 (only if current is 이슈)
+        if: steps.find.outputs.page_id != '' && steps.find.outputs.current == '이슈'
+        env:
+          PAGE_ID: ${{ steps.find.outputs.page_id }}
+        run: |
+          curl -s -X PATCH "https://api.notion.com/v1/pages/$PAGE_ID" \
+            -H "Authorization: Bearer $NOTION_TOKEN" \
+            -H "Notion-Version: $NOTION_VERSION" \
+            -H "Content-Type: application/json" \
+            -d '{"properties":{"상태":{"status":{"name":"진행 중"}}}}'
+          echo "Promoted $PAGE_ID → 진행 중"


### PR DESCRIPTION
## 이슈 번호
close #185 

## 주요 변경사항
- **notion-sync.yml**: push 트리거 + sync-push job 추가 (브랜치 push 시 이슈→진행 중 승격), PR open/reopened/ready_for_review→리뷰 중으로 매핑 단순화, 미사용 트리거(assigned, review_requested) 및 PR title/body fallback 검색 제거, concurrency group에 github.ref_name fallback 추가
- **cd.yml**: 선조건(RDS PG17+pgvector 교체, Secrets Manager DATABASE_URL 갱신) 충족으로 `if: ${{ false }}` 게이트 제거 → dev push 시 staging ECS 자동 배포 + Prisma migrate 활성화. 
task definition 중복 등록 제거 (migrate/서비스용 register 2회 → 1회, deploy를 update-service로 대체)
인증은 OIDC 대신 임시로 IAM 액세스 키 사용.

## 테스트 결과 (스크린샷)
- 워크플로 YAML 변경 (앱 빌드/테스트 무관)
- 실제 검증은 dev 머지 후 첫 자동 배포 run에서 확인 예정 (ECR push → Prisma migrate → ECS 배포 → ALB 헬스체크 통과)

## 참고 및 개선사항
- 인증을 임시로 IAM 액세스 키로 사용 중 → 추후 GitHub OIDC role로 교체 권장 (장기 자격증명 보안 이슈)
- envoy 사이드카는 Service Connect로 서비스 레벨 주입(TD 미포함) 확인 완료 → migrate one-off 태스크는 사이드카 없이 실행되므로 전용 migrate TD 불필요
