### PR TITLE
fix: PostgreSQL 마이그레이션 이후 auth 오류 해결

### DIFF
--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -6,7 +6,9 @@ import { AccessTokenGuard } from './guards/access-token.guard';
 import { AuthTokenService } from './services/auth-token.service';
 import { JwtTokenService } from './services/jwt-token.service';
 import { KakaoAuthService } from './services/kakao-auth.service';
+import { AuthRepository } from './repositories/auth.repository';
 import { PrismaModule } from '../../infra/prisma/prisma.module';
+import { UserRepository } from '../user/repositories/user.repository';
 
 @Module({
   imports: [PrismaModule],
@@ -16,6 +18,8 @@ import { PrismaModule } from '../../infra/prisma/prisma.module';
     AuthTokenService,
     JwtTokenService,
     AccessTokenGuard,
+    AuthRepository,
+    UserRepository,
   ],
   exports: [JwtTokenService, AccessTokenGuard],
 })

--- a/src/modules/auth/repositories/auth.repository.ts
+++ b/src/modules/auth/repositories/auth.repository.ts
@@ -1,0 +1,88 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../../infra/prisma/prisma.service';
+
+@Injectable()
+export class AuthRepository {
+  constructor(private readonly prismaService: PrismaService) {}
+
+  findRefreshTokenByHash(tokenHash: string) {
+    return this.prismaService.refreshToken.findUnique({
+      where: { tokenHash },
+    });
+  }
+
+  async rotateRefreshToken({
+    userId,
+    tokenHash,
+    expiresAt,
+  }: {
+    userId: number;
+    tokenHash: string;
+    expiresAt: Date;
+  }) {
+    return this.prismaService.$transaction(
+      async (tx) => {
+        const existingToken = await tx.refreshToken.findUnique({
+          where: { tokenHash },
+        });
+
+        if (existingToken) {
+          return { created: false as const, revokedCount: 0 };
+        }
+
+        const revoked = await tx.refreshToken.updateMany({
+          where: { userId: BigInt(userId), revokedAt: null },
+          data: { revokedAt: new Date() },
+        });
+
+        await tx.refreshToken.create({
+          data: {
+            userId: BigInt(userId),
+            tokenHash,
+            expiresAt,
+          },
+        });
+
+        return { created: true as const, revokedCount: revoked.count };
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+    );
+  }
+
+  async revokeRefreshTokenByHash(tokenHash: string) {
+    const result = await this.prismaService.refreshToken.updateMany({
+      where: { tokenHash, revokedAt: null },
+      data: { revokedAt: new Date() },
+    });
+
+    return result.count;
+  }
+
+  async revokeAllUserTokens(userId: number) {
+    const result = await this.prismaService.refreshToken.updateMany({
+      where: { userId: BigInt(userId), revokedAt: null },
+      data: { revokedAt: new Date() },
+    });
+
+    return result.count;
+  }
+
+  createRefreshToken({
+    userId,
+    tokenHash,
+    expiresAt,
+  }: {
+    userId: number;
+    tokenHash: string;
+    expiresAt: Date;
+  }) {
+    return this.prismaService.refreshToken.create({
+      data: {
+        userId: BigInt(userId),
+        tokenHash,
+        expiresAt,
+      },
+    });
+  }
+}

--- a/src/modules/auth/services/auth-token.service.ts
+++ b/src/modules/auth/services/auth-token.service.ts
@@ -2,9 +2,9 @@ import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { createHash } from 'crypto';
 import type { SignOptions } from 'jsonwebtoken';
-import { PrismaService } from '../../../infra/prisma/prisma.service';
 import { AuthTokenPayload, JwtTokenService } from './jwt-token.service';
 import { AppException } from '../../../common/errors/app.exception';
+import { AuthRepository } from '../repositories/auth.repository';
 
 @Injectable()
 export class AuthTokenService {
@@ -13,7 +13,7 @@ export class AuthTokenService {
   constructor(
     private readonly configService: ConfigService,
     private readonly jwtTokenService: JwtTokenService,
-    private readonly prismaService: PrismaService,
+    private readonly authRepository: AuthRepository,
   ) {}
 
   async refreshTokens(refreshToken: string) {
@@ -74,9 +74,8 @@ export class AuthTokenService {
 
   private async assertRefreshTokenActive(refreshToken: string, userId: number) {
     const tokenHash = this.hashToken(refreshToken);
-    const existingToken = await this.prismaService.refreshToken.findUnique({
-      where: { tokenHash },
-    });
+    const existingToken =
+      await this.authRepository.findRefreshTokenByHash(tokenHash);
 
     if (!existingToken || String(existingToken.userId) !== String(userId)) {
       throw new UnauthorizedException();
@@ -89,11 +88,9 @@ export class AuthTokenService {
 
   private async revokeRefreshToken(refreshToken: string) {
     const tokenHash = this.hashToken(refreshToken);
-    const result = await this.prismaService.refreshToken.updateMany({
-      where: { tokenHash, revokedAt: null },
-      data: { revokedAt: new Date() },
-    });
-    if (result.count === 0) {
+    const revokedCount =
+      await this.authRepository.revokeRefreshTokenByHash(tokenHash);
+    if (revokedCount === 0) {
       this.logger.warn('Refresh token already revoked or not found.', {
         tokenHash,
       });
@@ -102,11 +99,7 @@ export class AuthTokenService {
   }
 
   async revokeAllUserTokens(userId: number) {
-    const result = await this.prismaService.refreshToken.updateMany({
-      where: { userId: BigInt(userId), revokedAt: null },
-      data: { revokedAt: new Date() },
-    });
-    return result.count;
+    return this.authRepository.revokeAllUserTokens(userId);
   }
 
   private async storeRefreshToken(refreshToken: string, userId: number) {
@@ -118,9 +111,8 @@ export class AuthTokenService {
     const expiresAt = new Date(payload.exp * 1000);
 
     const tokenHash = this.hashToken(refreshToken);
-    const existingToken = await this.prismaService.refreshToken.findUnique({
-      where: { tokenHash },
-    });
+    const existingToken =
+      await this.authRepository.findRefreshTokenByHash(tokenHash);
 
     if (existingToken) {
       this.logger.warn('Refresh token hash collision detected.', {
@@ -132,12 +124,10 @@ export class AuthTokenService {
       });
     }
 
-    await this.prismaService.refreshToken.create({
-      data: {
-        userId: BigInt(userId),
-        tokenHash,
-        expiresAt,
-      },
+    await this.authRepository.createRefreshToken({
+      userId,
+      tokenHash,
+      expiresAt,
     });
   }
 

--- a/src/modules/auth/services/kakao-auth.service.ts
+++ b/src/modules/auth/services/kakao-auth.service.ts
@@ -149,47 +149,63 @@ export class KakaoAuthService {
       },
     };
 
-    try {
-      // TODO(vibe-pgvector): User.vibeVector가 Unsupported("vector") + NOT NULL이라 Prisma client의 .create가
-      // 타입 시그니처에서 제거됨 (delegate가 create 메서드 자체를 노출 안 함). 런타임에서도 INSERT가 vibeVector
-      // 누락으로 실패함. 적절한 해결: $executeRaw로 raw INSERT 후 findFirstOrThrow로 row 가져오기.
-      // 임시: delegate를 any로 캐스팅해 type 우회 + 결과를 User로 단언. **이 코드는 런타임에 실패하므로 follow-up 필수**.
-      const userDelegate = this.prismaService.user as unknown as {
-        create: (args: { data: Record<string, unknown> }) => Promise<User>;
-      };
-      const createdUser = await userDelegate.create({
+    const existing = await this.prismaService.user.findUnique({ where });
+    if (existing) {
+      const updatedUser = await this.prismaService.user.update({
+        where,
         data: {
-          birthdate: KakaoAuthService.DEFAULT_BIRTHDATE,
           email,
           nickname,
-          introVoiceUrl: KakaoAuthService.DEFAULT_INTRO_VOICE_URL,
-          introText: '',
-          profileImageUrl: KakaoAuthService.DEFAULT_PROFILE_IMAGE_URL,
-          code: KakaoAuthService.DEFAULT_ADDRESS_CODE,
-          provider: AuthProvider.KAKAO,
-          providerUserId,
         },
       });
 
-      return { user: createdUser, isNewUser: true };
-    } catch (error) {
-      if (
-        error instanceof Prisma.PrismaClientKnownRequestError &&
-        error.code === 'P2002'
-      ) {
-        const updatedUser = await this.prismaService.user.update({
-          where,
-          data: {
-            email,
-            nickname,
-          },
-        });
-
-        return { user: updatedUser, isNewUser: false };
-      }
-
-      throw error;
+      return { user: updatedUser, isNewUser: false };
     }
+
+    const insertedRows = await this.prismaService.$queryRaw<
+      Array<{ id: bigint }>
+    >(Prisma.sql`
+      INSERT INTO "User" (
+        "birthdate",
+        "email",
+        "nickname",
+        "updatedAt",
+        "introVoiceUrl",
+        "introText",
+        "profileImageUrl",
+        "code",
+        "provider",
+        "providerUserId",
+        "vibeVector"
+      )
+      VALUES (
+        ${KakaoAuthService.DEFAULT_BIRTHDATE},
+        ${email},
+        ${nickname},
+        NOW(),
+        ${KakaoAuthService.DEFAULT_INTRO_VOICE_URL},
+        ${''},
+        ${KakaoAuthService.DEFAULT_PROFILE_IMAGE_URL},
+        ${KakaoAuthService.DEFAULT_ADDRESS_CODE},
+        ${AuthProvider.KAKAO}::"AuthProvider",
+        ${providerUserId},
+        '[0]'::vector
+      )
+      RETURNING "id"
+    `);
+
+    const createdId = insertedRows[0]?.id;
+    if (!createdId) {
+      throw new AppException('SERVER_TEMPORARY_ERROR', {
+        message: '카카오 신규 유저 생성에 실패했습니다.',
+      });
+    }
+
+    const createdUser = await this.prismaService.user.findUniqueOrThrow({
+      where: { id: createdId },
+    });
+
+    return { user: createdUser, isNewUser: true };
   }
 
   private async rotateRefreshTokens(refreshToken: string, userId: number) {

--- a/src/modules/auth/services/kakao-auth.service.ts
+++ b/src/modules/auth/services/kakao-auth.service.ts
@@ -1,11 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import {
-  ActiveStatus,
-  AddressLevel,
-  AuthProvider,
-  Prisma,
-} from '@prisma/client';
+import { ActiveStatus } from '@prisma/client';
 import { createHash } from 'crypto';
 import type { SignOptions } from 'jsonwebtoken';
 import { PrismaService } from '../../../infra/prisma/prisma.service';
@@ -13,6 +8,8 @@ import { JwtTokenService } from './jwt-token.service';
 import { AppException } from '../../../common/errors/app.exception';
 import { KakaoLoginRequestDto } from '../dtos/kakao-login-request.dto';
 import { KakaoLoginResponseDto } from '../dtos/kakao-login-response.dto';
+import { UserRepository } from '../../user/repositories/user.repository';
+import { AuthRepository } from '../repositories/auth.repository';
 
 export type KakaoLoginResult = KakaoLoginResponseDto & {
   refreshToken: string;
@@ -53,6 +50,8 @@ export class KakaoAuthService {
     private readonly configService: ConfigService,
     private readonly jwtTokenService: JwtTokenService,
     private readonly prismaService: PrismaService,
+    private readonly userRepository: UserRepository,
+    private readonly authRepository: AuthRepository,
   ) {}
 
   async loginWithKakao(
@@ -77,11 +76,21 @@ export class KakaoAuthService {
     const email =
       profile.kakao_account?.email ?? `kakao-${providerUserId}@kakao.local`;
 
-    const userRecord = await this.upsertUser({
+    const userRecord = await this.userRepository.upsertKakaoUser({
       providerUserId,
       nickname,
       email,
+      defaultBirthdate: KakaoAuthService.DEFAULT_BIRTHDATE,
+      defaultAddressCode: KakaoAuthService.DEFAULT_ADDRESS_CODE,
+      defaultIntroVoiceUrl: KakaoAuthService.DEFAULT_INTRO_VOICE_URL,
+      defaultProfileImageUrl: KakaoAuthService.DEFAULT_PROFILE_IMAGE_URL,
     });
+
+    if (!userRecord) {
+      throw new AppException('SERVER_TEMPORARY_ERROR', {
+        message: '카카오 신규 유저 생성에 실패했습니다.',
+      });
+    }
 
     const userId = Number(userRecord.user.id) || 0;
     await this.ensureUserCanLogin(userId, userRecord.user.status);
@@ -131,82 +140,6 @@ export class KakaoAuthService {
     };
   }
 
-  private async upsertUser({
-    providerUserId,
-    nickname,
-    email,
-  }: {
-    providerUserId: string;
-    nickname: string;
-    email: string;
-  }) {
-    await this.ensureDefaultAddress();
-    const where = {
-      provider_providerUserId: {
-        provider: AuthProvider.KAKAO,
-        providerUserId,
-      },
-    };
-
-    const existing = await this.prismaService.user.findUnique({ where });
-    if (existing) {
-      const updatedUser = await this.prismaService.user.update({
-        where,
-        data: {
-          email,
-          nickname,
-        },
-      });
-
-      return { user: updatedUser, isNewUser: false };
-    }
-
-    const insertedRows = await this.prismaService.$queryRaw<
-      Array<{ id: bigint }>
-    >(Prisma.sql`
-      INSERT INTO "User" (
-        "birthdate",
-        "email",
-        "nickname",
-        "updatedAt",
-        "introVoiceUrl",
-        "introText",
-        "profileImageUrl",
-        "code",
-        "provider",
-        "providerUserId",
-        "vibeVector"
-      )
-      VALUES (
-        ${KakaoAuthService.DEFAULT_BIRTHDATE},
-        ${email},
-        ${nickname},
-        NOW(),
-        ${KakaoAuthService.DEFAULT_INTRO_VOICE_URL},
-        ${''},
-        ${KakaoAuthService.DEFAULT_PROFILE_IMAGE_URL},
-        ${KakaoAuthService.DEFAULT_ADDRESS_CODE},
-        ${AuthProvider.KAKAO}::"AuthProvider",
-        ${providerUserId},
-        '[0]'::vector
-      )
-      RETURNING "id"
-    `);
-
-    const createdId = insertedRows[0]?.id;
-    if (!createdId) {
-      throw new AppException('SERVER_TEMPORARY_ERROR', {
-        message: '카카오 신규 유저 생성에 실패했습니다.',
-      });
-    }
-
-    const createdUser = await this.prismaService.user.findUniqueOrThrow({
-      where: { id: createdId },
-    });
-
-    return { user: createdUser, isNewUser: true };
-  }
-
   private async rotateRefreshTokens(refreshToken: string, userId: number) {
     const refreshSecret = this.configService.get<string>(
       'JWT_REFRESH_SECRET',
@@ -216,36 +149,21 @@ export class KakaoAuthService {
     const expiresAt = new Date(payload.exp * 1000);
 
     const tokenHash = createHash('sha256').update(refreshToken).digest('hex');
-    await this.prismaService.$transaction(
-      async (tx) => {
-        const existingToken = await tx.refreshToken.findUnique({
-          where: { tokenHash },
-        });
+    const result = await this.authRepository.rotateRefreshToken({
+      userId,
+      tokenHash,
+      expiresAt,
+    });
 
-        if (existingToken) {
-          this.logger.warn('Refresh token hash collision detected.', {
-            userId,
-            tokenHash,
-          });
-          throw new AppException('SERVER_TEMPORARY_ERROR', {
-            message: 'Refresh token collision detected.',
-          });
-        }
-
-        await tx.refreshToken.updateMany({
-          where: { userId: BigInt(userId), revokedAt: null },
-          data: { revokedAt: new Date() },
-        });
-        await tx.refreshToken.create({
-          data: {
-            userId: BigInt(userId),
-            tokenHash,
-            expiresAt,
-          },
-        });
-      },
-      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
-    );
+    if (!result.created) {
+      this.logger.warn('Refresh token hash collision detected.', {
+        userId,
+        tokenHash,
+      });
+      throw new AppException('SERVER_TEMPORARY_ERROR', {
+        message: 'Refresh token collision detected.',
+      });
+    }
   }
 
   private async ensureUserCanLogin(
@@ -297,27 +215,6 @@ export class KakaoAuthService {
       user.code === null ||
       user.code === KakaoAuthService.DEFAULT_ADDRESS_CODE
     );
-  }
-
-  private async ensureDefaultAddress() {
-    await this.prismaService.address.upsert({
-      where: { code: KakaoAuthService.DEFAULT_ADDRESS_CODE },
-      update: {},
-      create: {
-        code: KakaoAuthService.DEFAULT_ADDRESS_CODE,
-        sidoCode: '00',
-        sigunguCode: '000',
-        emdCode: '000',
-        riCode: '00',
-        fullName: 'Unknown',
-        sidoName: 'Unknown',
-        sigunguName: null,
-        emdName: null,
-        riName: null,
-        level: AddressLevel.SIGUNGU,
-        parentCode: null,
-      },
-    });
   }
 
   private async fetchKakaoToken(

--- a/src/modules/auth/services/kakao-auth.service.ts
+++ b/src/modules/auth/services/kakao-auth.service.ts
@@ -3,7 +3,6 @@ import { ConfigService } from '@nestjs/config';
 import { ActiveStatus } from '@prisma/client';
 import { createHash } from 'crypto';
 import type { SignOptions } from 'jsonwebtoken';
-import { PrismaService } from '../../../infra/prisma/prisma.service';
 import { JwtTokenService } from './jwt-token.service';
 import { AppException } from '../../../common/errors/app.exception';
 import { KakaoLoginRequestDto } from '../dtos/kakao-login-request.dto';
@@ -49,7 +48,6 @@ export class KakaoAuthService {
   constructor(
     private readonly configService: ConfigService,
     private readonly jwtTokenService: JwtTokenService,
-    private readonly prismaService: PrismaService,
     private readonly userRepository: UserRepository,
     private readonly authRepository: AuthRepository,
   ) {}
@@ -181,19 +179,11 @@ export class KakaoAuthService {
       return;
     }
 
-    // TODO(schema): "내가 신고당한 횟수" — 옛 Report.reportedId 직접 조회 → UserReport 경유로 변경.
-    const reportCount = await this.prismaService.userReport.count({
-      where: {
-        reportedUserId: BigInt(userId),
-        report: { deletedAt: null },
-      },
-    });
+    const reportCount =
+      await this.userRepository.countActiveReportsByUserId(userId);
 
     if (reportCount >= reportLimit) {
-      await this.prismaService.user.update({
-        where: { id: BigInt(userId) },
-        data: { status: ActiveStatus.INACTIVE },
-      });
+      await this.userRepository.markInactive(userId);
       throw new AppException('AUTH_USER_BLOCKED');
     }
   }

--- a/src/modules/auth/services/kakao-auth.service.ts
+++ b/src/modules/auth/services/kakao-auth.service.ts
@@ -5,7 +5,6 @@ import {
   AddressLevel,
   AuthProvider,
   Prisma,
-  type User,
 } from '@prisma/client';
 import { createHash } from 'crypto';
 import type { SignOptions } from 'jsonwebtoken';

--- a/src/modules/user/repositories/user.repository.ts
+++ b/src/modules/user/repositories/user.repository.ts
@@ -1,10 +1,98 @@
 import { Injectable } from '@nestjs/common';
-import { ActiveStatus, Sex } from '@prisma/client';
+import {
+  ActiveStatus,
+  AddressLevel,
+  AuthProvider,
+  Prisma,
+  Sex,
+} from '@prisma/client';
 import { PrismaService } from '../../../infra/prisma/prisma.service';
 
 @Injectable()
 export class UserRepository {
   constructor(private readonly prismaService: PrismaService) {}
+
+  async upsertKakaoUser({
+    providerUserId,
+    email,
+    nickname,
+    defaultBirthdate,
+    defaultAddressCode,
+    defaultIntroVoiceUrl,
+    defaultProfileImageUrl,
+  }: {
+    providerUserId: string;
+    email: string;
+    nickname: string;
+    defaultBirthdate: Date;
+    defaultAddressCode: string;
+    defaultIntroVoiceUrl: string;
+    defaultProfileImageUrl: string;
+  }) {
+    await this.ensureDefaultAddress(defaultAddressCode);
+
+    const where = {
+      provider_providerUserId: {
+        provider: AuthProvider.KAKAO,
+        providerUserId,
+      },
+    };
+
+    const existing = await this.prismaService.user.findUnique({ where });
+    if (existing) {
+      const updatedUser = await this.prismaService.user.update({
+        where,
+        data: {
+          email,
+        },
+      });
+
+      return { user: updatedUser, isNewUser: false };
+    }
+
+    const insertedRows = await this.prismaService.$queryRaw<
+      Array<{ id: bigint }>
+    >(Prisma.sql`
+      INSERT INTO "User" (
+        "birthdate",
+        "email",
+        "nickname",
+        "updatedAt",
+        "introVoiceUrl",
+        "introText",
+        "profileImageUrl",
+        "code",
+        "provider",
+        "providerUserId",
+        "vibeVector"
+      )
+      VALUES (
+        ${defaultBirthdate},
+        ${email},
+        ${nickname},
+        NOW(),
+        ${defaultIntroVoiceUrl},
+        ${''},
+        ${defaultProfileImageUrl},
+        ${defaultAddressCode},
+        ${AuthProvider.KAKAO}::"AuthProvider",
+        ${providerUserId},
+        '[0]'::vector
+      )
+      RETURNING "id"
+    `);
+
+    const createdId = insertedRows[0]?.id;
+    if (!createdId) {
+      return null;
+    }
+
+    const createdUser = await this.prismaService.user.findUniqueOrThrow({
+      where: { id: createdId },
+    });
+
+    return { user: createdUser, isNewUser: true };
+  }
 
   findProfileById(userId: number) {
     return this.prismaService.user.findFirst({
@@ -169,6 +257,27 @@ export class UserRepository {
       data: {
         status: ActiveStatus.INACTIVE,
         deletedAt: new Date(),
+      },
+    });
+  }
+
+  private async ensureDefaultAddress(defaultAddressCode: string) {
+    await this.prismaService.address.upsert({
+      where: { code: defaultAddressCode },
+      update: {},
+      create: {
+        code: defaultAddressCode,
+        sidoCode: '00',
+        sigunguCode: '000',
+        emdCode: '000',
+        riCode: '00',
+        fullName: 'Unknown',
+        sidoName: 'Unknown',
+        sigunguName: null,
+        emdName: null,
+        riName: null,
+        level: AddressLevel.SIGUNGU,
+        parentCode: null,
       },
     });
   }

--- a/src/modules/user/repositories/user.repository.ts
+++ b/src/modules/user/repositories/user.repository.ts
@@ -31,67 +31,77 @@ export class UserRepository {
   }) {
     await this.ensureDefaultAddress(defaultAddressCode);
 
-    const where = {
-      provider_providerUserId: {
-        provider: AuthProvider.KAKAO,
-        providerUserId,
-      },
-    };
+    return this.prismaService.$transaction(async (tx) => {
+      const insertedRows = await tx.$queryRaw<Array<{ id: bigint }>>(
+        Prisma.sql`
+          INSERT INTO "User" (
+            "birthdate",
+            "email",
+            "nickname",
+            "updatedAt",
+            "introVoiceUrl",
+            "introText",
+            "profileImageUrl",
+            "code",
+            "provider",
+            "providerUserId",
+            "vibeVector"
+          )
+          VALUES (
+            ${defaultBirthdate},
+            ${email},
+            ${nickname},
+            NOW(),
+            ${defaultIntroVoiceUrl},
+            ${''},
+            ${defaultProfileImageUrl},
+            ${defaultAddressCode},
+            ${AuthProvider.KAKAO}::"AuthProvider",
+            ${providerUserId},
+            '[0]'::vector
+          )
+          ON CONFLICT ("provider", "providerUserId") DO NOTHING
+          RETURNING "id"
+        `,
+      );
 
-    const existing = await this.prismaService.user.findUnique({ where });
-    if (existing) {
-      const updatedUser = await this.prismaService.user.update({
-        where,
-        data: {
-          email,
+      const insertedId = insertedRows[0]?.id;
+      if (insertedId) {
+        const createdUser = await tx.user.findUniqueOrThrow({
+          where: { id: insertedId },
+        });
+
+        return { user: createdUser, isNewUser: true };
+      }
+
+      const updatedUser = await tx.user.update({
+        where: {
+          provider_providerUserId: {
+            provider: AuthProvider.KAKAO,
+            providerUserId,
+          },
         },
+        data: { email },
       });
 
       return { user: updatedUser, isNewUser: false };
-    }
-
-    const insertedRows = await this.prismaService.$queryRaw<
-      Array<{ id: bigint }>
-    >(Prisma.sql`
-      INSERT INTO "User" (
-        "birthdate",
-        "email",
-        "nickname",
-        "updatedAt",
-        "introVoiceUrl",
-        "introText",
-        "profileImageUrl",
-        "code",
-        "provider",
-        "providerUserId",
-        "vibeVector"
-      )
-      VALUES (
-        ${defaultBirthdate},
-        ${email},
-        ${nickname},
-        NOW(),
-        ${defaultIntroVoiceUrl},
-        ${''},
-        ${defaultProfileImageUrl},
-        ${defaultAddressCode},
-        ${AuthProvider.KAKAO}::"AuthProvider",
-        ${providerUserId},
-        '[0]'::vector
-      )
-      RETURNING "id"
-    `);
-
-    const createdId = insertedRows[0]?.id;
-    if (!createdId) {
-      return null;
-    }
-
-    const createdUser = await this.prismaService.user.findUniqueOrThrow({
-      where: { id: createdId },
     });
+  }
 
-    return { user: createdUser, isNewUser: true };
+  countActiveReportsByUserId(userId: number) {
+    return this.prismaService.userReport.count({
+      where: {
+        reportedUserId: BigInt(userId),
+        report: { deletedAt: null },
+      },
+    });
+  }
+
+  markInactive(userId: number) {
+    return this.prismaService.user.update({
+      where: { id: BigInt(userId) },
+      data: { status: ActiveStatus.INACTIVE },
+    });
   }
 
   findProfileById(userId: number) {

--- a/src/modules/user/user.module.ts
+++ b/src/modules/user/user.module.ts
@@ -8,5 +8,6 @@ import { AuthModule } from '../auth/auth.module';
   controllers: [UserController],
   providers: [UserService, UserRepository],
   imports: [AuthModule],
+  exports: [UserRepository],
 })
 export class UserModule {}


### PR DESCRIPTION
## 이슈 번호
close #192 

## 주요 변경사항
- PostgreSQL 전환 이후 발생한 카카오 로그인 오류 수정
- 카카오 OAuth 인증 정보 및 PostgreSQL 기준 auth flow를 점검


## 테스트 결과 (스크린샷)
- 기존의 auth 관련 api들이 정상 동작 함과 DB에 user가 새롭게 형식에 맞춰 생성되는 것을 확인

## 참고 및 개선사항
- Kakao auth 로그인 로직 수정
- PostgreSQL User 생성 시 `createdAt`, `updatedAt` 처리 보완
- Prisma/PostgreSQL 스키마 기준 유저 생성 로직 정리
- 로그인 이후 access token / refresh token 발급 흐름 확인