### PR TITLE
feat: 정모 삭제 API 구현

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -135,14 +135,22 @@ jobs:
           # `aws ecs wait services-stable`은 옛 deployment가 ACTIVE로 남아있는 동안 풀리지 않아
           # 새 태스크가 멀쩡히 떠도 자주 타임아웃까지 끌려간다. 더 실용적으로,
           # PRIMARY deployment의 rolloutState=COMPLETED만 확인한다 (= 새 태스크 healthy + desiredCount 도달).
-          echo "Polling PRIMARY deployment rolloutState (max 10min, 15s 간격)..."
-          for i in $(seq 1 40); do
-            STATE=$(aws ecs describe-services \
+          # 이미지 pull(1~3분) + ALB healthcheck warmup(1~2.5분) + 컨테이너 부팅까지 합하면 7~12분이
+          # 일반적이라, 여유롭게 60회 × 15s = 15분으로 설정한다.
+          MAX_ATTEMPTS=60
+          INTERVAL=15
+          echo "Polling PRIMARY deployment rolloutState (max $((MAX_ATTEMPTS * INTERVAL / 60))min, ${INTERVAL}s 간격)..."
+          for i in $(seq 1 "$MAX_ATTEMPTS"); do
+            INFO=$(aws ecs describe-services \
               --cluster ${{ env.ECS_CLUSTER }} \
               --services ${{ env.ECS_SERVICE }} \
-              --query "services[0].deployments[?status=='PRIMARY'].rolloutState | [0]" \
-              --output text)
-            echo "[$i/40] PRIMARY rolloutState=$STATE"
+              --query "services[0].deployments[?status=='PRIMARY'] | [0]" \
+              --output json)
+            STATE=$(echo "$INFO" | jq -r '.rolloutState // "UNKNOWN"')
+            RUNNING=$(echo "$INFO" | jq -r '.runningCount // 0')
+            DESIRED=$(echo "$INFO" | jq -r '.desiredCount // 0')
+            FAILED_TASKS=$(echo "$INFO" | jq -r '.failedTasks // 0')
+            echo "[$i/$MAX_ATTEMPTS] PRIMARY rolloutState=$STATE running=$RUNNING/$DESIRED failedTasks=$FAILED_TASKS"
             case "$STATE" in
               COMPLETED)
                 echo "Deployment completed."
@@ -157,10 +165,14 @@ jobs:
                 exit 1
                 ;;
             esac
-            sleep 15
+            sleep "$INTERVAL"
           done
 
-          echo "::error::Timeout: PRIMARY rolloutState가 10분 안에 COMPLETED 도달 못 함"
+          echo "::error::Timeout: PRIMARY rolloutState가 $((MAX_ATTEMPTS * INTERVAL / 60))분 안에 COMPLETED 도달 못 함"
+          aws ecs describe-services \
+            --cluster ${{ env.ECS_CLUSTER }} \
+            --services ${{ env.ECS_SERVICE }} \
+            --query 'services[0].deployments' --output json
           exit 1
 
       - name: Smoke test (ALB health)

--- a/README.md
+++ b/README.md
@@ -70,6 +70,37 @@ npm run start:dev
 
 ---
 
+### 🏃 빠른 실행 (외부 RDS 사용 시)
+
+로컬에 Postgres 컨테이너를 띄우지 않고 외부 RDS만 가리켜도 서버는 뜹니다.
+
+1. `.env`의 `DATABASE_URL`을 RDS로 지정:
+
+   ```env
+   DATABASE_URL=postgresql://<user>:<pw>@<rds-endpoint>:5432/<db>?sslmode=require
+   ```
+2. 연결 확인 (선택):
+
+   ```bash
+   npx prisma db pull --print >/dev/null
+   ```
+3. 마이그레이션 적용 — **공용 RDS면 반드시 `deploy`** 사용 (`dev`는 drift 시 reset 제안, `reset`은 데이터 삭제):
+
+   ```bash
+   npm run prisma:migrate:deploy
+   ```
+4. 서버 기동:
+
+   ```bash
+   npm run start:dev
+   ```
+
+> **Redis는 현재 코드에서 사용하지 않으므로** 로컬에 띄울 필요 없습니다. 추후 캐시/세션/pub-sub 도입 시 README에 재안내합니다.
+
+> `prisma db pull` 실행 시 `vector` 타입과 일부 check constraint(`chat_room_club_id_check` 등)에 대한 미지원 경고가 나오는 것은 Prisma의 한계이며 동작에는 영향 없습니다. 벡터 필드는 `$queryRaw` / `$executeRaw`로 처리합니다.
+
+---
+
 ## 🐳 로컬 인프라 (PostgreSQL / Redis)
 
 `docker-compose.yml`은 backend 이미지 단독 실행용입니다. DB/Redis는 외부(RDS/ElastiCache)에 두는 게 기본이며, 로컬 개발 시에는 다음과 같이 단일 컨테이너로 띄우는 것을 권장합니다.
@@ -165,15 +196,17 @@ GET /api/v1/health/fatapi
 * Unit tests
 * Build
 
-**CD** — `dev` 브랜치에 머지되면 staging ECS로 자동 배포 (`.github/workflows/cd.yml`):
+**CD** — `dev` 브랜치에 머지되면 staging ECS로 자동 배포 (`.github/workflows/cd.yml`, 현재 **활성**):
 
-* OIDC로 AWS 인증
-* ECR로 이미지 push (`linux/amd64`, `:<sha>` + `:latest`)
-* ECS one-off task로 `prisma migrate deploy` 실행
-* `eum-backend-service` 업데이트 + 안정화 대기
-* ALB 헬스(`https://staging.eum-dating.com/api/v1/health`) 스모크
+* IAM Access Key로 AWS 인증 (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` secrets, 추후 GitHub OIDC role로 교체 예정)
+* ECR로 이미지 build & push (`linux/amd64`, `:<sha>` + `:latest`, GHA cache 활용)
+* 현재 task definition 기반으로 새 이미지 태그를 적용해 새 revision 등록
+* ECS one-off task(EC2 launch type)로 `npx prisma migrate deploy` 실행 — exit code 0이 아니면 배포 중단
+* 동일 revision으로 `eum-backend-service` `update-service`
+* `aws ecs wait services-stable` 대신 **PRIMARY deployment의 `rolloutState=COMPLETED` 폴링** (15초 × 60회 = 최대 15분, `FAILED` 시 즉시 실패)
+* ALB 헬스(`https://staging.eum-dating.com/api/v1/health`) 스모크 (5초 간격 × 최대 12회)
 
-> CD job은 staging RDS PG 교체 / OIDC role 등록 / Secrets Manager 갱신이 끝날 때까지 `if: ${{ false }}`로 비활성 상태입니다. 활성화 절차는 `cd.yml`의 TODO 코멘트 참고.
+> 동시 배포 방지: `concurrency: cd-staging` (취소 없이 직렬화).
 
 ---
 

--- a/src/common/errors/error-codes.ts
+++ b/src/common/errors/error-codes.ts
@@ -194,6 +194,11 @@ export const ERROR_DEFINITIONS = {
     code: 'MEETING-001',
     message: '입력값을 확인해 주세요.',
   },
+  MEETING_NOT_FOUND: {
+    status: HttpStatus.NOT_FOUND,
+    code: 'MEETING-002',
+    message: '해당 정모를 찾을 수 없어요.',
+  },
 
   // SYSTEM
   SERVER_TEMPORARY_ERROR: {

--- a/src/infra/prisma/prisma.service.ts
+++ b/src/infra/prisma/prisma.service.ts
@@ -11,7 +11,17 @@ export class PrismaService
     const url = process.env.DATABASE_URL;
     if (!url) throw new Error('DATABASE_URL is not set');
 
-    super({ adapter: new PrismaPg({ connectionString: url }) });
+    // RDS는 SSL 강제 + Amazon CA 체인이라 node-postgres가 self-signed로
+    // 인식. 공용 dev/staging DB라 검증을 생략한다. 운영 DB 연결 시에는
+    // RDS root CA 번들로 verify-full로 격상 필요.
+    const isRds = url.includes('.rds.amazonaws.com');
+
+    super({
+      adapter: new PrismaPg({
+        connectionString: url,
+        ...(isRds && { ssl: { rejectUnauthorized: false } }),
+      }),
+    });
   }
 
   async onModuleInit() {

--- a/src/modules/club/controllers/meeting/meeting.controller.spec.ts
+++ b/src/modules/club/controllers/meeting/meeting.controller.spec.ts
@@ -30,7 +30,10 @@ describe('MeetingController', () => {
         },
         {
           provide: MeetingService,
-          useValue: { createMeeting: jest.fn() },
+          useValue: {
+            createMeeting: jest.fn(),
+            deleteMeeting: jest.fn(),
+          },
         },
         AccessTokenGuard,
       ],

--- a/src/modules/club/controllers/meeting/meeting.controller.ts
+++ b/src/modules/club/controllers/meeting/meeting.controller.ts
@@ -1,24 +1,36 @@
-import { Body, Controller, Param, Post, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Param,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiBody,
   ApiCreatedResponse,
   ApiForbiddenResponse,
   ApiNotFoundResponse,
+  ApiOkResponse,
   ApiOperation,
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { AccessTokenGuard } from '../../../auth/guards/access-token.guard';
 import { RequiredUserId } from '../../../auth/decorators';
+import { ParsePositiveIntPipe } from '../../../../common/pipes/parse-positive-int.pipe';
 import { MeetingService } from '../../services/meeting/meeting.service';
-import type {
+import {
   CreateMeetingRequestDto,
   CreateMeetingResponseDto,
+  DeleteMeetingResponseDto,
 } from '../../dtos/meeting.dto';
 
 @ApiTags('Meeting')
 @ApiBearerAuth('access-token')
+@ApiUnauthorizedResponse({ description: '로그인 필요' })
+@ApiForbiddenResponse({ description: '호스트가 아님' })
 @UseGuards(AccessTokenGuard)
 @Controller('clubs/:clubId/meetings')
 export class MeetingController {
@@ -26,41 +38,40 @@ export class MeetingController {
 
   @Post()
   @ApiOperation({ summary: '정모 생성 (호스트만)' })
-  @ApiBody({
-    schema: {
-      type: 'object',
-      properties: {
-        name: { type: 'string', example: '매주하는 새벽등산' },
-        introText: {
-          type: 'string',
-          example: '함께 새벽 산행할 분들 모집해요.',
-        },
-        date: { type: 'string', example: '매주 목요일 저녁 19시' },
-        spot: { type: 'string', example: '종로역 1번 출구 앞' },
-        capacity: { type: 'integer', example: 15 },
-        cost: { type: 'string', example: '1인 10,000원', nullable: true },
-        joinPolicy: {
-          type: 'string',
-          enum: ['AUTO', 'APPROVAL_REQUIRED'],
-          example: 'AUTO',
-        },
-      },
-      required: ['name', 'introText', 'date', 'spot', 'capacity', 'joinPolicy'],
-    },
+  @ApiBody({ type: CreateMeetingRequestDto })
+  @ApiCreatedResponse({
+    description: '정모 생성 완료',
+    type: CreateMeetingResponseDto,
   })
-  @ApiCreatedResponse({ description: '정모 생성 완료' })
-  @ApiUnauthorizedResponse({ description: '로그인 필요' })
-  @ApiForbiddenResponse({ description: '호스트가 아님' })
   @ApiNotFoundResponse({ description: '클럽을 찾을 수 없음' })
   async createMeeting(
     @RequiredUserId() userId: number,
-    @Param('clubId') clubId: string,
+    @Param('clubId', new ParsePositiveIntPipe()) clubId: number,
     @Body() dto: CreateMeetingRequestDto,
   ): Promise<CreateMeetingResponseDto> {
     return this.meetingService.createMeeting(
       BigInt(userId),
       BigInt(clubId),
       dto,
+    );
+  }
+
+  @Delete(':meetingId')
+  @ApiOperation({ summary: '정모 삭제 (호스트만, soft delete)' })
+  @ApiOkResponse({
+    description: '정모 삭제 완료',
+    type: DeleteMeetingResponseDto,
+  })
+  @ApiNotFoundResponse({ description: '클럽 또는 정모를 찾을 수 없음' })
+  async deleteMeeting(
+    @RequiredUserId() userId: number,
+    @Param('clubId', new ParsePositiveIntPipe()) clubId: number,
+    @Param('meetingId', new ParsePositiveIntPipe()) meetingId: number,
+  ): Promise<DeleteMeetingResponseDto> {
+    return this.meetingService.deleteMeeting(
+      BigInt(userId),
+      BigInt(clubId),
+      BigInt(meetingId),
     );
   }
 }

--- a/src/modules/club/dtos/meeting.dto.ts
+++ b/src/modules/club/dtos/meeting.dto.ts
@@ -1,26 +1,105 @@
 import { MeetingJoinPolicy } from '@prisma/client';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsEnum,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MaxLength,
+  Min,
+} from 'class-validator';
 
-export interface CreateMeetingRequestDto {
-  name: string;
-  introText: string;
-  date: string;
-  spot: string;
-  capacity: number;
+export class CreateMeetingRequestDto {
+  @ApiProperty({ example: '매주하는 새벽등산', maxLength: 50 })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(50)
+  name!: string;
+
+  @ApiProperty({ example: '함께 새벽 산행할 분들 모집해요.', maxLength: 200 })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  introText!: string;
+
+  @ApiProperty({ example: '매주 목요일 저녁 19시', maxLength: 100 })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  date!: string;
+
+  @ApiProperty({ example: '종로역 1번 출구 앞', maxLength: 200 })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  spot!: string;
+
+  @ApiProperty({ example: 15 })
+  @IsInt()
+  @Min(1)
+  capacity!: number;
+
+  @ApiPropertyOptional({
+    example: '1인 10,000원',
+    nullable: true,
+    maxLength: 50,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(50)
   cost?: string;
-  joinPolicy: MeetingJoinPolicy;
+
+  @ApiProperty({ enum: MeetingJoinPolicy, example: MeetingJoinPolicy.AUTO })
+  @IsEnum(MeetingJoinPolicy)
+  joinPolicy!: MeetingJoinPolicy;
 }
 
-export interface CreateMeetingResponseDto {
-  meetingId: number;
-  clubId: number;
-  name: string;
-  introText: string;
-  date: string;
-  spot: string;
-  capacity: number;
-  cost: string | null;
-  joinPolicy: MeetingJoinPolicy;
-  isRegular: boolean;
-  attendeeCount: number;
-  createdAt: string;
+export class CreateMeetingResponseDto {
+  @ApiProperty({ example: 1 })
+  meetingId!: number;
+
+  @ApiProperty({ example: 10 })
+  clubId!: number;
+
+  @ApiProperty({ example: '매주하는 새벽등산' })
+  name!: string;
+
+  @ApiProperty({ example: '함께 새벽 산행할 분들 모집해요.' })
+  introText!: string;
+
+  @ApiProperty({ example: '매주 목요일 저녁 19시' })
+  date!: string;
+
+  @ApiProperty({ example: '종로역 1번 출구 앞' })
+  spot!: string;
+
+  @ApiProperty({ example: 15 })
+  capacity!: number;
+
+  @ApiPropertyOptional({ example: '1인 10,000원', nullable: true })
+  cost!: string | null;
+
+  @ApiProperty({ enum: MeetingJoinPolicy, example: MeetingJoinPolicy.AUTO })
+  joinPolicy!: MeetingJoinPolicy;
+
+  @ApiProperty({ example: true })
+  isRegular!: boolean;
+
+  @ApiProperty({ example: 0 })
+  attendeeCount!: number;
+
+  @ApiProperty({ example: '2026-05-31T12:00:00.000Z' })
+  createdAt!: string;
+}
+
+export class DeleteMeetingResponseDto {
+  @ApiProperty({ example: 88 })
+  meetingId!: number;
+
+  @ApiProperty({ example: 10 })
+  clubId!: number;
+
+  @ApiProperty({ example: '2026-05-31T12:00:00.000Z' })
+  deletedAt!: string;
 }

--- a/src/modules/club/repositories/meeting.repository.ts
+++ b/src/modules/club/repositories/meeting.repository.ts
@@ -18,4 +18,39 @@ export class MeetingRepository {
   }) {
     return this.prisma.meeting.create({ data });
   }
+
+  async findById(meetingId: bigint): Promise<{
+    id: bigint;
+    clubId: bigint;
+    deletedAt: Date | null;
+  } | null> {
+    return this.prisma.meeting.findUnique({
+      where: { id: meetingId },
+      select: { id: true, clubId: true, deletedAt: true },
+    });
+  }
+
+  async softDeleteWithMembers(
+    clubId: bigint,
+    meetingId: bigint,
+    deletedAt: Date,
+  ): Promise<boolean> {
+    return this.prisma.$transaction(async (tx) => {
+      const result = await tx.meeting.updateMany({
+        where: { id: meetingId, clubId, deletedAt: null },
+        data: { deletedAt },
+      });
+
+      if (result.count === 0) {
+        return false;
+      }
+
+      await tx.meetingMember.updateMany({
+        where: { meetingId, deletedAt: null },
+        data: { deletedAt },
+      });
+
+      return true;
+    });
+  }
 }

--- a/src/modules/club/services/meeting/meeting.service.spec.ts
+++ b/src/modules/club/services/meeting/meeting.service.spec.ts
@@ -10,6 +10,7 @@ describe('MeetingService', () => {
   let service: MeetingService;
   const findById = jest.fn();
   const create = jest.fn();
+  const softDeleteWithMembers = jest.fn();
 
   const validDto: CreateMeetingRequestDto = {
     name: '매주하는 새벽등산',
@@ -27,12 +28,19 @@ describe('MeetingService', () => {
   beforeEach(async () => {
     findById.mockReset();
     create.mockReset();
+    softDeleteWithMembers.mockReset();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         MeetingService,
         { provide: ClubRepository, useValue: { findById } },
-        { provide: MeetingRepository, useValue: { create } },
+        {
+          provide: MeetingRepository,
+          useValue: {
+            create,
+            softDeleteWithMembers,
+          },
+        },
       ],
     }).compile();
 
@@ -112,18 +120,138 @@ describe('MeetingService', () => {
     });
   });
 
-  it('capacity가 0 이하면 MEETING_VALIDATION_FAILED', async () => {
-    findById.mockResolvedValue({
-      id: clubId,
-      hostId: hostUserId,
-      deletedAt: null,
+  describe('deleteMeeting', () => {
+    const meetingId = 88n;
+
+    it('호스트가 정모를 삭제하면 Meeting + MeetingMember가 soft delete된다', async () => {
+      findById.mockResolvedValue({
+        id: clubId,
+        hostId: hostUserId,
+        deletedAt: null,
+      });
+      softDeleteWithMembers.mockResolvedValue(true);
+
+      const result = await service.deleteMeeting(hostUserId, clubId, meetingId);
+
+      expect(result.meetingId).toBe(Number(meetingId));
+      expect(result.clubId).toBe(Number(clubId));
+      expect(typeof result.deletedAt).toBe('string');
+      expect(softDeleteWithMembers).toHaveBeenCalledTimes(1);
+      expect(softDeleteWithMembers).toHaveBeenCalledWith(
+        clubId,
+        meetingId,
+        expect.any(Date),
+      );
     });
 
-    await expect(
-      service.createMeeting(hostUserId, clubId, { ...validDto, capacity: 0 }),
-    ).rejects.toMatchObject({
-      internalCode: 'MEETING_VALIDATION_FAILED',
+    it('repository에서 삭제 대상이 갱신되지 않으면 MEETING_NOT_FOUND', async () => {
+      findById.mockResolvedValue({
+        id: clubId,
+        hostId: hostUserId,
+        deletedAt: null,
+      });
+      softDeleteWithMembers.mockResolvedValue(false);
+
+      await expect(
+        service.deleteMeeting(hostUserId, clubId, meetingId),
+      ).rejects.toMatchObject({
+        internalCode: 'MEETING_NOT_FOUND',
+      });
+      expect(softDeleteWithMembers).toHaveBeenCalledWith(
+        clubId,
+        meetingId,
+        expect.any(Date),
+      );
     });
-    expect(create).not.toHaveBeenCalled();
+
+    it('호스트가 아니면 CLUB_FORBIDDEN_NOT_HOST', async () => {
+      findById.mockResolvedValue({
+        id: clubId,
+        hostId: 999n,
+        deletedAt: null,
+      });
+
+      await expect(
+        service.deleteMeeting(hostUserId, clubId, meetingId),
+      ).rejects.toMatchObject({
+        internalCode: 'CLUB_FORBIDDEN_NOT_HOST',
+      });
+      expect(softDeleteWithMembers).not.toHaveBeenCalled();
+    });
+
+    it('클럽이 없으면 CLUB_NOT_FOUND', async () => {
+      findById.mockResolvedValue(null);
+
+      await expect(
+        service.deleteMeeting(hostUserId, clubId, meetingId),
+      ).rejects.toMatchObject({
+        internalCode: 'CLUB_NOT_FOUND',
+      });
+      expect(softDeleteWithMembers).not.toHaveBeenCalled();
+    });
+
+    it('soft-deleted 클럽이면 CLUB_NOT_FOUND', async () => {
+      findById.mockResolvedValue({
+        id: clubId,
+        hostId: hostUserId,
+        deletedAt: new Date(),
+      });
+
+      await expect(
+        service.deleteMeeting(hostUserId, clubId, meetingId),
+      ).rejects.toMatchObject({
+        internalCode: 'CLUB_NOT_FOUND',
+      });
+    });
+
+    // 아래 3개 케이스(정모 없음 / 이미 삭제됨 / clubId 불일치)는 모두
+    // softDeleteWithMembers의 WHERE 절(id + clubId + deletedAt: null)에서 걸러져
+    // count=0 → false 반환 → MEETING_NOT_FOUND로 귀결된다. service 레벨에서는
+    // 구분 불가능하지만 입력 의도를 문서화하기 위해 케이스별로 유지한다.
+    // (입력별 동작 차이는 repository 레벨 테스트에서 검증할 항목.)
+    it('정모가 없으면 MEETING_NOT_FOUND', async () => {
+      findById.mockResolvedValue({
+        id: clubId,
+        hostId: hostUserId,
+        deletedAt: null,
+      });
+      softDeleteWithMembers.mockResolvedValue(false);
+
+      await expect(
+        service.deleteMeeting(hostUserId, clubId, meetingId),
+      ).rejects.toMatchObject({
+        internalCode: 'MEETING_NOT_FOUND',
+      });
+    });
+
+    it('이미 삭제된 정모면 MEETING_NOT_FOUND', async () => {
+      findById.mockResolvedValue({
+        id: clubId,
+        hostId: hostUserId,
+        deletedAt: null,
+      });
+      softDeleteWithMembers.mockResolvedValue(false);
+
+      await expect(
+        service.deleteMeeting(hostUserId, clubId, meetingId),
+      ).rejects.toMatchObject({
+        internalCode: 'MEETING_NOT_FOUND',
+      });
+    });
+
+    it('clubId/meetingId 불일치면 MEETING_NOT_FOUND', async () => {
+      findById.mockResolvedValue({
+        id: clubId,
+        hostId: hostUserId,
+        deletedAt: null,
+      });
+      softDeleteWithMembers.mockResolvedValue(false);
+
+      await expect(
+        service.deleteMeeting(hostUserId, clubId, meetingId),
+      ).rejects.toMatchObject({
+        internalCode: 'MEETING_NOT_FOUND',
+      });
+    });
   });
 });

--- a/src/modules/club/services/meeting/meeting.service.ts
+++ b/src/modules/club/services/meeting/meeting.service.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@nestjs/common';
-import { MeetingJoinPolicy } from '@prisma/client';
 import { AppException } from '../../../../common/errors/app.exception';
 import { ClubRepository } from '../../repositories/club.repository';
 import { MeetingRepository } from '../../repositories/meeting.repository';
 import {
   CreateMeetingRequestDto,
   CreateMeetingResponseDto,
+  DeleteMeetingResponseDto,
 } from '../../dtos/meeting.dto';
 
 @Injectable()
@@ -27,8 +27,6 @@ export class MeetingService {
     if (club.hostId !== userId) {
       throw new AppException('CLUB_FORBIDDEN_NOT_HOST');
     }
-
-    this.validateDto(dto);
 
     const created = await this.meetingRepository.create({
       clubId,
@@ -57,23 +55,33 @@ export class MeetingService {
     };
   }
 
-  private validateDto(dto: CreateMeetingRequestDto): void {
-    const violations: string[] = [];
-    if (!dto.name || dto.name.length > 50) violations.push('name');
-    if (!dto.introText || dto.introText.length > 200)
-      violations.push('introText');
-    if (!dto.date || dto.date.length > 100) violations.push('date');
-    if (!dto.spot) violations.push('spot');
-    if (!Number.isInteger(dto.capacity) || dto.capacity <= 0)
-      violations.push('capacity');
-    if (dto.cost !== undefined && dto.cost.length > 50) violations.push('cost');
-    if (!Object.values(MeetingJoinPolicy).includes(dto.joinPolicy))
-      violations.push('joinPolicy');
-
-    if (violations.length > 0) {
-      throw new AppException('MEETING_VALIDATION_FAILED', {
-        details: { fields: violations },
-      });
+  async deleteMeeting(
+    userId: bigint,
+    clubId: bigint,
+    meetingId: bigint,
+  ): Promise<DeleteMeetingResponseDto> {
+    const club = await this.clubRepository.findById(clubId);
+    if (!club || club.deletedAt) {
+      throw new AppException('CLUB_NOT_FOUND');
     }
+    if (club.hostId !== userId) {
+      throw new AppException('CLUB_FORBIDDEN_NOT_HOST');
+    }
+
+    const deletedAt = new Date();
+    const deleted = await this.meetingRepository.softDeleteWithMembers(
+      clubId,
+      meetingId,
+      deletedAt,
+    );
+    if (!deleted) {
+      throw new AppException('MEETING_NOT_FOUND');
+    }
+
+    return {
+      meetingId: Number(meetingId),
+      clubId: Number(clubId),
+      deletedAt: deletedAt.toISOString(),
+    };
   }
 }


### PR DESCRIPTION
## 이슈 번호
close #189 

## 주요 변경사항
  ### 기능
  - `DELETE /api/v1/clubs/:clubId/meetings/:meetingId` 추가 (호스트만, soft delete)
  - 트랜잭션으로 Meeting + MeetingMember 일괄 soft delete
  - `MEETING_NOT_FOUND` 에러 코드 신규 등록
  - 부가: 정모 생성 DTO 검증을 `class-validator` 데코레이터로 일원화 + Swagger 401/403 응답
  클래스 레벨로 승격 + `maxLength` 메타데이터 명시

  ### 인프라
  - PrismaService: `DATABASE_URL`이 `*.rds.amazonaws.com`이면 SSL 자동 활성화
  (`rejectUnauthorized: false`) — 팀 공용 staging RDS 연결 시 "self-signed certificate in
  certificate chain" 우회
  - CD: `rolloutState` 폴링 타임아웃 10분 → 15분으로 확장, `running/desired/failedTasks` 매 회
  로그, 타임아웃 시 deployments 전체 덤프
  
  ### 문서
  - README에 "RDS 단독 실행 가이드" 신규 섹션 추가
  - Redis 미사용 / `prisma db pull` 경고 정상임을 명시
  - CD 섹션을 실제 `cd.yml` 동작(IAM 키 인증, PRIMARY rolloutState 폴링)에 맞춰 갱신

## 테스트 결과 (스크린샷)
**정모 생성 완료**
<img width="1405" height="570" alt="image" src="https://github.com/user-attachments/assets/2ff6dcce-553c-40f3-9b36-478bfe1681a0" />

**존재하지 않는 클럽 ID일 때**
<img width="1405" height="810" alt="image" src="https://github.com/user-attachments/assets/91ef3fb1-ab0d-4b46-a2a4-cf564a75a0c3" />

**존재하지 않는 정기모임 ID일 때**
<img width="1413" height="815" alt="image" src="https://github.com/user-attachments/assets/35783c71-b62f-426b-9c0f-3fba2c0892d7" />

**정모 삭제 완료**
<img width="1409" height="810" alt="image" src="https://github.com/user-attachments/assets/7678e51d-7fd2-4b93-bf6c-97e1d1e81c11" />

**이미 삭제된 정모를 삭제할 때**
<img width="1416" height="811" alt="image" src="https://github.com/user-attachments/assets/5f257ea1-f7cb-46fb-aabc-cc4bff6fbcb9" />


## 참고 및 개선사항
  - PrismaService의 SSL `rejectUnauthorized: false`는 dev/staging 한정으로 처리했고 운영 DB 붙는 단계에선 RDS root CA 번들 기반 `verify-full`로 격상 필요합니다
  - 카카오 로그인이 안되는 관계로 AUTH 없이 테스트 진행했습니다 (PR 코드는 auth 반영)
