### PR TITLE
feat: 정모 상세 조회/수정 API 구현 및 정기모임 스키마 수정

### DIFF
--- a/prisma/dbml/schema.dbml
+++ b/prisma/dbml/schema.dbml
@@ -425,12 +425,16 @@ Table Meeting {
   id BigInt [pk, increment]
   name String [not null]
   introText String [not null]
-  date String [not null]
   spot String [not null]
   capacity Int [not null]
   cost String
   joinPolicy MeetingJoinPolicy [not null, default: 'AUTO']
   isRegular Boolean [not null, default: true]
+  recurrenceType RecurrenceType [not null]
+  daysOfWeek DayOfWeek[] [not null]
+  dayOfMonth Int
+  hour Int [not null]
+  minute Int [not null]
   createdAt DateTime [default: `now()`, not null]
   deletedAt DateTime
   updatedAt DateTime
@@ -550,6 +554,22 @@ Enum ClubUserStatus {
 Enum MeetingJoinPolicy {
   AUTO
   APPROVAL_REQUIRED
+}
+
+Enum RecurrenceType {
+  DAILY
+  WEEKLY
+  MONTHLY
+}
+
+Enum DayOfWeek {
+  MON
+  TUE
+  WED
+  THU
+  FRI
+  SAT
+  SUN
 }
 
 Enum ReportCategory {

--- a/prisma/migrations/20260607152429_meeting_recurrence/migration.sql
+++ b/prisma/migrations/20260607152429_meeting_recurrence/migration.sql
@@ -1,0 +1,30 @@
+-- CreateEnum
+CREATE TYPE "RecurrenceType" AS ENUM ('DAILY', 'WEEKLY', 'MONTHLY');
+
+-- CreateEnum
+CREATE TYPE "DayOfWeek" AS ENUM ('MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN');
+
+-- Step 1: 신규 컬럼을 nullable / 기본값으로 추가 (기존 row 보존)
+ALTER TABLE "Meeting"
+  ADD COLUMN "recurrenceType" "RecurrenceType",
+  ADD COLUMN "daysOfWeek"     "DayOfWeek"[] DEFAULT ARRAY[]::"DayOfWeek"[],
+  ADD COLUMN "dayOfMonth"     INTEGER,
+  ADD COLUMN "hour"           INTEGER,
+  ADD COLUMN "minute"         INTEGER;
+
+-- Step 2: 기존 row 일률 백필 (개발/더미 데이터 가정: 매주 목요일 오후 7시)
+UPDATE "Meeting"
+SET "recurrenceType" = 'WEEKLY',
+    "daysOfWeek"     = ARRAY['THU']::"DayOfWeek"[],
+    "hour"           = 19,
+    "minute"         = 0
+WHERE "recurrenceType" IS NULL;
+
+-- Step 3: NOT NULL 강제
+ALTER TABLE "Meeting"
+  ALTER COLUMN "recurrenceType" SET NOT NULL,
+  ALTER COLUMN "hour"           SET NOT NULL,
+  ALTER COLUMN "minute"         SET NOT NULL;
+
+-- Step 4: 구 컬럼 제거
+ALTER TABLE "Meeting" DROP COLUMN "date";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -87,6 +87,22 @@ enum MeetingJoinPolicy {
   APPROVAL_REQUIRED
 }
 
+enum RecurrenceType {
+  DAILY
+  WEEKLY
+  MONTHLY
+}
+
+enum DayOfWeek {
+  MON
+  TUE
+  WED
+  THU
+  FRI
+  SAT
+  SUN
+}
+
 enum ReportCategory {
   INAPPROPRIATE
   SEXUAL_HARASSMENT
@@ -604,19 +620,23 @@ model ClubLike {
 }
 
 model Meeting {
-  id         BigInt            @id @default(autoincrement()) @db.BigInt
-  name       String            @db.VarChar(50)
-  introText  String            @db.VarChar(200)
-  date       String            @db.VarChar(100)
-  spot       String            @db.Text
-  capacity   Int               @db.Integer
-  cost       String?           @db.VarChar(50)
-  joinPolicy MeetingJoinPolicy @default(AUTO)
-  isRegular  Boolean           @default(true)
-  createdAt  DateTime          @default(now()) @db.Timestamp(6)
-  deletedAt  DateTime?         @db.Timestamp(6)
-  updatedAt  DateTime?         @updatedAt
-  clubId     BigInt            @db.BigInt
+  id             BigInt            @id @default(autoincrement()) @db.BigInt
+  name           String            @db.VarChar(50)
+  introText      String            @db.VarChar(200)
+  spot           String            @db.Text
+  capacity       Int               @db.Integer
+  cost           String?           @db.VarChar(50)
+  joinPolicy     MeetingJoinPolicy @default(AUTO)
+  isRegular      Boolean           @default(true)
+  recurrenceType RecurrenceType
+  daysOfWeek     DayOfWeek[]       @default([])
+  dayOfMonth     Int?              @db.Integer
+  hour           Int               @db.Integer
+  minute         Int               @db.Integer
+  createdAt      DateTime          @default(now()) @db.Timestamp(6)
+  deletedAt      DateTime?         @db.Timestamp(6)
+  updatedAt      DateTime?         @updatedAt
+  clubId         BigInt            @db.BigInt
 
   club           Club            @relation(fields: [clubId], references: [id], onDelete: Cascade) // 클럽 삭제 시 정기모임도 삭제
   meetingMembers MeetingMember[]

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,4 +1,4 @@
-import { Prisma, PrismaClient } from '@prisma/client';
+import { DayOfWeek, Prisma, PrismaClient, RecurrenceType } from '@prisma/client';
 import { PrismaPg } from '@prisma/adapter-pg';
 import { parse } from 'csv-parse/sync';
 import * as dotenv from 'dotenv';
@@ -449,17 +449,40 @@ async function insertDummyData() {
     skipDuplicates: true,
   });
 
+  const RECURRENCE_TYPES: RecurrenceType[] = ['DAILY', 'WEEKLY', 'MONTHLY'];
+  const DAY_OF_WEEK_VALUES: DayOfWeek[] = [
+    'MON',
+    'TUE',
+    'WED',
+    'THU',
+    'FRI',
+    'SAT',
+    'SUN',
+  ];
+
   await prisma.meeting.createMany({
-    data: Array.from({ length: DUMMY_COUNT }, (_, index) => ({
-      id: BigInt(index + 1),
-      name: `Seed Meeting ${index + 1}`,
-      date: daysFromSeed(7 + index),
-      createdAt: daysFromSeed(index),
-      updatedAt: daysFromSeed(index),
-      clubId: BigInt(index + 1),
-      spot: `Seed meeting spot ${index + 1}`,
-      isRegular: index % 2 === 0,
-    })),
+    data: Array.from({ length: DUMMY_COUNT }, (_, index) => {
+      const type = RECURRENCE_TYPES[index % RECURRENCE_TYPES.length];
+      return {
+        id: BigInt(index + 1),
+        name: `Seed Meeting ${index + 1}`,
+        introText: `Seed meeting intro ${index + 1}`,
+        spot: `Seed meeting spot ${index + 1}`,
+        capacity: 8 + (index % 5),
+        cost: index % 4 === 0 ? null : `1인 ${(index + 1) * 1000}원`,
+        joinPolicy: index % 3 === 0 ? 'APPROVAL_REQUIRED' : 'AUTO',
+        isRegular: index % 2 === 0,
+        recurrenceType: type,
+        daysOfWeek:
+          type === 'WEEKLY' ? [DAY_OF_WEEK_VALUES[index % 7]] : [],
+        dayOfMonth: type === 'MONTHLY' ? ((index % 28) + 1) : null,
+        hour: (index + 9) % 24,
+        minute: (index * 10) % 60,
+        createdAt: daysFromSeed(index),
+        updatedAt: daysFromSeed(index),
+        clubId: BigInt(index + 1),
+      };
+    }),
     skipDuplicates: true,
   });
 

--- a/src/common/errors/error-codes.ts
+++ b/src/common/errors/error-codes.ts
@@ -187,12 +187,27 @@ export const ERROR_DEFINITIONS = {
     code: 'CLUB-002',
     message: '호스트만 이 작업을 수행할 수 있어요.',
   },
+  CLUB_FORBIDDEN_NOT_MEMBER: {
+    status: HttpStatus.FORBIDDEN,
+    code: 'CLUB-003',
+    message: '클럽 멤버만 참여할 수 있어요.',
+  },
 
   // MEETING
   MEETING_VALIDATION_FAILED: {
     status: HttpStatus.BAD_REQUEST,
     code: 'MEETING-001',
     message: '입력값을 확인해 주세요.',
+  },
+  MEETING_NOT_FOUND: {
+    status: HttpStatus.NOT_FOUND,
+    code: 'MEETING-002',
+    message: '해당 정모를 찾을 수 없어요.',
+  },
+  MEETING_CAPACITY_BELOW_ATTENDEES: {
+    status: HttpStatus.CONFLICT,
+    code: 'MEETING-003',
+    message: '현재 참석자 수보다 수용 인원을 낮출 수 없어요.',
   },
 
   // SYSTEM

--- a/src/common/utils/datetime.util.spec.ts
+++ b/src/common/utils/datetime.util.spec.ts
@@ -1,0 +1,21 @@
+import { toKstIso } from './datetime.util';
+
+describe('toKstIso', () => {
+  it('UTC instant를 +09:00 오프셋으로 변환한다', () => {
+    expect(toKstIso(new Date('2026-04-20T01:00:00Z'))).toBe(
+      '2026-04-20T10:00:00+09:00',
+    );
+  });
+
+  it('자정 직전 UTC가 KST에서는 다음날 오전이 된다', () => {
+    expect(toKstIso(new Date('2026-04-20T15:30:45Z'))).toBe(
+      '2026-04-21T00:30:45+09:00',
+    );
+  });
+
+  it('연말 경계도 정확히 처리한다', () => {
+    expect(toKstIso(new Date('2026-12-31T15:00:00Z'))).toBe(
+      '2027-01-01T00:00:00+09:00',
+    );
+  });
+});

--- a/src/common/utils/datetime.util.ts
+++ b/src/common/utils/datetime.util.ts
@@ -1,0 +1,16 @@
+const KST_OFFSET_MINUTES = 9 * 60;
+
+function pad2(value: number): string {
+  return value.toString().padStart(2, '0');
+}
+
+export function toKstIso(date: Date): string {
+  const shifted = new Date(date.getTime() + KST_OFFSET_MINUTES * 60_000);
+  const year = shifted.getUTCFullYear();
+  const month = pad2(shifted.getUTCMonth() + 1);
+  const day = pad2(shifted.getUTCDate());
+  const hour = pad2(shifted.getUTCHours());
+  const minute = pad2(shifted.getUTCMinutes());
+  const second = pad2(shifted.getUTCSeconds());
+  return `${year}-${month}-${day}T${hour}:${minute}:${second}+09:00`;
+}

--- a/src/modules/club/controllers/meeting/meeting.controller.ts
+++ b/src/modules/club/controllers/meeting/meeting.controller.ts
@@ -1,24 +1,42 @@
-import { Body, Controller, Param, Post, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiBody,
+  ApiConflictResponse,
   ApiCreatedResponse,
   ApiForbiddenResponse,
   ApiNotFoundResponse,
+  ApiOkResponse,
   ApiOperation,
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { AccessTokenGuard } from '../../../auth/guards/access-token.guard';
 import { RequiredUserId } from '../../../auth/decorators';
+import { ParsePositiveIntPipe } from '../../../../common/pipes/parse-positive-int.pipe';
 import { MeetingService } from '../../services/meeting/meeting.service';
-import type {
+import {
   CreateMeetingRequestDto,
   CreateMeetingResponseDto,
+  DeleteMeetingResponseDto,
+  GetMeetingDetailResponseDto,
+  UpdateMeetingRequestDto,
+  UpdateMeetingResponseDto,
 } from '../../dtos/meeting.dto';
 
 @ApiTags('Meeting')
 @ApiBearerAuth('access-token')
+@ApiUnauthorizedResponse({ description: '로그인 필요' })
+@ApiForbiddenResponse({ description: '권한 없음' })
 @UseGuards(AccessTokenGuard)
 @Controller('clubs/:clubId/meetings')
 export class MeetingController {
@@ -26,41 +44,84 @@ export class MeetingController {
 
   @Post()
   @ApiOperation({ summary: '정모 생성 (호스트만)' })
-  @ApiBody({
-    schema: {
-      type: 'object',
-      properties: {
-        name: { type: 'string', example: '매주하는 새벽등산' },
-        introText: {
-          type: 'string',
-          example: '함께 새벽 산행할 분들 모집해요.',
-        },
-        date: { type: 'string', example: '매주 목요일 저녁 19시' },
-        spot: { type: 'string', example: '종로역 1번 출구 앞' },
-        capacity: { type: 'integer', example: 15 },
-        cost: { type: 'string', example: '1인 10,000원', nullable: true },
-        joinPolicy: {
-          type: 'string',
-          enum: ['AUTO', 'APPROVAL_REQUIRED'],
-          example: 'AUTO',
-        },
-      },
-      required: ['name', 'introText', 'date', 'spot', 'capacity', 'joinPolicy'],
-    },
+  @ApiBody({ type: CreateMeetingRequestDto })
+  @ApiCreatedResponse({
+    description: '정모 생성 완료',
+    type: CreateMeetingResponseDto,
   })
-  @ApiCreatedResponse({ description: '정모 생성 완료' })
-  @ApiUnauthorizedResponse({ description: '로그인 필요' })
-  @ApiForbiddenResponse({ description: '호스트가 아님' })
   @ApiNotFoundResponse({ description: '클럽을 찾을 수 없음' })
   async createMeeting(
     @RequiredUserId() userId: number,
-    @Param('clubId') clubId: string,
+    @Param('clubId', new ParsePositiveIntPipe()) clubId: number,
     @Body() dto: CreateMeetingRequestDto,
   ): Promise<CreateMeetingResponseDto> {
     return this.meetingService.createMeeting(
       BigInt(userId),
       BigInt(clubId),
       dto,
+    );
+  }
+
+  @Get(':meetingId')
+  @ApiOperation({ summary: '정모 상세 조회 (클럽 가입자만)' })
+  @ApiOkResponse({
+    description: '정모 상세 조회 성공',
+    type: GetMeetingDetailResponseDto,
+  })
+  @ApiNotFoundResponse({ description: '클럽 또는 정모를 찾을 수 없음' })
+  async getMeetingDetail(
+    @RequiredUserId() userId: number,
+    @Param('clubId', new ParsePositiveIntPipe()) clubId: number,
+    @Param('meetingId', new ParsePositiveIntPipe()) meetingId: number,
+  ): Promise<GetMeetingDetailResponseDto> {
+    return this.meetingService.getMeetingDetail(
+      BigInt(userId),
+      BigInt(clubId),
+      BigInt(meetingId),
+    );
+  }
+
+  @Patch(':meetingId')
+  @ApiOperation({ summary: '정모 수정 (호스트만)' })
+  @ApiBody({ type: UpdateMeetingRequestDto })
+  @ApiOkResponse({
+    description: '정모 수정 완료',
+    type: UpdateMeetingResponseDto,
+  })
+  @ApiNotFoundResponse({ description: '클럽 또는 정모를 찾을 수 없음' })
+  @ApiConflictResponse({
+    description: '현재 참석자 수보다 수용 인원을 낮출 수 없음',
+  })
+  async updateMeeting(
+    @RequiredUserId() userId: number,
+    @Param('clubId', new ParsePositiveIntPipe()) clubId: number,
+    @Param('meetingId', new ParsePositiveIntPipe()) meetingId: number,
+    @Body() dto: UpdateMeetingRequestDto,
+  ): Promise<UpdateMeetingResponseDto> {
+    return this.meetingService.updateMeeting(
+      BigInt(userId),
+      BigInt(clubId),
+      BigInt(meetingId),
+      dto,
+    );
+  }
+
+  @Delete(':meetingId')
+  @ApiOperation({ summary: '정모 삭제 (호스트만, soft delete)' })
+  @ApiOkResponse({
+    description: '정모 삭제 완료',
+    type: DeleteMeetingResponseDto,
+  })
+  @ApiNotFoundResponse({ description: '클럽 또는 정모를 찾을 수 없음' })
+  async deleteMeeting(
+    @RequiredUserId() userId: number,
+    @Param('clubId', new ParsePositiveIntPipe()) clubId: number,
+    @Param('meetingId', new ParsePositiveIntPipe()) meetingId: number,
+  ): Promise<DeleteMeetingResponseDto> {
+    return this.meetingService.deleteMeeting(
+      BigInt(userId),
+      BigInt(clubId),
+      BigInt(meetingId),
     );
   }
 }

--- a/src/modules/club/dtos/meeting.dto.spec.ts
+++ b/src/modules/club/dtos/meeting.dto.spec.ts
@@ -1,0 +1,122 @@
+import { DayOfWeek, RecurrenceType } from '@prisma/client';
+import { RecurrenceShapeConstraint } from './meeting.dto';
+
+describe('RecurrenceShapeConstraint', () => {
+  const c = new RecurrenceShapeConstraint();
+
+  it('WEEKLY + daysOfWeek 만 → 통과', () => {
+    expect(
+      c.validate({
+        type: RecurrenceType.WEEKLY,
+        daysOfWeek: [DayOfWeek.THU],
+        hour: 19,
+        minute: 0,
+      }),
+    ).toBe(true);
+  });
+
+  it('WEEKLY + dayOfMonth 동시에 → 거절', () => {
+    expect(
+      c.validate({
+        type: RecurrenceType.WEEKLY,
+        daysOfWeek: [DayOfWeek.THU],
+        dayOfMonth: 15,
+        hour: 19,
+        minute: 0,
+      }),
+    ).toBe(false);
+  });
+
+  it('MONTHLY + dayOfMonth 만 → 통과', () => {
+    expect(
+      c.validate({
+        type: RecurrenceType.MONTHLY,
+        dayOfMonth: 15,
+        hour: 19,
+        minute: 0,
+      }),
+    ).toBe(true);
+  });
+
+  it('MONTHLY + daysOfWeek 동시에 → 거절', () => {
+    expect(
+      c.validate({
+        type: RecurrenceType.MONTHLY,
+        dayOfMonth: 15,
+        daysOfWeek: [DayOfWeek.THU],
+        hour: 19,
+        minute: 0,
+      }),
+    ).toBe(false);
+  });
+
+  it('DAILY + 부수 필드 없음 → 통과', () => {
+    expect(c.validate({ type: RecurrenceType.DAILY, hour: 7, minute: 0 })).toBe(
+      true,
+    );
+  });
+
+  it('DAILY + daysOfWeek → 거절', () => {
+    expect(
+      c.validate({
+        type: RecurrenceType.DAILY,
+        daysOfWeek: [DayOfWeek.MON],
+        hour: 7,
+        minute: 0,
+      }),
+    ).toBe(false);
+  });
+
+  it('DAILY + dayOfMonth → 거절', () => {
+    expect(
+      c.validate({
+        type: RecurrenceType.DAILY,
+        dayOfMonth: 1,
+        hour: 7,
+        minute: 0,
+      }),
+    ).toBe(false);
+  });
+
+  it('빈 daysOfWeek 배열은 부수 필드로 간주하지 않음', () => {
+    expect(
+      c.validate({
+        type: RecurrenceType.DAILY,
+        daysOfWeek: [],
+        hour: 7,
+        minute: 0,
+      }),
+    ).toBe(true);
+  });
+
+  it('잘못된 input(null) → 다른 검증기에 위임 (true)', () => {
+    expect(c.validate(null)).toBe(true);
+    expect(c.validate(undefined)).toBe(true);
+  });
+
+  it('defaultMessage: WEEKLY가 아닌데 daysOfWeek 있음', () => {
+    const msg = c.defaultMessage({
+      value: {
+        type: RecurrenceType.MONTHLY,
+        daysOfWeek: [DayOfWeek.THU],
+        dayOfMonth: 15,
+        hour: 19,
+        minute: 0,
+      },
+    } as never);
+    expect(msg).toContain('daysOfWeek');
+  });
+
+  it('defaultMessage: MONTHLY가 아닌데 dayOfMonth 있음', () => {
+    const msg = c.defaultMessage({
+      value: {
+        type: RecurrenceType.WEEKLY,
+        daysOfWeek: [DayOfWeek.THU],
+        dayOfMonth: 15,
+        hour: 19,
+        minute: 0,
+      },
+    } as never);
+    expect(msg).toContain('dayOfMonth');
+  });
+});

--- a/src/modules/club/dtos/meeting.dto.ts
+++ b/src/modules/club/dtos/meeting.dto.ts
@@ -131,6 +131,7 @@ export class CreateMeetingRequestDto {
   joinPolicy!: MeetingJoinPolicy;
 
   @ApiProperty({ type: RecurrenceInputDto })
+  @IsDefined()
   @ValidateNested()
   @Type(() => RecurrenceInputDto)
   @Validate(RecurrenceShapeConstraint)

--- a/src/modules/club/dtos/meeting.dto.ts
+++ b/src/modules/club/dtos/meeting.dto.ts
@@ -5,6 +5,7 @@ import {
   ArrayMinSize,
   ArrayUnique,
   IsArray,
+  IsDefined,
   IsEnum,
   IsInt,
   IsNotEmpty,
@@ -60,6 +61,7 @@ export class RecurrenceInputDto {
     description: 'WEEKLY일 때 필수 (1개 이상)',
   })
   @ValidateIf((o: RecurrenceInputDto) => o.type === RecurrenceType.WEEKLY)
+  @IsDefined()
   @IsArray()
   @ArrayMinSize(1)
   @ArrayUnique()
@@ -71,6 +73,7 @@ export class RecurrenceInputDto {
     description: 'MONTHLY일 때 필수 (1-31)',
   })
   @ValidateIf((o: RecurrenceInputDto) => o.type === RecurrenceType.MONTHLY)
+  @IsDefined()
   @IsInt()
   @Min(1)
   @Max(31)

--- a/src/modules/club/dtos/meeting.dto.ts
+++ b/src/modules/club/dtos/meeting.dto.ts
@@ -1,26 +1,295 @@
-import { MeetingJoinPolicy } from '@prisma/client';
+import { DayOfWeek, MeetingJoinPolicy, RecurrenceType } from '@prisma/client';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  ArrayMinSize,
+  ArrayUnique,
+  IsArray,
+  IsEnum,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+  Validate,
+  ValidateIf,
+  ValidateNested,
+  ValidationArguments,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
 
-export interface CreateMeetingRequestDto {
-  name: string;
-  introText: string;
-  date: string;
-  spot: string;
-  capacity: number;
-  cost?: string;
-  joinPolicy: MeetingJoinPolicy;
+@ValidatorConstraint({ name: 'RecurrenceShape', async: false })
+export class RecurrenceShapeConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown): boolean {
+    if (!value || typeof value !== 'object') return true;
+    const r = value as RecurrenceInputDto;
+
+    const hasWeekDays = Array.isArray(r.daysOfWeek) && r.daysOfWeek.length > 0;
+    const hasMonthDay = r.dayOfMonth !== undefined && r.dayOfMonth !== null;
+
+    if (r.type !== RecurrenceType.WEEKLY && hasWeekDays) return false;
+    if (r.type !== RecurrenceType.MONTHLY && hasMonthDay) return false;
+    return true;
+  }
+
+  defaultMessage(args: ValidationArguments): string {
+    const r = args.value as RecurrenceInputDto | undefined;
+    if (
+      r?.type !== RecurrenceType.WEEKLY &&
+      Array.isArray(r?.daysOfWeek) &&
+      r.daysOfWeek.length > 0
+    ) {
+      return 'daysOfWeek는 type=WEEKLY일 때만 허용됩니다.';
+    }
+    return 'dayOfMonth는 type=MONTHLY일 때만 허용됩니다.';
+  }
 }
 
-export interface CreateMeetingResponseDto {
-  meetingId: number;
-  clubId: number;
-  name: string;
-  introText: string;
-  date: string;
-  spot: string;
-  capacity: number;
-  cost: string | null;
-  joinPolicy: MeetingJoinPolicy;
-  isRegular: boolean;
-  attendeeCount: number;
-  createdAt: string;
+export class RecurrenceInputDto {
+  @ApiProperty({ enum: RecurrenceType, example: RecurrenceType.WEEKLY })
+  @IsEnum(RecurrenceType)
+  type!: RecurrenceType;
+
+  @ApiPropertyOptional({
+    enum: DayOfWeek,
+    isArray: true,
+    example: [DayOfWeek.THU],
+    description: 'WEEKLY일 때 필수 (1개 이상)',
+  })
+  @ValidateIf((o: RecurrenceInputDto) => o.type === RecurrenceType.WEEKLY)
+  @IsArray()
+  @ArrayMinSize(1)
+  @ArrayUnique()
+  @IsEnum(DayOfWeek, { each: true })
+  daysOfWeek?: DayOfWeek[];
+
+  @ApiPropertyOptional({
+    example: 15,
+    description: 'MONTHLY일 때 필수 (1-31)',
+  })
+  @ValidateIf((o: RecurrenceInputDto) => o.type === RecurrenceType.MONTHLY)
+  @IsInt()
+  @Min(1)
+  @Max(31)
+  dayOfMonth?: number;
+
+  @ApiProperty({ example: 19, description: '0-23 (KST)' })
+  @IsInt()
+  @Min(0)
+  @Max(23)
+  hour!: number;
+
+  @ApiProperty({ example: 0, description: '0-59' })
+  @IsInt()
+  @Min(0)
+  @Max(59)
+  minute!: number;
+}
+
+export class CreateMeetingRequestDto {
+  @ApiProperty({ example: '매주하는 새벽등산', maxLength: 50 })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(50)
+  name!: string;
+
+  @ApiProperty({ example: '함께 새벽 산행할 분들 모집해요.', maxLength: 200 })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  introText!: string;
+
+  @ApiProperty({ example: '종로역 1번 출구 앞', maxLength: 200 })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  spot!: string;
+
+  @ApiProperty({ example: 15 })
+  @IsInt()
+  @Min(1)
+  capacity!: number;
+
+  @ApiPropertyOptional({
+    example: '1인 10,000원',
+    nullable: true,
+    maxLength: 50,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(50)
+  cost?: string;
+
+  @ApiProperty({ enum: MeetingJoinPolicy, example: MeetingJoinPolicy.AUTO })
+  @IsEnum(MeetingJoinPolicy)
+  joinPolicy!: MeetingJoinPolicy;
+
+  @ApiProperty({ type: RecurrenceInputDto })
+  @ValidateNested()
+  @Type(() => RecurrenceInputDto)
+  @Validate(RecurrenceShapeConstraint)
+  recurrence!: RecurrenceInputDto;
+}
+
+export class UpdateMeetingRequestDto {
+  @ApiPropertyOptional({ example: '매주하는 새벽등산', maxLength: 50 })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(50)
+  name?: string;
+
+  @ApiPropertyOptional({
+    example: '함께 새벽 산행할 분들 모집해요.',
+    maxLength: 200,
+  })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  introText?: string;
+
+  @ApiPropertyOptional({ example: '종로역 1번 출구 앞', maxLength: 200 })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  spot?: string;
+
+  @ApiPropertyOptional({ example: 15 })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  capacity?: number;
+
+  @ApiPropertyOptional({
+    example: '1인 10,000원',
+    nullable: true,
+    maxLength: 50,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(50)
+  cost?: string | null;
+
+  @ApiPropertyOptional({
+    enum: MeetingJoinPolicy,
+    example: MeetingJoinPolicy.AUTO,
+  })
+  @IsOptional()
+  @IsEnum(MeetingJoinPolicy)
+  joinPolicy?: MeetingJoinPolicy;
+
+  @ApiPropertyOptional({ type: RecurrenceInputDto })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => RecurrenceInputDto)
+  @Validate(RecurrenceShapeConstraint)
+  recurrence?: RecurrenceInputDto;
+}
+
+export class RecurrenceDto {
+  @ApiProperty({ enum: RecurrenceType, example: RecurrenceType.WEEKLY })
+  type!: RecurrenceType;
+
+  @ApiProperty({
+    enum: DayOfWeek,
+    isArray: true,
+    nullable: true,
+    example: [DayOfWeek.THU],
+  })
+  daysOfWeek!: DayOfWeek[] | null;
+
+  @ApiProperty({ example: null, nullable: true })
+  dayOfMonth!: number | null;
+
+  @ApiProperty({ example: 19 })
+  hour!: number;
+
+  @ApiProperty({ example: 0 })
+  minute!: number;
+}
+
+export class AttendeePreviewDto {
+  @ApiProperty({ example: 42 })
+  userId!: number;
+
+  @ApiProperty({ example: '루씨' })
+  nickname!: string;
+
+  @ApiProperty({ example: 'https://cdn.example.com/profile/42.jpg' })
+  profileImageUrl!: string;
+}
+
+export class MeetingDetailDto {
+  @ApiProperty({ example: 88 })
+  meetingId!: number;
+
+  @ApiProperty({ example: 12 })
+  clubId!: number;
+
+  @ApiProperty({ example: '매주하는 새벽등산🔥' })
+  name!: string;
+
+  @ApiProperty({ example: '등산화와 물을 꼭 지참해 주세요.' })
+  introText!: string;
+
+  @ApiProperty({ example: '종로역 1번 출구 앞' })
+  spot!: string;
+
+  @ApiPropertyOptional({ example: '1인 30,000원', nullable: true })
+  cost!: string | null;
+
+  @ApiProperty({ example: 8 })
+  capacity!: number;
+
+  @ApiProperty({ example: 4 })
+  attendeeCount!: number;
+
+  @ApiProperty({ enum: MeetingJoinPolicy, example: MeetingJoinPolicy.AUTO })
+  joinPolicy!: MeetingJoinPolicy;
+
+  @ApiProperty({ example: true })
+  isRegular!: boolean;
+
+  @ApiProperty({ example: true })
+  isAttending!: boolean;
+
+  @ApiProperty({ type: RecurrenceDto })
+  recurrence!: RecurrenceDto;
+
+  @ApiProperty({ example: '매주 목요일 오후 7시' })
+  dateLabel!: string;
+
+  @ApiProperty({ example: '2026-12-12T19:00:00+09:00' })
+  nextOccurrenceAt!: string;
+
+  @ApiProperty({ type: [AttendeePreviewDto] })
+  attendeesPreview!: AttendeePreviewDto[];
+
+  @ApiProperty({ example: '2026-04-20T10:00:00+09:00' })
+  createdAt!: string;
+
+  @ApiProperty({ example: null, nullable: true })
+  updatedAt!: string | null;
+}
+
+export class CreateMeetingResponseDto extends MeetingDetailDto {}
+
+export class GetMeetingDetailResponseDto extends MeetingDetailDto {}
+
+export class UpdateMeetingResponseDto extends MeetingDetailDto {}
+
+export class DeleteMeetingResponseDto {
+  @ApiProperty({ example: 88 })
+  meetingId!: number;
+
+  @ApiProperty({ example: 10 })
+  clubId!: number;
+
+  @ApiProperty({ example: '2026-05-31T12:00:00+09:00' })
+  deletedAt!: string;
 }

--- a/src/modules/club/repositories/club.repository.ts
+++ b/src/modules/club/repositories/club.repository.ts
@@ -15,4 +15,19 @@ export class ClubRepository {
       select: { id: true, hostId: true, deletedAt: true },
     });
   }
+
+  async findActiveClubUser(
+    userId: bigint,
+    clubId: bigint,
+  ): Promise<{ id: bigint } | null> {
+    return this.prisma.clubUser.findFirst({
+      where: {
+        userId,
+        clubId,
+        status: 'ACTIVE',
+        leftAt: null,
+      },
+      select: { id: true },
+    });
+  }
 }

--- a/src/modules/club/repositories/club.repository.ts
+++ b/src/modules/club/repositories/club.repository.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { ClubUserStatus } from '@prisma/client';
 import { PrismaService } from '../../../infra/prisma/prisma.service';
 
 @Injectable()
@@ -24,7 +25,7 @@ export class ClubRepository {
       where: {
         userId,
         clubId,
-        status: 'ACTIVE',
+        status: ClubUserStatus.ACTIVE,
         leftAt: null,
       },
       select: { id: true },

--- a/src/modules/club/repositories/meeting.repository.ts
+++ b/src/modules/club/repositories/meeting.repository.ts
@@ -1,6 +1,52 @@
 import { Injectable } from '@nestjs/common';
-import { MeetingJoinPolicy } from '@prisma/client';
+import { DayOfWeek, MeetingJoinPolicy, RecurrenceType } from '@prisma/client';
 import { PrismaService } from '../../../infra/prisma/prisma.service';
+
+export type MeetingDetailRow = {
+  id: bigint;
+  clubId: bigint;
+  name: string;
+  introText: string;
+  spot: string;
+  capacity: number;
+  cost: string | null;
+  joinPolicy: MeetingJoinPolicy;
+  isRegular: boolean;
+  recurrenceType: RecurrenceType;
+  daysOfWeek: DayOfWeek[];
+  dayOfMonth: number | null;
+  hour: number;
+  minute: number;
+  createdAt: Date;
+  updatedAt: Date | null;
+  deletedAt: Date | null;
+};
+
+export type AttendeePreviewRow = {
+  userId: bigint;
+  nickname: string;
+  profileImageUrl: string;
+};
+
+const MEETING_DETAIL_SELECT = {
+  id: true,
+  clubId: true,
+  name: true,
+  introText: true,
+  spot: true,
+  capacity: true,
+  cost: true,
+  joinPolicy: true,
+  isRegular: true,
+  recurrenceType: true,
+  daysOfWeek: true,
+  dayOfMonth: true,
+  hour: true,
+  minute: true,
+  createdAt: true,
+  updatedAt: true,
+  deletedAt: true,
+} as const;
 
 @Injectable()
 export class MeetingRepository {
@@ -10,12 +56,126 @@ export class MeetingRepository {
     clubId: bigint;
     name: string;
     introText: string;
-    date: string;
     spot: string;
     capacity: number;
     cost: string | null;
     joinPolicy: MeetingJoinPolicy;
-  }) {
-    return this.prisma.meeting.create({ data });
+    recurrenceType: RecurrenceType;
+    daysOfWeek: DayOfWeek[];
+    dayOfMonth: number | null;
+    hour: number;
+    minute: number;
+  }): Promise<MeetingDetailRow> {
+    return this.prisma.meeting.create({
+      data,
+      select: MEETING_DETAIL_SELECT,
+    });
+  }
+
+  async findById(meetingId: bigint): Promise<{
+    id: bigint;
+    clubId: bigint;
+    deletedAt: Date | null;
+  } | null> {
+    return this.prisma.meeting.findUnique({
+      where: { id: meetingId },
+      select: { id: true, clubId: true, deletedAt: true },
+    });
+  }
+
+  async findDetail(
+    clubId: bigint,
+    meetingId: bigint,
+  ): Promise<MeetingDetailRow | null> {
+    const meeting = await this.prisma.meeting.findFirst({
+      where: { id: meetingId, clubId, deletedAt: null },
+      select: MEETING_DETAIL_SELECT,
+    });
+    return meeting ?? null;
+  }
+
+  async update(
+    meetingId: bigint,
+    data: {
+      name?: string;
+      introText?: string;
+      spot?: string;
+      capacity?: number;
+      cost?: string | null;
+      joinPolicy?: MeetingJoinPolicy;
+      recurrenceType?: RecurrenceType;
+      daysOfWeek?: DayOfWeek[];
+      dayOfMonth?: number | null;
+      hour?: number;
+      minute?: number;
+    },
+  ): Promise<MeetingDetailRow> {
+    return this.prisma.meeting.update({
+      where: { id: meetingId },
+      data,
+      select: MEETING_DETAIL_SELECT,
+    });
+  }
+
+  async countAttendees(meetingId: bigint): Promise<number> {
+    return this.prisma.meetingMember.count({
+      where: { meetingId, deletedAt: null },
+    });
+  }
+
+  async findAttendeesPreview(
+    meetingId: bigint,
+    limit: number,
+  ): Promise<AttendeePreviewRow[]> {
+    const rows = await this.prisma.meetingMember.findMany({
+      where: { meetingId, deletedAt: null },
+      take: limit,
+      orderBy: { joinedAt: 'asc' },
+      select: {
+        clubUser: {
+          select: {
+            user: {
+              select: { id: true, nickname: true, profileImageUrl: true },
+            },
+          },
+        },
+      },
+    });
+    return rows.map((r) => ({
+      userId: r.clubUser.user.id,
+      nickname: r.clubUser.user.nickname,
+      profileImageUrl: r.clubUser.user.profileImageUrl,
+    }));
+  }
+
+  async isAttending(meetingId: bigint, clubUserId: bigint): Promise<boolean> {
+    const count = await this.prisma.meetingMember.count({
+      where: { meetingId, clubUserId, deletedAt: null },
+    });
+    return count > 0;
+  }
+
+  async softDeleteWithMembers(
+    clubId: bigint,
+    meetingId: bigint,
+    deletedAt: Date,
+  ): Promise<boolean> {
+    return this.prisma.$transaction(async (tx) => {
+      const result = await tx.meeting.updateMany({
+        where: { id: meetingId, clubId, deletedAt: null },
+        data: { deletedAt },
+      });
+
+      if (result.count === 0) {
+        return false;
+      }
+
+      await tx.meetingMember.updateMany({
+        where: { meetingId, deletedAt: null },
+        data: { deletedAt },
+      });
+
+      return true;
+    });
   }
 }

--- a/src/modules/club/services/meeting/meeting.service.spec.ts
+++ b/src/modules/club/services/meeting/meeting.service.spec.ts
@@ -1,38 +1,100 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { MeetingJoinPolicy } from '@prisma/client';
+import { DayOfWeek, MeetingJoinPolicy, RecurrenceType } from '@prisma/client';
 import { MeetingService } from './meeting.service';
 import { ClubRepository } from '../../repositories/club.repository';
-import { MeetingRepository } from '../../repositories/meeting.repository';
+import {
+  MeetingDetailRow,
+  MeetingRepository,
+} from '../../repositories/meeting.repository';
 import { AppException } from '../../../../common/errors/app.exception';
-import { CreateMeetingRequestDto } from '../../dtos/meeting.dto';
+import {
+  CreateMeetingRequestDto,
+  UpdateMeetingRequestDto,
+} from '../../dtos/meeting.dto';
 
 describe('MeetingService', () => {
   let service: MeetingService;
   const findById = jest.fn();
+  const findActiveClubUser = jest.fn();
   const create = jest.fn();
+  const findDetail = jest.fn();
+  const update = jest.fn();
+  const countAttendees = jest.fn();
+  const findAttendeesPreview = jest.fn();
+  const isAttending = jest.fn();
+  const softDeleteWithMembers = jest.fn();
 
   const validDto: CreateMeetingRequestDto = {
     name: '매주하는 새벽등산',
     introText: '함께 새벽 산행할 분들 모집',
-    date: '매주 목요일 저녁 19시',
     spot: '종로역 1번 출구 앞',
     capacity: 15,
     cost: '1인 10000원',
     joinPolicy: MeetingJoinPolicy.AUTO,
+    recurrence: {
+      type: RecurrenceType.WEEKLY,
+      daysOfWeek: [DayOfWeek.THU],
+      hour: 19,
+      minute: 0,
+    },
   };
 
   const hostUserId = 100n;
   const clubId = 7n;
+  const meetingId = 88n;
+
+  const baseMeetingRow: MeetingDetailRow = {
+    id: meetingId,
+    clubId,
+    name: validDto.name,
+    introText: validDto.introText,
+    spot: validDto.spot,
+    capacity: validDto.capacity,
+    cost: validDto.cost ?? null,
+    joinPolicy: validDto.joinPolicy,
+    isRegular: true,
+    recurrenceType: RecurrenceType.WEEKLY,
+    daysOfWeek: [DayOfWeek.THU],
+    dayOfMonth: null,
+    hour: 19,
+    minute: 0,
+    createdAt: new Date('2026-05-17T01:00:00.000Z'),
+    updatedAt: null,
+    deletedAt: null,
+  };
 
   beforeEach(async () => {
-    findById.mockReset();
-    create.mockReset();
+    [
+      findById,
+      findActiveClubUser,
+      create,
+      findDetail,
+      update,
+      countAttendees,
+      findAttendeesPreview,
+      isAttending,
+      softDeleteWithMembers,
+    ].forEach((fn) => fn.mockReset());
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         MeetingService,
-        { provide: ClubRepository, useValue: { findById } },
-        { provide: MeetingRepository, useValue: { create } },
+        {
+          provide: ClubRepository,
+          useValue: { findById, findActiveClubUser },
+        },
+        {
+          provide: MeetingRepository,
+          useValue: {
+            create,
+            findDetail,
+            update,
+            countAttendees,
+            findAttendeesPreview,
+            isAttending,
+            softDeleteWithMembers,
+          },
+        },
       ],
     }).compile();
 
@@ -43,87 +105,266 @@ describe('MeetingService', () => {
     expect(service).toBeDefined();
   });
 
-  it('호스트가 만들면 정모가 생성된다', async () => {
-    findById.mockResolvedValue({
-      id: clubId,
-      hostId: hostUserId,
-      deletedAt: null,
-    });
-    create.mockResolvedValue({
-      id: 1n,
-      clubId,
-      name: validDto.name,
-      introText: validDto.introText,
-      date: validDto.date,
-      spot: validDto.spot,
-      capacity: validDto.capacity,
-      cost: validDto.cost ?? null,
-      joinPolicy: validDto.joinPolicy,
-      isRegular: true,
-      createdAt: new Date('2026-05-17T12:00:00.000Z'),
-      deletedAt: null,
-      updatedAt: null,
+  describe('createMeeting', () => {
+    it('호스트가 만들면 정모가 생성된다', async () => {
+      findById.mockResolvedValue({
+        id: clubId,
+        hostId: hostUserId,
+        deletedAt: null,
+      });
+      create.mockResolvedValue(baseMeetingRow);
+
+      const result = await service.createMeeting(hostUserId, clubId, validDto);
+
+      expect(result.meetingId).toBe(Number(meetingId));
+      expect(result.clubId).toBe(Number(clubId));
+      expect(result.attendeeCount).toBe(0);
+      expect(result.dateLabel).toBe('매주 목요일 오후 7시');
+      expect(result.recurrence.type).toBe(RecurrenceType.WEEKLY);
+      expect(result.recurrence.daysOfWeek).toEqual([DayOfWeek.THU]);
+      expect(create).toHaveBeenCalledTimes(1);
     });
 
-    const result = await service.createMeeting(hostUserId, clubId, validDto);
+    it('호스트가 아니면 CLUB_FORBIDDEN_NOT_HOST', async () => {
+      findById.mockResolvedValue({
+        id: clubId,
+        hostId: 999n,
+        deletedAt: null,
+      });
 
-    expect(result.meetingId).toBe(1);
-    expect(result.clubId).toBe(Number(clubId));
-    expect(result.attendeeCount).toBe(0);
-    expect(create).toHaveBeenCalledTimes(1);
-  });
-
-  it('호스트가 아니면 CLUB_FORBIDDEN_NOT_HOST', async () => {
-    findById.mockResolvedValue({
-      id: clubId,
-      hostId: 999n,
-      deletedAt: null,
+      await expect(
+        service.createMeeting(hostUserId, clubId, validDto),
+      ).rejects.toMatchObject({
+        internalCode: 'CLUB_FORBIDDEN_NOT_HOST',
+      } satisfies Partial<AppException>);
+      expect(create).not.toHaveBeenCalled();
     });
 
-    await expect(
-      service.createMeeting(hostUserId, clubId, validDto),
-    ).rejects.toMatchObject({
-      internalCode: 'CLUB_FORBIDDEN_NOT_HOST',
-    } satisfies Partial<AppException>);
-    expect(create).not.toHaveBeenCalled();
-  });
-
-  it('클럽이 없으면 CLUB_NOT_FOUND', async () => {
-    findById.mockResolvedValue(null);
-
-    await expect(
-      service.createMeeting(hostUserId, clubId, validDto),
-    ).rejects.toMatchObject({
-      internalCode: 'CLUB_NOT_FOUND',
-    });
-  });
-
-  it('soft-deleted 클럽이면 CLUB_NOT_FOUND', async () => {
-    findById.mockResolvedValue({
-      id: clubId,
-      hostId: hostUserId,
-      deletedAt: new Date(),
+    it('클럽이 없으면 CLUB_NOT_FOUND', async () => {
+      findById.mockResolvedValue(null);
+      await expect(
+        service.createMeeting(hostUserId, clubId, validDto),
+      ).rejects.toMatchObject({ internalCode: 'CLUB_NOT_FOUND' });
     });
 
-    await expect(
-      service.createMeeting(hostUserId, clubId, validDto),
-    ).rejects.toMatchObject({
-      internalCode: 'CLUB_NOT_FOUND',
+    it('soft-deleted 클럽이면 CLUB_NOT_FOUND', async () => {
+      findById.mockResolvedValue({
+        id: clubId,
+        hostId: hostUserId,
+        deletedAt: new Date(),
+      });
+      await expect(
+        service.createMeeting(hostUserId, clubId, validDto),
+      ).rejects.toMatchObject({ internalCode: 'CLUB_NOT_FOUND' });
     });
   });
 
-  it('capacity가 0 이하면 MEETING_VALIDATION_FAILED', async () => {
-    findById.mockResolvedValue({
-      id: clubId,
-      hostId: hostUserId,
-      deletedAt: null,
+  describe('getMeetingDetail', () => {
+    beforeEach(() => {
+      findById.mockResolvedValue({
+        id: clubId,
+        hostId: hostUserId,
+        deletedAt: null,
+      });
+      findActiveClubUser.mockResolvedValue({ id: 555n });
+      findDetail.mockResolvedValue(baseMeetingRow);
+      countAttendees.mockResolvedValue(4);
+      findAttendeesPreview.mockResolvedValue([
+        { userId: 42n, nickname: '루씨', profileImageUrl: 'u1' },
+        { userId: 88n, nickname: '성현', profileImageUrl: 'u2' },
+      ]);
+      isAttending.mockResolvedValue(true);
     });
 
-    await expect(
-      service.createMeeting(hostUserId, clubId, { ...validDto, capacity: 0 }),
-    ).rejects.toMatchObject({
-      internalCode: 'MEETING_VALIDATION_FAILED',
+    it('가입자가 호출하면 상세를 돌려준다', async () => {
+      const result = await service.getMeetingDetail(
+        hostUserId,
+        clubId,
+        meetingId,
+      );
+
+      expect(result.attendeeCount).toBe(4);
+      expect(result.isAttending).toBe(true);
+      expect(result.attendeesPreview).toHaveLength(2);
+      expect(result.attendeesPreview[0]).toEqual({
+        userId: 42,
+        nickname: '루씨',
+        profileImageUrl: 'u1',
+      });
+      expect(result.dateLabel).toBe('매주 목요일 오후 7시');
+      expect(result.nextOccurrenceAt).toMatch(/T19:00:00\+09:00$/);
+      expect(result.createdAt).toMatch(/\+09:00$/);
     });
-    expect(create).not.toHaveBeenCalled();
+
+    it('클럽이 없으면 CLUB_NOT_FOUND', async () => {
+      findById.mockResolvedValue(null);
+      await expect(
+        service.getMeetingDetail(hostUserId, clubId, meetingId),
+      ).rejects.toMatchObject({ internalCode: 'CLUB_NOT_FOUND' });
+    });
+
+    it('가입자가 아니면 CLUB_FORBIDDEN_NOT_MEMBER', async () => {
+      findActiveClubUser.mockResolvedValue(null);
+      await expect(
+        service.getMeetingDetail(hostUserId, clubId, meetingId),
+      ).rejects.toMatchObject({
+        internalCode: 'CLUB_FORBIDDEN_NOT_MEMBER',
+      });
+      expect(findDetail).not.toHaveBeenCalled();
+    });
+
+    it('정모가 없으면 MEETING_NOT_FOUND', async () => {
+      findDetail.mockResolvedValue(null);
+      await expect(
+        service.getMeetingDetail(hostUserId, clubId, meetingId),
+      ).rejects.toMatchObject({ internalCode: 'MEETING_NOT_FOUND' });
+    });
+  });
+
+  describe('updateMeeting', () => {
+    beforeEach(() => {
+      findById.mockResolvedValue({
+        id: clubId,
+        hostId: hostUserId,
+        deletedAt: null,
+      });
+      findDetail.mockResolvedValue(baseMeetingRow);
+      countAttendees.mockResolvedValue(4);
+      findAttendeesPreview.mockResolvedValue([]);
+      findActiveClubUser.mockResolvedValue({ id: 555n });
+      isAttending.mockResolvedValue(false);
+    });
+
+    it('호스트가 recurrence를 변경하면 dateLabel이 갱신된다', async () => {
+      const dto: UpdateMeetingRequestDto = {
+        recurrence: {
+          type: RecurrenceType.DAILY,
+          hour: 7,
+          minute: 0,
+        },
+      };
+      update.mockResolvedValue({
+        ...baseMeetingRow,
+        recurrenceType: RecurrenceType.DAILY,
+        daysOfWeek: [],
+        dayOfMonth: null,
+        hour: 7,
+        minute: 0,
+        updatedAt: new Date(),
+      });
+
+      const result = await service.updateMeeting(
+        hostUserId,
+        clubId,
+        meetingId,
+        dto,
+      );
+
+      expect(update).toHaveBeenCalledWith(
+        meetingId,
+        expect.objectContaining({
+          recurrenceType: RecurrenceType.DAILY,
+          daysOfWeek: [],
+          dayOfMonth: null,
+          hour: 7,
+          minute: 0,
+        }),
+      );
+      expect(result.dateLabel).toBe('매일 오전 7시');
+      expect(result.recurrence.daysOfWeek).toBeNull();
+    });
+
+    it('capacity가 현재 참석자 수보다 작으면 MEETING_CAPACITY_BELOW_ATTENDEES', async () => {
+      countAttendees.mockResolvedValue(4);
+      await expect(
+        service.updateMeeting(hostUserId, clubId, meetingId, { capacity: 3 }),
+      ).rejects.toMatchObject({
+        internalCode: 'MEETING_CAPACITY_BELOW_ATTENDEES',
+      });
+      expect(update).not.toHaveBeenCalled();
+    });
+
+    it('호스트가 아니면 CLUB_FORBIDDEN_NOT_HOST', async () => {
+      findById.mockResolvedValue({
+        id: clubId,
+        hostId: 999n,
+        deletedAt: null,
+      });
+      await expect(
+        service.updateMeeting(hostUserId, clubId, meetingId, { capacity: 10 }),
+      ).rejects.toMatchObject({ internalCode: 'CLUB_FORBIDDEN_NOT_HOST' });
+    });
+
+    it('정모가 없으면 MEETING_NOT_FOUND', async () => {
+      findDetail.mockResolvedValue(null);
+      await expect(
+        service.updateMeeting(hostUserId, clubId, meetingId, { capacity: 10 }),
+      ).rejects.toMatchObject({ internalCode: 'MEETING_NOT_FOUND' });
+    });
+  });
+
+  describe('deleteMeeting', () => {
+    it('호스트가 정모를 삭제하면 Meeting + MeetingMember가 soft delete된다', async () => {
+      findById.mockResolvedValue({
+        id: clubId,
+        hostId: hostUserId,
+        deletedAt: null,
+      });
+      softDeleteWithMembers.mockResolvedValue(true);
+
+      const result = await service.deleteMeeting(hostUserId, clubId, meetingId);
+
+      expect(result.meetingId).toBe(Number(meetingId));
+      expect(result.clubId).toBe(Number(clubId));
+      expect(typeof result.deletedAt).toBe('string');
+      expect(softDeleteWithMembers).toHaveBeenCalledWith(
+        clubId,
+        meetingId,
+        expect.any(Date),
+      );
+    });
+
+    it('repository에서 삭제 대상이 갱신되지 않으면 MEETING_NOT_FOUND', async () => {
+      findById.mockResolvedValue({
+        id: clubId,
+        hostId: hostUserId,
+        deletedAt: null,
+      });
+      softDeleteWithMembers.mockResolvedValue(false);
+
+      await expect(
+        service.deleteMeeting(hostUserId, clubId, meetingId),
+      ).rejects.toMatchObject({ internalCode: 'MEETING_NOT_FOUND' });
+    });
+
+    it('호스트가 아니면 CLUB_FORBIDDEN_NOT_HOST', async () => {
+      findById.mockResolvedValue({
+        id: clubId,
+        hostId: 999n,
+        deletedAt: null,
+      });
+      await expect(
+        service.deleteMeeting(hostUserId, clubId, meetingId),
+      ).rejects.toMatchObject({ internalCode: 'CLUB_FORBIDDEN_NOT_HOST' });
+      expect(softDeleteWithMembers).not.toHaveBeenCalled();
+    });
+
+    it('클럽이 없으면 CLUB_NOT_FOUND', async () => {
+      findById.mockResolvedValue(null);
+      await expect(
+        service.deleteMeeting(hostUserId, clubId, meetingId),
+      ).rejects.toMatchObject({ internalCode: 'CLUB_NOT_FOUND' });
+    });
+
+    it('soft-deleted 클럽이면 CLUB_NOT_FOUND', async () => {
+      findById.mockResolvedValue({
+        id: clubId,
+        hostId: hostUserId,
+        deletedAt: new Date(),
+      });
+      await expect(
+        service.deleteMeeting(hostUserId, clubId, meetingId),
+      ).rejects.toMatchObject({ internalCode: 'CLUB_NOT_FOUND' });
+    });
   });
 });

--- a/src/modules/club/services/meeting/meeting.service.ts
+++ b/src/modules/club/services/meeting/meeting.service.ts
@@ -1,12 +1,25 @@
 import { Injectable } from '@nestjs/common';
-import { MeetingJoinPolicy } from '@prisma/client';
 import { AppException } from '../../../../common/errors/app.exception';
+import { toKstIso } from '../../../../common/utils/datetime.util';
 import { ClubRepository } from '../../repositories/club.repository';
-import { MeetingRepository } from '../../repositories/meeting.repository';
+import {
+  AttendeePreviewRow,
+  MeetingDetailRow,
+  MeetingRepository,
+} from '../../repositories/meeting.repository';
 import {
   CreateMeetingRequestDto,
   CreateMeetingResponseDto,
+  DeleteMeetingResponseDto,
+  GetMeetingDetailResponseDto,
+  UpdateMeetingRequestDto,
+  UpdateMeetingResponseDto,
 } from '../../dtos/meeting.dto';
+import {
+  computeNextOccurrenceKst,
+  formatDateLabel,
+  Recurrence,
+} from '../../utils/recurrence.util';
 
 @Injectable()
 export class MeetingService {
@@ -28,52 +41,200 @@ export class MeetingService {
       throw new AppException('CLUB_FORBIDDEN_NOT_HOST');
     }
 
-    this.validateDto(dto);
-
+    const { recurrence } = dto;
     const created = await this.meetingRepository.create({
       clubId,
       name: dto.name,
       introText: dto.introText,
-      date: dto.date,
       spot: dto.spot,
       capacity: dto.capacity,
       cost: dto.cost ?? null,
       joinPolicy: dto.joinPolicy,
+      recurrenceType: recurrence.type,
+      daysOfWeek: recurrence.daysOfWeek ?? [],
+      dayOfMonth: recurrence.dayOfMonth ?? null,
+      hour: recurrence.hour,
+      minute: recurrence.minute,
     });
 
+    return this.buildMeetingDetail(created, 0, [], false);
+  }
+
+  async getMeetingDetail(
+    userId: bigint,
+    clubId: bigint,
+    meetingId: bigint,
+  ): Promise<GetMeetingDetailResponseDto> {
+    const club = await this.clubRepository.findById(clubId);
+    if (!club || club.deletedAt) {
+      throw new AppException('CLUB_NOT_FOUND');
+    }
+
+    const clubUser = await this.clubRepository.findActiveClubUser(
+      userId,
+      clubId,
+    );
+    if (!clubUser) {
+      throw new AppException('CLUB_FORBIDDEN_NOT_MEMBER');
+    }
+
+    const meeting = await this.meetingRepository.findDetail(clubId, meetingId);
+    if (!meeting) {
+      throw new AppException('MEETING_NOT_FOUND');
+    }
+
+    const [attendeeCount, attendeesPreview, isAttending] = await Promise.all([
+      this.meetingRepository.countAttendees(meetingId),
+      this.meetingRepository.findAttendeesPreview(meetingId, 4),
+      this.meetingRepository.isAttending(meetingId, clubUser.id),
+    ]);
+
+    return this.buildMeetingDetail(
+      meeting,
+      attendeeCount,
+      attendeesPreview,
+      isAttending,
+    );
+  }
+
+  async updateMeeting(
+    userId: bigint,
+    clubId: bigint,
+    meetingId: bigint,
+    dto: UpdateMeetingRequestDto,
+  ): Promise<UpdateMeetingResponseDto> {
+    const club = await this.clubRepository.findById(clubId);
+    if (!club || club.deletedAt) {
+      throw new AppException('CLUB_NOT_FOUND');
+    }
+    if (club.hostId !== userId) {
+      throw new AppException('CLUB_FORBIDDEN_NOT_HOST');
+    }
+
+    const existing = await this.meetingRepository.findDetail(clubId, meetingId);
+    if (!existing) {
+      throw new AppException('MEETING_NOT_FOUND');
+    }
+
+    if (dto.capacity !== undefined) {
+      const currentAttendees =
+        await this.meetingRepository.countAttendees(meetingId);
+      if (dto.capacity < currentAttendees) {
+        throw new AppException('MEETING_CAPACITY_BELOW_ATTENDEES');
+      }
+    }
+
+    const { recurrence } = dto;
+
+    const updated = await this.meetingRepository.update(meetingId, {
+      ...(dto.name !== undefined ? { name: dto.name } : {}),
+      ...(dto.introText !== undefined ? { introText: dto.introText } : {}),
+      ...(dto.spot !== undefined ? { spot: dto.spot } : {}),
+      ...(dto.capacity !== undefined ? { capacity: dto.capacity } : {}),
+      ...(dto.cost !== undefined ? { cost: dto.cost ?? null } : {}),
+      ...(dto.joinPolicy !== undefined ? { joinPolicy: dto.joinPolicy } : {}),
+      ...(recurrence
+        ? {
+            recurrenceType: recurrence.type,
+            daysOfWeek: recurrence.daysOfWeek ?? [],
+            dayOfMonth: recurrence.dayOfMonth ?? null,
+            hour: recurrence.hour,
+            minute: recurrence.minute,
+          }
+        : {}),
+    });
+
+    const [attendeeCount, attendeesPreview, clubUser] = await Promise.all([
+      this.meetingRepository.countAttendees(meetingId),
+      this.meetingRepository.findAttendeesPreview(meetingId, 4),
+      this.clubRepository.findActiveClubUser(userId, clubId),
+    ]);
+    const isAttending = clubUser
+      ? await this.meetingRepository.isAttending(meetingId, clubUser.id)
+      : false;
+
+    return this.buildMeetingDetail(
+      updated,
+      attendeeCount,
+      attendeesPreview,
+      isAttending,
+    );
+  }
+
+  async deleteMeeting(
+    userId: bigint,
+    clubId: bigint,
+    meetingId: bigint,
+  ): Promise<DeleteMeetingResponseDto> {
+    const club = await this.clubRepository.findById(clubId);
+    if (!club || club.deletedAt) {
+      throw new AppException('CLUB_NOT_FOUND');
+    }
+    if (club.hostId !== userId) {
+      throw new AppException('CLUB_FORBIDDEN_NOT_HOST');
+    }
+
+    const deletedAt = new Date();
+    const deleted = await this.meetingRepository.softDeleteWithMembers(
+      clubId,
+      meetingId,
+      deletedAt,
+    );
+    if (!deleted) {
+      throw new AppException('MEETING_NOT_FOUND');
+    }
+
     return {
-      meetingId: Number(created.id),
-      clubId: Number(created.clubId),
-      name: created.name,
-      introText: created.introText,
-      date: created.date,
-      spot: created.spot,
-      capacity: created.capacity,
-      cost: created.cost,
-      joinPolicy: created.joinPolicy,
-      isRegular: created.isRegular,
-      attendeeCount: 0,
-      createdAt: created.createdAt.toISOString(),
+      meetingId: Number(meetingId),
+      clubId: Number(clubId),
+      deletedAt: toKstIso(deletedAt),
     };
   }
 
-  private validateDto(dto: CreateMeetingRequestDto): void {
-    const violations: string[] = [];
-    if (!dto.name || dto.name.length > 50) violations.push('name');
-    if (!dto.introText || dto.introText.length > 200)
-      violations.push('introText');
-    if (!dto.date || dto.date.length > 100) violations.push('date');
-    if (!dto.spot) violations.push('spot');
-    if (!Number.isInteger(dto.capacity) || dto.capacity <= 0)
-      violations.push('capacity');
-    if (dto.cost !== undefined && dto.cost.length > 50) violations.push('cost');
-    if (!Object.values(MeetingJoinPolicy).includes(dto.joinPolicy))
-      violations.push('joinPolicy');
+  private buildMeetingDetail(
+    meeting: MeetingDetailRow,
+    attendeeCount: number,
+    attendeesPreview: AttendeePreviewRow[],
+    isAttending: boolean,
+  ): GetMeetingDetailResponseDto {
+    const recurrence: Recurrence = {
+      type: meeting.recurrenceType,
+      daysOfWeek: meeting.daysOfWeek,
+      dayOfMonth: meeting.dayOfMonth,
+      hour: meeting.hour,
+      minute: meeting.minute,
+    };
+    const nextOccurrence = computeNextOccurrenceKst(recurrence, new Date());
 
-    if (violations.length > 0) {
-      throw new AppException('MEETING_VALIDATION_FAILED', {
-        details: { fields: violations },
-      });
-    }
+    return {
+      meetingId: Number(meeting.id),
+      clubId: Number(meeting.clubId),
+      name: meeting.name,
+      introText: meeting.introText,
+      spot: meeting.spot,
+      cost: meeting.cost,
+      capacity: meeting.capacity,
+      attendeeCount,
+      joinPolicy: meeting.joinPolicy,
+      isRegular: meeting.isRegular,
+      isAttending,
+      recurrence: {
+        type: meeting.recurrenceType,
+        daysOfWeek:
+          meeting.recurrenceType === 'WEEKLY' ? meeting.daysOfWeek : null,
+        dayOfMonth: meeting.dayOfMonth,
+        hour: meeting.hour,
+        minute: meeting.minute,
+      },
+      dateLabel: formatDateLabel(recurrence),
+      nextOccurrenceAt: toKstIso(nextOccurrence),
+      attendeesPreview: attendeesPreview.map((a) => ({
+        userId: Number(a.userId),
+        nickname: a.nickname,
+        profileImageUrl: a.profileImageUrl,
+      })),
+      createdAt: toKstIso(meeting.createdAt),
+      updatedAt: meeting.updatedAt ? toKstIso(meeting.updatedAt) : null,
+    };
   }
 }

--- a/src/modules/club/utils/recurrence.util.spec.ts
+++ b/src/modules/club/utils/recurrence.util.spec.ts
@@ -1,0 +1,187 @@
+import { toKstIso } from '../../../common/utils/datetime.util';
+import {
+  computeNextOccurrenceKst,
+  formatDateLabel,
+  Recurrence,
+} from './recurrence.util';
+
+describe('formatDateLabel', () => {
+  it('DAILY: 매일 오후 7시', () => {
+    expect(
+      formatDateLabel({
+        type: 'DAILY',
+        daysOfWeek: [],
+        dayOfMonth: null,
+        hour: 19,
+        minute: 0,
+      }),
+    ).toBe('매일 오후 7시');
+  });
+
+  it('WEEKLY THU 19:00 → "매주 목요일 오후 7시"', () => {
+    expect(
+      formatDateLabel({
+        type: 'WEEKLY',
+        daysOfWeek: ['THU'],
+        dayOfMonth: null,
+        hour: 19,
+        minute: 0,
+      }),
+    ).toBe('매주 목요일 오후 7시');
+  });
+
+  it('WEEKLY MON/WED/FRI 19:30 → "매주 월/수/금요일 오후 7시 30분"', () => {
+    expect(
+      formatDateLabel({
+        type: 'WEEKLY',
+        daysOfWeek: ['WED', 'MON', 'FRI'],
+        dayOfMonth: null,
+        hour: 19,
+        minute: 30,
+      }),
+    ).toBe('매주 월/수/금요일 오후 7시 30분');
+  });
+
+  it('MONTHLY 15 07:00 → "매달 15일 오전 7시"', () => {
+    expect(
+      formatDateLabel({
+        type: 'MONTHLY',
+        daysOfWeek: [],
+        dayOfMonth: 15,
+        hour: 7,
+        minute: 0,
+      }),
+    ).toBe('매달 15일 오전 7시');
+  });
+
+  it('자정 12시 처리', () => {
+    expect(
+      formatDateLabel({
+        type: 'DAILY',
+        daysOfWeek: [],
+        dayOfMonth: null,
+        hour: 0,
+        minute: 0,
+      }),
+    ).toBe('매일 오전 12시');
+    expect(
+      formatDateLabel({
+        type: 'DAILY',
+        daysOfWeek: [],
+        dayOfMonth: null,
+        hour: 12,
+        minute: 0,
+      }),
+    ).toBe('매일 오후 12시');
+  });
+});
+
+describe('computeNextOccurrenceKst', () => {
+  const REC_WEEKLY_THU_19: Recurrence = {
+    type: 'WEEKLY',
+    daysOfWeek: ['THU'],
+    dayOfMonth: null,
+    hour: 19,
+    minute: 0,
+  };
+
+  it('WEEKLY THU 19:00, 월요일에 호출하면 같은주 목요일 19:00 KST', () => {
+    // 2026-12-07 (월) 09:00 KST = 2026-12-07T00:00:00Z
+    const now = new Date('2026-12-07T00:00:00Z');
+    const next = computeNextOccurrenceKst(REC_WEEKLY_THU_19, now);
+    expect(toKstIso(next)).toBe('2026-12-10T19:00:00+09:00');
+  });
+
+  it('WEEKLY THU 19:00, 같은 목요일 18:59에는 오늘 19:00', () => {
+    // 2026-12-10 (목) 18:59 KST = 2026-12-10T09:59:00Z
+    const now = new Date('2026-12-10T09:59:00Z');
+    const next = computeNextOccurrenceKst(REC_WEEKLY_THU_19, now);
+    expect(toKstIso(next)).toBe('2026-12-10T19:00:00+09:00');
+  });
+
+  it('WEEKLY THU 19:00, 같은 목요일 19:00 정각에는 다음주', () => {
+    // 2026-12-10 (목) 19:00 KST = 2026-12-10T10:00:00Z
+    const now = new Date('2026-12-10T10:00:00Z');
+    const next = computeNextOccurrenceKst(REC_WEEKLY_THU_19, now);
+    expect(toKstIso(next)).toBe('2026-12-17T19:00:00+09:00');
+  });
+
+  it('DAILY 19:00, 오늘 19:00 이전이면 오늘', () => {
+    const now = new Date('2026-12-10T09:59:00Z'); // 18:59 KST
+    const next = computeNextOccurrenceKst(
+      {
+        type: 'DAILY',
+        daysOfWeek: [],
+        dayOfMonth: null,
+        hour: 19,
+        minute: 0,
+      },
+      now,
+    );
+    expect(toKstIso(next)).toBe('2026-12-10T19:00:00+09:00');
+  });
+
+  it('DAILY 자정 직후 → 오늘 시각이 이미 지났으면 내일', () => {
+    const now = new Date('2026-12-10T15:01:00Z'); // 00:01 KST 익일
+    const next = computeNextOccurrenceKst(
+      {
+        type: 'DAILY',
+        daysOfWeek: [],
+        dayOfMonth: null,
+        hour: 0,
+        minute: 0,
+      },
+      now,
+    );
+    // KST 2026-12-11 00:01 시점, 오늘 00:00은 이미 지났으니 2026-12-12 00:00
+    expect(toKstIso(next)).toBe('2026-12-12T00:00:00+09:00');
+  });
+
+  it('MONTHLY 31일, 2월에는 말일(28/29)로 폴백', () => {
+    // 2026-01-31 (토) 23:00 KST 이미 19:00 지남 → 다음 발생은 2026-02-28 19:00
+    const now = new Date('2026-01-31T14:00:00Z'); // 23:00 KST
+    const next = computeNextOccurrenceKst(
+      {
+        type: 'MONTHLY',
+        daysOfWeek: [],
+        dayOfMonth: 31,
+        hour: 19,
+        minute: 0,
+      },
+      now,
+    );
+    expect(toKstIso(next)).toBe('2026-02-28T19:00:00+09:00');
+  });
+
+  it('MONTHLY 15일, 이번달 15일 미래면 이번달', () => {
+    // 2026-04-10 KST → 다음은 2026-04-15
+    const now = new Date('2026-04-10T03:00:00Z'); // 12:00 KST
+    const next = computeNextOccurrenceKst(
+      {
+        type: 'MONTHLY',
+        daysOfWeek: [],
+        dayOfMonth: 15,
+        hour: 19,
+        minute: 0,
+      },
+      now,
+    );
+    expect(toKstIso(next)).toBe('2026-04-15T19:00:00+09:00');
+  });
+
+  it('WEEKLY 여러 요일 중 가장 가까운 요일 선택', () => {
+    // 2026-12-10 (목) 20:00 KST → MON/WED/FRI 중 가장 가까운 건 FRI
+    const now = new Date('2026-12-10T11:00:00Z');
+    const next = computeNextOccurrenceKst(
+      {
+        type: 'WEEKLY',
+        daysOfWeek: ['MON', 'WED', 'FRI'],
+        dayOfMonth: null,
+        hour: 19,
+        minute: 0,
+      },
+      now,
+    );
+    expect(toKstIso(next)).toBe('2026-12-11T19:00:00+09:00');
+  });
+});

--- a/src/modules/club/utils/recurrence.util.ts
+++ b/src/modules/club/utils/recurrence.util.ts
@@ -1,0 +1,180 @@
+import { DayOfWeek, RecurrenceType } from '@prisma/client';
+
+const KST_OFFSET_MS = 9 * 60 * 60_000;
+
+const DAY_OF_WEEK_LABEL: Record<DayOfWeek, string> = {
+  MON: '월',
+  TUE: '화',
+  WED: '수',
+  THU: '목',
+  FRI: '금',
+  SAT: '토',
+  SUN: '일',
+};
+
+const DAY_OF_WEEK_ORDER: Record<DayOfWeek, number> = {
+  MON: 1,
+  TUE: 2,
+  WED: 3,
+  THU: 4,
+  FRI: 5,
+  SAT: 6,
+  SUN: 0,
+};
+
+export type Recurrence = {
+  type: RecurrenceType;
+  daysOfWeek: DayOfWeek[];
+  dayOfMonth: number | null;
+  hour: number;
+  minute: number;
+};
+
+function formatTimeOfDay(hour: number, minute: number): string {
+  const meridiem = hour < 12 ? '오전' : '오후';
+  const displayHour = hour % 12 === 0 ? 12 : hour % 12;
+  if (minute === 0) {
+    return `${meridiem} ${displayHour}시`;
+  }
+  return `${meridiem} ${displayHour}시 ${minute}분`;
+}
+
+function sortedDaysOfWeek(days: DayOfWeek[]): DayOfWeek[] {
+  const order: DayOfWeek[] = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'];
+  return [...days].sort((a, b) => order.indexOf(a) - order.indexOf(b));
+}
+
+export function formatDateLabel(rec: Recurrence): string {
+  const time = formatTimeOfDay(rec.hour, rec.minute);
+  switch (rec.type) {
+    case 'DAILY':
+      return `매일 ${time}`;
+    case 'WEEKLY': {
+      const labels = sortedDaysOfWeek(rec.daysOfWeek).map(
+        (d) => DAY_OF_WEEK_LABEL[d],
+      );
+      return `매주 ${labels.join('/')}요일 ${time}`;
+    }
+    case 'MONTHLY':
+      return `매달 ${rec.dayOfMonth}일 ${time}`;
+  }
+}
+
+function toKstParts(date: Date): {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  dayOfWeek: number;
+} {
+  const shifted = new Date(date.getTime() + KST_OFFSET_MS);
+  return {
+    year: shifted.getUTCFullYear(),
+    month: shifted.getUTCMonth(),
+    day: shifted.getUTCDate(),
+    hour: shifted.getUTCHours(),
+    minute: shifted.getUTCMinutes(),
+    dayOfWeek: shifted.getUTCDay(),
+  };
+}
+
+function kstToUtc(
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+): Date {
+  return new Date(Date.UTC(year, month, day, hour, minute) - KST_OFFSET_MS);
+}
+
+function lastDayOfMonth(year: number, month: number): number {
+  return new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+}
+
+function isStrictlyAfter(
+  a: { day: number; hour: number; minute: number },
+  b: { day: number; hour: number; minute: number },
+): boolean {
+  if (a.day !== b.day) return a.day > b.day;
+  if (a.hour !== b.hour) return a.hour > b.hour;
+  return a.minute > b.minute;
+}
+
+export function computeNextOccurrenceKst(rec: Recurrence, now: Date): Date {
+  const k = toKstParts(now);
+
+  if (rec.type === 'DAILY') {
+    const todayCandidate = { day: k.day, hour: rec.hour, minute: rec.minute };
+    const fromNow = { day: k.day, hour: k.hour, minute: k.minute };
+    if (isStrictlyAfter(todayCandidate, fromNow)) {
+      return kstToUtc(k.year, k.month, k.day, rec.hour, rec.minute);
+    }
+    return kstToUtc(k.year, k.month, k.day + 1, rec.hour, rec.minute);
+  }
+
+  if (rec.type === 'WEEKLY') {
+    const targetWeekdays = rec.daysOfWeek.map((d) => DAY_OF_WEEK_ORDER[d]);
+    let bestOffset: number | null = null;
+    for (const target of targetWeekdays) {
+      let offset = (target - k.dayOfWeek + 7) % 7;
+      if (
+        offset === 0 &&
+        !isStrictlyAfter(
+          { day: 0, hour: rec.hour, minute: rec.minute },
+          { day: 0, hour: k.hour, minute: k.minute },
+        )
+      ) {
+        offset = 7;
+      }
+      if (bestOffset === null || offset < bestOffset) {
+        bestOffset = offset;
+      }
+    }
+    return kstToUtc(
+      k.year,
+      k.month,
+      k.day + (bestOffset ?? 0),
+      rec.hour,
+      rec.minute,
+    );
+  }
+
+  // MONTHLY
+  const dayOfMonth = rec.dayOfMonth ?? 1;
+  for (let monthsAhead = 0; monthsAhead < 13; monthsAhead++) {
+    const targetMonth = k.month + monthsAhead;
+    const targetYear = k.year + Math.floor(targetMonth / 12);
+    const normalizedMonth = ((targetMonth % 12) + 12) % 12;
+    const lastDay = lastDayOfMonth(targetYear, normalizedMonth);
+    const effectiveDay = Math.min(dayOfMonth, lastDay);
+    if (monthsAhead === 0) {
+      const candidate = {
+        day: effectiveDay,
+        hour: rec.hour,
+        minute: rec.minute,
+      };
+      const fromNow = { day: k.day, hour: k.hour, minute: k.minute };
+      if (isStrictlyAfter(candidate, fromNow)) {
+        return kstToUtc(
+          targetYear,
+          normalizedMonth,
+          effectiveDay,
+          rec.hour,
+          rec.minute,
+        );
+      }
+      continue;
+    }
+    return kstToUtc(
+      targetYear,
+      normalizedMonth,
+      effectiveDay,
+      rec.hour,
+      rec.minute,
+    );
+  }
+  // 도달 불가 (1년 이내 반드시 다음 발생 존재)
+  return kstToUtc(k.year + 1, k.month, dayOfMonth, rec.hour, rec.minute);
+}


### PR DESCRIPTION
## 이슈 번호
close #182 

 ## 주요 변경사항
  - `POST /api/v1/clubs/:clubId/meetings` 수정
    - 일시 입력을 `date: String`에서 `recurrence: { type, daysOfWeek?, dayOfMonth?, hour, minute }` 객체로 구조화
    - 응답을 상세 조회와 동일한 `MeetingDetailDto` shape로 통일 (recurrence, dateLabel, nextOccurrenceAt, attendeesPreview 포함)
- `GET /api/v1/clubs/:clubId/meetings/:meetingId` 구현 - 클럽 ACTIVE 멤버만.
  - recurrence, dateLabel, nextOccurrenceAt(KST), attendeesPreview(4명), isAttending 포함
- `PATCH /api/v1/clubs/:clubId/meetings/:meetingId` 구현 - 호스트만, 부분 수정. capacity가 현재 참석자보다 작으면 409
- 정모 일시 스키마 구조화: `Meeting.date String` 제거, `RecurrenceType`·`DayOfWeek` enum + `daysOfWeek/dayOfMonth/hour/minute` 컬럼화. 
  - 마이그레이션은 nullable 추가 → 백필 → NOT NULL → 구 컬럼 DROP의 3단계 안전 패턴으로 기존 row 보존
- POST/PATCH 검증 강화: `RecurrenceShapeConstraint`(cross-field 커스텀 ValidatorConstraint)로 type과 안 맞는 부수 필드(WEEKLY+dayOfMonth 등) 422 차단. service의 `normalizeRecurrenceInput` 제거 → 단일 source of truth
- KST 직렬화 공용 util `src/common/utils/datetime.util.ts` (`toKstIso`) 신설. 응답의 createdAt/updatedAt/nextOccurrenceAt 모두 `+09:00`
- 도메인 util `src/modules/club/utils/recurrence.util.ts` 신설 (`formatDateLabel`, `computeNextOccurrenceKst`)
- 에러 코드 2종 추가: `CLUB-003 CLUB_FORBIDDEN_NOT_MEMBER`, `MEETING-003 MEETING_CAPACITY_BELOW_ATTENDEES`
- seed.ts 정모 더미를 DAILY/WEEKLY/MONTHLY 순환으로 다양화 + 누락 NOT NULL 필드(introText, capacity) 채움

## 테스트 결과
**매주 정기모임 생성 성공**
<img width="1370" height="808" alt="image" src="https://github.com/user-attachments/assets/4d8ef8e4-c4a7-4ba0-8fa0-2e05062cdadd" />

**매월 정기모임 생성 성공**
<img width="1376" height="811" alt="image" src="https://github.com/user-attachments/assets/6f57516e-452f-4d77-b830-a58dadc6e62a" />

**매일 정기모임 생성 성공**
<img width="1367" height="810" alt="image" src="https://github.com/user-attachments/assets/c78afe78-736b-4905-bc40-bd3306ad564d" />

**매주 정기모임 생성 실패**
<img width="1396" height="799" alt="image" src="https://github.com/user-attachments/assets/92ace22a-2b10-4084-8da0-3eb756c8dcfb" />

**매월 정기모임 생성 실패**
<img width="1386" height="795" alt="image" src="https://github.com/user-attachments/assets/713dac78-ef30-4399-9baf-702af7f933e0" />

**정기모임 상세 조회 성공**
<img width="1384" height="749" alt="image" src="https://github.com/user-attachments/assets/86cf3294-bc2e-4ef7-b0fe-f277a80883b6" />

**미가입 유저의 정기모임 조회**
<img width="1383" height="810" alt="image" src="https://github.com/user-attachments/assets/044b302f-1839-4afe-86b4-cdfaa0d408a9" />

**존재하지 않는 클럽의 정기모임 조회**
<img width="1378" height="812" alt="image" src="https://github.com/user-attachments/assets/cd011c46-c7b0-420a-abcf-556d5b14e92a" />

**삭제된 정기모임 조회**
<img width="1382" height="813" alt="image" src="https://github.com/user-attachments/assets/84e73259-becb-4193-afe0-5f18b1c98d1f" />

**정기모임 수정 성공**
<img width="1382" height="807" alt="image" src="https://github.com/user-attachments/assets/6b334524-79b8-4d3d-9b2e-5ece6db50e00" />

**정기모임 recurrence 수정 실패**
<img width="1378" height="714" alt="image" src="https://github.com/user-attachments/assets/748be04c-6d39-466d-90d7-67251c6f4572" />

## 참고 및 개선사항
- ECS 롤링 배포 동안 짧은 incompat window: 현재 RDS에 데이터가 존재하는 상태이기 때문에 마이그레이션이 `date` 컬럼을 제거한 직후 새 task가 healthy 되기 전까지(3~7분) 구 task의 정모 생성 INSERT는 500.
  - 스테이징 서버는 테스트용이기 때문에 영향 없을 것으로 추정됩니다
- 로컬에서는 npm run prisma:migrate:deploy -> npx prisma db seed 실행하시면 됩니다
  - 또는 npm run prisma:migrate:reset (DB 초기화 이후 seed 자동 삽입)