### PR TITLE
[EUM-13] feat: 정모 참석/취소/참석자 목록 API 구현

### DIFF
--- a/src/common/errors/error-codes.ts
+++ b/src/common/errors/error-codes.ts
@@ -209,6 +209,26 @@ export const ERROR_DEFINITIONS = {
     code: 'MEETING-003',
     message: '현재 참석자 수보다 수용 인원을 낮출 수 없어요.',
   },
+  MEETING_CAPACITY_EXCEEDED: {
+    status: HttpStatus.CONFLICT,
+    code: 'MEETING-004',
+    message: '참석 인원이 다 찼어요.',
+  },
+  MEETING_ALREADY_JOINED: {
+    status: HttpStatus.CONFLICT,
+    code: 'MEETING-005',
+    message: '이미 참석 중인 정모예요.',
+  },
+  MEETING_NOT_JOINED: {
+    status: HttpStatus.NOT_FOUND,
+    code: 'MEETING-006',
+    message: '참석 중인 정모가 아니에요.',
+  },
+  MEETING_HOST_CANNOT_LEAVE: {
+    status: HttpStatus.FORBIDDEN,
+    code: 'MEETING-007',
+    message: '호스트는 본인 정모 참석을 취소할 수 없어요.',
+  },
 
   // SYSTEM
   SERVER_TEMPORARY_ERROR: {

--- a/src/common/errors/error-codes.ts
+++ b/src/common/errors/error-codes.ts
@@ -229,6 +229,11 @@ export const ERROR_DEFINITIONS = {
     code: 'MEETING-007',
     message: '호스트는 본인 정모 참석을 취소할 수 없어요.',
   },
+  MEETING_APPROVAL_NOT_SUPPORTED: {
+    status: HttpStatus.NOT_IMPLEMENTED,
+    code: 'MEETING-008',
+    message: '승인 정모는 곧 지원될 예정이에요.',
+  },
 
   // SYSTEM
   SERVER_TEMPORARY_ERROR: {

--- a/src/common/utils/cursor.util.ts
+++ b/src/common/utils/cursor.util.ts
@@ -1,0 +1,35 @@
+import { AppException } from '../errors/app.exception';
+
+function b64urlEncode(input: string): string {
+  return Buffer.from(input, 'utf8')
+    .toString('base64')
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replaceAll('=', '');
+}
+
+function b64urlDecode(input: string): string {
+  const padLen = (4 - (input.length % 4)) % 4;
+  const padded = input + '='.repeat(padLen);
+  const base64 = padded.replaceAll('-', '+').replaceAll('_', '/');
+  return Buffer.from(base64, 'base64').toString('utf8');
+}
+
+export function encodeCursor<T extends object>(payload: T): string {
+  return b64urlEncode(JSON.stringify(payload));
+}
+
+export function decodeCursorRaw(cursor: string): Record<string, unknown> {
+  try {
+    const json = b64urlDecode(cursor);
+    const parsed = JSON.parse(json) as unknown;
+    if (typeof parsed !== 'object' || parsed === null) {
+      throw new Error('cursor payload is not an object');
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    throw new AppException('VALIDATION_INVALID_FORMAT', {
+      message: 'cursor 형식이 올바르지 않습니다.',
+    });
+  }
+}

--- a/src/modules/chat/services/message/message.service.ts
+++ b/src/modules/chat/services/message/message.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 import { AppException } from '../../../../common/errors/app.exception';
-import { decodeCursor, encodeCursor } from '../../utils/cursor.util';
+import { decodeMessageCursor, encodeCursor } from '../../utils/cursor.util';
 import { ChatGateway } from '../../gateways/chat.gateway';
 import { ChatMediaService } from '../chat-media/chat-media.service';
 
@@ -73,10 +73,9 @@ export class MessageService {
       null;
 
     const size = query.size ?? 30;
-    const cursor = query.cursor ? decodeCursor(query.cursor) : null;
+    const cursor = query.cursor ? decodeMessageCursor(query.cursor) : null;
     const cursorSentAt = cursor ? new Date(cursor.sortAt) : null;
-    const cursorMessageId =
-      cursor && 'messageId' in cursor ? BigInt(cursor.messageId) : null;
+    const cursorMessageId = cursor ? BigInt(cursor.messageId) : null;
 
     const messages = await this.messageRepo.findMessagesByRoomId(
       roomId,

--- a/src/modules/chat/services/room/room.service.ts
+++ b/src/modules/chat/services/room/room.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 import { AppException } from '../../../../common/errors/app.exception';
-import { decodeCursor, encodeCursor } from '../../utils/cursor.util';
+import { decodeRoomCursor, encodeCursor } from '../../utils/cursor.util';
 import { buildMessagePreview } from '../../utils/message-preview.util';
 
 import type {
@@ -163,10 +163,9 @@ export class RoomService {
     const me = BigInt(meUserId);
     const size = query.size ?? 20;
 
-    const cursor = query.cursor ? decodeCursor(query.cursor) : null;
+    const cursor = query.cursor ? decodeRoomCursor(query.cursor) : null;
     const cursorSortAt = cursor ? new Date(cursor.sortAt) : null;
-    const cursorRoomId =
-      cursor && 'roomId' in cursor ? BigInt(cursor.roomId) : null;
+    const cursorRoomId = cursor ? BigInt(cursor.roomId) : null;
 
     const myRoomIds = await this.participantRepo.getMyRoomIds(me);
     if (myRoomIds.length === 0) return { nextCursor: null, items: [] };

--- a/src/modules/chat/utils/cursor.util.ts
+++ b/src/modules/chat/utils/cursor.util.ts
@@ -1,4 +1,7 @@
 import { AppException } from '../../../common/errors/app.exception';
+import { decodeCursorRaw } from '../../../common/utils/cursor.util';
+
+export { encodeCursor } from '../../../common/utils/cursor.util';
 
 export type MessageCursorPayload = {
   sortAt: string;
@@ -10,51 +13,25 @@ export type RoomCursorPayload = {
   roomId: string;
 };
 
-function b64urlEncode(input: string): string {
-  return Buffer.from(input, 'utf8')
-    .toString('base64')
-    .replaceAll('+', '-')
-    .replaceAll('/', '_')
-    .replaceAll('=', '');
-}
-
-function b64urlDecode(input: string): string {
-  const padLen = (4 - (input.length % 4)) % 4;
-  const padded = input + '='.repeat(padLen);
-  const base64 = padded.replaceAll('-', '+').replaceAll('_', '/');
-  return Buffer.from(base64, 'base64').toString('utf8');
-}
-
-export function encodeCursor(
-  payload: MessageCursorPayload | RoomCursorPayload,
-): string {
-  return b64urlEncode(JSON.stringify(payload));
-}
-
-export function decodeCursor(
-  cursor: string,
-): MessageCursorPayload | RoomCursorPayload {
-  try {
-    const json = b64urlDecode(cursor);
-    const parsed = JSON.parse(json) as Record<string, unknown>;
-
-    if (!parsed.sortAt || typeof parsed.sortAt !== 'string') {
-      throw new Error('invalid cursor: missing or invalid sortAt');
-    }
-
-    // messageId가 있으면 MessageCursorPayload, roomId가 있으면 RoomCursorPayload
-    if (parsed.messageId && typeof parsed.messageId === 'string') {
-      return { sortAt: parsed.sortAt, messageId: parsed.messageId };
-    }
-
-    if (parsed.roomId && typeof parsed.roomId === 'string') {
-      return { sortAt: parsed.sortAt, roomId: parsed.roomId };
-    }
-
-    throw new Error('invalid cursor: missing both messageId and roomId');
-  } catch {
-    throw new AppException('VALIDATION_INVALID_FORMAT', {
-      message: 'cursor 형식이 올바르지 않습니다.',
-    });
+export function decodeMessageCursor(cursor: string): MessageCursorPayload {
+  const parsed = decodeCursorRaw(cursor);
+  if (
+    typeof parsed.sortAt === 'string' &&
+    typeof parsed.messageId === 'string'
+  ) {
+    return { sortAt: parsed.sortAt, messageId: parsed.messageId };
   }
+  throw new AppException('VALIDATION_INVALID_FORMAT', {
+    message: 'cursor 형식이 올바르지 않습니다.',
+  });
+}
+
+export function decodeRoomCursor(cursor: string): RoomCursorPayload {
+  const parsed = decodeCursorRaw(cursor);
+  if (typeof parsed.sortAt === 'string' && typeof parsed.roomId === 'string') {
+    return { sortAt: parsed.sortAt, roomId: parsed.roomId };
+  }
+  throw new AppException('VALIDATION_INVALID_FORMAT', {
+    message: 'cursor 형식이 올바르지 않습니다.',
+  });
 }

--- a/src/modules/club/controllers/meeting/meeting.controller.ts
+++ b/src/modules/club/controllers/meeting/meeting.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   Patch,
   Post,
+  Query,
   UseGuards,
 } from '@nestjs/common';
 import {
@@ -17,6 +18,7 @@ import {
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
+  ApiQuery,
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
@@ -29,6 +31,10 @@ import {
   CreateMeetingResponseDto,
   DeleteMeetingResponseDto,
   GetMeetingDetailResponseDto,
+  JoinMeetingResponseDto,
+  LeaveMeetingResponseDto,
+  ListAttendeesQueryDto,
+  ListAttendeesResponseDto,
   UpdateMeetingRequestDto,
   UpdateMeetingResponseDto,
 } from '../../dtos/meeting.dto';
@@ -122,6 +128,72 @@ export class MeetingController {
       BigInt(userId),
       BigInt(clubId),
       BigInt(meetingId),
+    );
+  }
+
+  @Post(':meetingId/attendees/me')
+  @ApiOperation({ summary: '정모 참석 (클럽 멤버만, AUTO 정책)' })
+  @ApiCreatedResponse({
+    description: '정모 참석 완료',
+    type: JoinMeetingResponseDto,
+  })
+  @ApiNotFoundResponse({ description: '클럽 또는 정모를 찾을 수 없음' })
+  @ApiConflictResponse({ description: '이미 참석 중이거나 정원이 가득 참' })
+  async joinMeeting(
+    @RequiredUserId() userId: number,
+    @Param('clubId', new ParsePositiveIntPipe()) clubId: number,
+    @Param('meetingId', new ParsePositiveIntPipe()) meetingId: number,
+  ): Promise<JoinMeetingResponseDto> {
+    return this.meetingService.joinMeeting(
+      BigInt(userId),
+      BigInt(clubId),
+      BigInt(meetingId),
+    );
+  }
+
+  @Delete(':meetingId/attendees/me')
+  @ApiOperation({ summary: '정모 참석 취소 (본인, 호스트 불가)' })
+  @ApiOkResponse({
+    description: '정모 참석 취소 완료',
+    type: LeaveMeetingResponseDto,
+  })
+  @ApiNotFoundResponse({
+    description: '클럽/정모 없음 또는 참석 중인 정모가 아님',
+  })
+  async leaveMeeting(
+    @RequiredUserId() userId: number,
+    @Param('clubId', new ParsePositiveIntPipe()) clubId: number,
+    @Param('meetingId', new ParsePositiveIntPipe()) meetingId: number,
+  ): Promise<LeaveMeetingResponseDto> {
+    return this.meetingService.leaveMeeting(
+      BigInt(userId),
+      BigInt(clubId),
+      BigInt(meetingId),
+    );
+  }
+
+  @Get(':meetingId/attendees')
+  @ApiOperation({
+    summary: '정모 참석자 목록 (클럽 멤버만, cursor pagination)',
+  })
+  @ApiQuery({ name: 'cursor', required: false })
+  @ApiQuery({ name: 'size', required: false, example: 30 })
+  @ApiOkResponse({
+    description: '참석자 목록 조회 성공',
+    type: ListAttendeesResponseDto,
+  })
+  @ApiNotFoundResponse({ description: '클럽 또는 정모를 찾을 수 없음' })
+  async listAttendees(
+    @RequiredUserId() userId: number,
+    @Param('clubId', new ParsePositiveIntPipe()) clubId: number,
+    @Param('meetingId', new ParsePositiveIntPipe()) meetingId: number,
+    @Query() query: ListAttendeesQueryDto,
+  ): Promise<ListAttendeesResponseDto> {
+    return this.meetingService.listAttendees(
+      BigInt(userId),
+      BigInt(clubId),
+      BigInt(meetingId),
+      query,
     );
   }
 }

--- a/src/modules/club/controllers/meeting/meeting.controller.ts
+++ b/src/modules/club/controllers/meeting/meeting.controller.ts
@@ -19,6 +19,7 @@ import {
   ApiOkResponse,
   ApiOperation,
   ApiQuery,
+  ApiResponse,
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
@@ -139,6 +140,7 @@ export class MeetingController {
   })
   @ApiNotFoundResponse({ description: '클럽 또는 정모를 찾을 수 없음' })
   @ApiConflictResponse({ description: '이미 참석 중이거나 정원이 가득 참' })
+  @ApiResponse({ status: 501, description: '승인 정모는 아직 미지원' })
   async joinMeeting(
     @RequiredUserId() userId: number,
     @Param('clubId', new ParsePositiveIntPipe()) clubId: number,

--- a/src/modules/club/dtos/meeting.dto.spec.ts
+++ b/src/modules/club/dtos/meeting.dto.spec.ts
@@ -78,11 +78,33 @@ describe('RecurrenceShapeConstraint', () => {
     ).toBe(false);
   });
 
-  it('빈 daysOfWeek 배열은 부수 필드로 간주하지 않음', () => {
+  it('DAILY + 빈 daysOfWeek 배열 → 거절 (존재 여부 기준)', () => {
     expect(
       c.validate({
         type: RecurrenceType.DAILY,
         daysOfWeek: [],
+        hour: 7,
+        minute: 0,
+      }),
+    ).toBe(false);
+  });
+
+  it('DAILY + scalar daysOfWeek(예: "MON") → 거절', () => {
+    expect(
+      c.validate({
+        type: RecurrenceType.DAILY,
+        daysOfWeek: 'MON' as unknown as DayOfWeek[],
+        hour: 7,
+        minute: 0,
+      }),
+    ).toBe(false);
+  });
+
+  it('DAILY + daysOfWeek=null → 통과 (null=명시적 부재)', () => {
+    expect(
+      c.validate({
+        type: RecurrenceType.DAILY,
+        daysOfWeek: null as unknown as DayOfWeek[],
         hour: 7,
         minute: 0,
       }),

--- a/src/modules/club/dtos/meeting.dto.ts
+++ b/src/modules/club/dtos/meeting.dto.ts
@@ -33,7 +33,7 @@ export class RecurrenceShapeConstraint implements ValidatorConstraintInterface {
     if (!value || typeof value !== 'object') return true;
     const r = value as RecurrenceInputDto;
 
-    const hasWeekDays = Array.isArray(r.daysOfWeek) && r.daysOfWeek.length > 0;
+    const hasWeekDays = r.daysOfWeek !== undefined && r.daysOfWeek !== null;
     const hasMonthDay = r.dayOfMonth !== undefined && r.dayOfMonth !== null;
 
     if (r.type !== RecurrenceType.WEEKLY && hasWeekDays) return false;
@@ -45,8 +45,8 @@ export class RecurrenceShapeConstraint implements ValidatorConstraintInterface {
     const r = args.value as RecurrenceInputDto | undefined;
     if (
       r?.type !== RecurrenceType.WEEKLY &&
-      Array.isArray(r?.daysOfWeek) &&
-      r.daysOfWeek.length > 0
+      r?.daysOfWeek !== undefined &&
+      r?.daysOfWeek !== null
     ) {
       return 'daysOfWeek는 type=WEEKLY일 때만 허용됩니다.';
     }

--- a/src/modules/club/dtos/meeting.dto.ts
+++ b/src/modules/club/dtos/meeting.dto.ts
@@ -1,4 +1,9 @@
-import { DayOfWeek, MeetingJoinPolicy, RecurrenceType } from '@prisma/client';
+import {
+  ClubAuthority,
+  DayOfWeek,
+  MeetingJoinPolicy,
+  RecurrenceType,
+} from '@prisma/client';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import {
@@ -296,4 +301,96 @@ export class DeleteMeetingResponseDto {
 
   @ApiProperty({ example: '2026-05-31T12:00:00+09:00' })
   deletedAt!: string;
+}
+
+export class JoinMeetingResponseDto {
+  @ApiProperty({ example: 5001 })
+  meetingMemberId!: number;
+
+  @ApiProperty({ example: 88 })
+  meetingId!: number;
+
+  @ApiProperty({ example: 333 })
+  clubUserId!: number;
+
+  @ApiProperty({ example: 42 })
+  userId!: number;
+
+  @ApiProperty({ example: '2026-05-01T20:05:00+09:00' })
+  joinedAt!: string;
+}
+
+export class LeaveMeetingResponseDto {
+  @ApiProperty({ example: 88 })
+  meetingId!: number;
+
+  @ApiProperty({ example: 42 })
+  userId!: number;
+
+  @ApiProperty({ example: '2026-05-01T20:10:00+09:00' })
+  canceledAt!: string;
+}
+
+export class ListAttendeesQueryDto {
+  @ApiPropertyOptional({ description: 'opaque cursor (base64url)' })
+  @IsOptional()
+  @IsString()
+  cursor?: string;
+
+  @ApiPropertyOptional({ example: 30, minimum: 1, maximum: 100, default: 30 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  size?: number;
+}
+
+export class AttendeeUserDto {
+  @ApiProperty({ example: 42 })
+  userId!: number;
+
+  @ApiProperty({ example: '달콤한목소리' })
+  nickname!: string;
+
+  @ApiProperty({ example: 'https://cdn.example.com/profile/42.jpg' })
+  profileImageUrl!: string;
+
+  @ApiProperty({ enum: ClubAuthority, example: ClubAuthority.GENERAL })
+  authority!: ClubAuthority;
+}
+
+export class AttendeeItemDto {
+  @ApiProperty({ example: 5001 })
+  meetingMemberId!: number;
+
+  @ApiProperty({ example: 333 })
+  clubUserId!: number;
+
+  @ApiProperty({ type: AttendeeUserDto })
+  user!: AttendeeUserDto;
+
+  @ApiProperty({ example: '2026-05-01T20:05:00+09:00' })
+  joinedAt!: string;
+}
+
+export class ListAttendeesResponseDto {
+  @ApiProperty({ example: 88 })
+  meetingId!: number;
+
+  @ApiProperty({ example: 14 })
+  attendeeCount!: number;
+
+  @ApiProperty({ type: [AttendeeItemDto] })
+  attendees!: AttendeeItemDto[];
+
+  @ApiProperty({
+    example:
+      'eyJqb2luZWRBdCI6IjIwMjYtMDUtMDFUMjA6MDc6MDArMDk6MDAiLCJpZCI6IjUwMDIifQ',
+    nullable: true,
+  })
+  nextCursor!: string | null;
+
+  @ApiProperty({ example: true })
+  hasMore!: boolean;
 }

--- a/src/modules/club/repositories/meeting.repository.ts
+++ b/src/modules/club/repositories/meeting.repository.ts
@@ -1,5 +1,10 @@
 import { Injectable } from '@nestjs/common';
-import { DayOfWeek, MeetingJoinPolicy, RecurrenceType } from '@prisma/client';
+import {
+  ClubAuthority,
+  DayOfWeek,
+  MeetingJoinPolicy,
+  RecurrenceType,
+} from '@prisma/client';
 import { PrismaService } from '../../../infra/prisma/prisma.service';
 
 export type MeetingDetailRow = {
@@ -28,6 +33,24 @@ export type AttendeePreviewRow = {
   profileImageUrl: string;
 };
 
+export type MeetingMemberRow = {
+  id: bigint;
+  meetingId: bigint;
+  clubUserId: bigint;
+  joinedAt: Date;
+  deletedAt: Date | null;
+};
+
+export type AttendeeListRow = {
+  id: bigint;
+  clubUserId: bigint;
+  joinedAt: Date;
+  userId: bigint;
+  nickname: string;
+  profileImageUrl: string;
+  authority: ClubAuthority;
+};
+
 const MEETING_DETAIL_SELECT = {
   id: true,
   clubId: true,
@@ -54,6 +77,7 @@ export class MeetingRepository {
 
   async create(data: {
     clubId: bigint;
+    hostClubUserId: bigint;
     name: string;
     introText: string;
     spot: string;
@@ -66,9 +90,16 @@ export class MeetingRepository {
     hour: number;
     minute: number;
   }): Promise<MeetingDetailRow> {
-    return this.prisma.meeting.create({
-      data,
-      select: MEETING_DETAIL_SELECT,
+    const { hostClubUserId, ...meetingData } = data;
+    return this.prisma.$transaction(async (tx) => {
+      const meeting = await tx.meeting.create({
+        data: meetingData,
+        select: MEETING_DETAIL_SELECT,
+      });
+      await tx.meetingMember.create({
+        data: { meetingId: meeting.id, clubUserId: hostClubUserId },
+      });
+      return meeting;
     });
   }
 
@@ -177,5 +208,100 @@ export class MeetingRepository {
 
       return true;
     });
+  }
+
+  async findMemberByMeetingAndClubUser(
+    meetingId: bigint,
+    clubUserId: bigint,
+  ): Promise<MeetingMemberRow | null> {
+    return this.prisma.meetingMember.findUnique({
+      where: { meetingId_clubUserId: { meetingId, clubUserId } },
+      select: {
+        id: true,
+        meetingId: true,
+        clubUserId: true,
+        joinedAt: true,
+        deletedAt: true,
+      },
+    });
+  }
+
+  async joinMeeting(
+    meetingId: bigint,
+    clubUserId: bigint,
+  ): Promise<MeetingMemberRow> {
+    const joinedAt = new Date();
+    return this.prisma.meetingMember.upsert({
+      where: { meetingId_clubUserId: { meetingId, clubUserId } },
+      create: { meetingId, clubUserId, joinedAt },
+      update: { deletedAt: null, joinedAt },
+      select: {
+        id: true,
+        meetingId: true,
+        clubUserId: true,
+        joinedAt: true,
+        deletedAt: true,
+      },
+    });
+  }
+
+  async leaveMeeting(
+    meetingId: bigint,
+    clubUserId: bigint,
+    deletedAt: Date,
+  ): Promise<number> {
+    const result = await this.prisma.meetingMember.updateMany({
+      where: { meetingId, clubUserId, deletedAt: null },
+      data: { deletedAt },
+    });
+    return result.count;
+  }
+
+  async listActiveMembers(
+    meetingId: bigint,
+    cursor: { joinedAt: Date; id: bigint } | null,
+    take: number,
+  ): Promise<AttendeeListRow[]> {
+    const rows = await this.prisma.meetingMember.findMany({
+      where: {
+        meetingId,
+        deletedAt: null,
+        ...(cursor
+          ? {
+              OR: [
+                { joinedAt: { gt: cursor.joinedAt } },
+                {
+                  joinedAt: cursor.joinedAt,
+                  id: { gt: cursor.id },
+                },
+              ],
+            }
+          : {}),
+      },
+      take,
+      orderBy: [{ joinedAt: 'asc' }, { id: 'asc' }],
+      select: {
+        id: true,
+        clubUserId: true,
+        joinedAt: true,
+        clubUser: {
+          select: {
+            authority: true,
+            user: {
+              select: { id: true, nickname: true, profileImageUrl: true },
+            },
+          },
+        },
+      },
+    });
+    return rows.map((r) => ({
+      id: r.id,
+      clubUserId: r.clubUserId,
+      joinedAt: r.joinedAt,
+      userId: r.clubUser.user.id,
+      nickname: r.clubUser.user.nickname,
+      profileImageUrl: r.clubUser.user.profileImageUrl,
+      authority: r.clubUser.authority,
+    }));
   }
 }

--- a/src/modules/club/repositories/meeting.repository.ts
+++ b/src/modules/club/repositories/meeting.repository.ts
@@ -140,11 +140,45 @@ export class MeetingRepository {
       hour?: number;
       minute?: number;
     },
-  ): Promise<MeetingDetailRow> {
-    return this.prisma.meeting.update({
-      where: { id: meetingId },
-      data,
-      select: MEETING_DETAIL_SELECT,
+  ): Promise<{
+    meeting: MeetingDetailRow | null;
+    capacityBelowAttendees: boolean;
+    meetingMissing: boolean;
+  }> {
+    return this.prisma.$transaction(async (tx) => {
+      const rows = await tx.$queryRaw<
+        Array<{ id: bigint; deletedAt: Date | null }>
+      >`SELECT id, "deletedAt" FROM "Meeting" WHERE id = ${meetingId} FOR UPDATE`;
+      if (rows.length === 0 || rows[0].deletedAt !== null) {
+        return {
+          meeting: null,
+          capacityBelowAttendees: false,
+          meetingMissing: true,
+        };
+      }
+
+      if (data.capacity !== undefined) {
+        const count = await tx.meetingMember.count({
+          where: { meetingId, deletedAt: null },
+        });
+        if (data.capacity < count) {
+          return {
+            meeting: null,
+            capacityBelowAttendees: true,
+            meetingMissing: false,
+          };
+        }
+      }
+      const meeting = await tx.meeting.update({
+        where: { id: meetingId },
+        data,
+        select: MEETING_DETAIL_SELECT,
+      });
+      return {
+        meeting,
+        capacityBelowAttendees: false,
+        meetingMissing: false,
+      };
     });
   }
 
@@ -229,33 +263,90 @@ export class MeetingRepository {
   async joinMeeting(
     meetingId: bigint,
     clubUserId: bigint,
-    capacity: number,
-  ): Promise<{ member: MeetingMemberRow | null; capacityExceeded: boolean }> {
-    return this.prisma.$transaction(
-      async (tx) => {
-        const count = await tx.meetingMember.count({
-          where: { meetingId, deletedAt: null },
-        });
-        if (count >= capacity) {
-          return { member: null, capacityExceeded: true };
-        }
-        const joinedAt = new Date();
-        const member = await tx.meetingMember.upsert({
-          where: { meetingId_clubUserId: { meetingId, clubUserId } },
-          create: { meetingId, clubUserId, joinedAt },
-          update: { deletedAt: null, joinedAt },
-          select: {
-            id: true,
-            meetingId: true,
-            clubUserId: true,
-            joinedAt: true,
-            deletedAt: true,
-          },
-        });
-        return { member, capacityExceeded: false };
-      },
-      { isolationLevel: 'Serializable' },
-    );
+  ): Promise<{
+    member: MeetingMemberRow | null;
+    capacityExceeded: boolean;
+    meetingMissing: boolean;
+    alreadyJoined: boolean;
+    approvalRequired: boolean;
+  }> {
+    return this.prisma.$transaction(async (tx) => {
+      const rows = await tx.$queryRaw<
+        Array<{
+          id: bigint;
+          capacity: number;
+          joinPolicy: MeetingJoinPolicy;
+          deletedAt: Date | null;
+        }>
+      >`SELECT id, capacity, "joinPolicy", "deletedAt" FROM "Meeting" WHERE id = ${meetingId} FOR UPDATE`;
+
+      if (rows.length === 0 || rows[0].deletedAt !== null) {
+        return {
+          member: null,
+          capacityExceeded: false,
+          meetingMissing: true,
+          alreadyJoined: false,
+          approvalRequired: false,
+        };
+      }
+      if (rows[0].joinPolicy === MeetingJoinPolicy.APPROVAL_REQUIRED) {
+        return {
+          member: null,
+          capacityExceeded: false,
+          meetingMissing: false,
+          alreadyJoined: false,
+          approvalRequired: true,
+        };
+      }
+      const capacity = rows[0].capacity;
+
+      const existing = await tx.meetingMember.findUnique({
+        where: { meetingId_clubUserId: { meetingId, clubUserId } },
+        select: { id: true, deletedAt: true },
+      });
+      if (existing && existing.deletedAt === null) {
+        return {
+          member: null,
+          capacityExceeded: false,
+          meetingMissing: false,
+          alreadyJoined: true,
+          approvalRequired: false,
+        };
+      }
+
+      const count = await tx.meetingMember.count({
+        where: { meetingId, deletedAt: null },
+      });
+      if (count >= capacity) {
+        return {
+          member: null,
+          capacityExceeded: true,
+          meetingMissing: false,
+          alreadyJoined: false,
+          approvalRequired: false,
+        };
+      }
+      const joinedAt = new Date();
+      const member = await tx.meetingMember.upsert({
+        where: { meetingId_clubUserId: { meetingId, clubUserId } },
+        create: { meetingId, clubUserId, joinedAt },
+        update: { deletedAt: null, joinedAt },
+        select: {
+          id: true,
+          meetingId: true,
+          clubUserId: true,
+          joinedAt: true,
+          deletedAt: true,
+        },
+      });
+      return {
+        member,
+        capacityExceeded: false,
+        meetingMissing: false,
+        alreadyJoined: false,
+        approvalRequired: false,
+      };
+    });
   }
 
   async leaveMeeting(

--- a/src/modules/club/repositories/meeting.repository.ts
+++ b/src/modules/club/repositories/meeting.repository.ts
@@ -229,20 +229,33 @@ export class MeetingRepository {
   async joinMeeting(
     meetingId: bigint,
     clubUserId: bigint,
-  ): Promise<MeetingMemberRow> {
-    const joinedAt = new Date();
-    return this.prisma.meetingMember.upsert({
-      where: { meetingId_clubUserId: { meetingId, clubUserId } },
-      create: { meetingId, clubUserId, joinedAt },
-      update: { deletedAt: null, joinedAt },
-      select: {
-        id: true,
-        meetingId: true,
-        clubUserId: true,
-        joinedAt: true,
-        deletedAt: true,
+    capacity: number,
+  ): Promise<{ member: MeetingMemberRow | null; capacityExceeded: boolean }> {
+    return this.prisma.$transaction(
+      async (tx) => {
+        const count = await tx.meetingMember.count({
+          where: { meetingId, deletedAt: null },
+        });
+        if (count >= capacity) {
+          return { member: null, capacityExceeded: true };
+        }
+        const joinedAt = new Date();
+        const member = await tx.meetingMember.upsert({
+          where: { meetingId_clubUserId: { meetingId, clubUserId } },
+          create: { meetingId, clubUserId, joinedAt },
+          update: { deletedAt: null, joinedAt },
+          select: {
+            id: true,
+            meetingId: true,
+            clubUserId: true,
+            joinedAt: true,
+            deletedAt: true,
+          },
+        });
+        return { member, capacityExceeded: false };
       },
-    });
+      { isolationLevel: 'Serializable' },
+    );
   }
 
   async leaveMeeting(

--- a/src/modules/club/repositories/meeting.repository.ts
+++ b/src/modules/club/repositories/meeting.repository.ts
@@ -126,6 +126,7 @@ export class MeetingRepository {
   }
 
   async update(
+    clubId: bigint,
     meetingId: bigint,
     data: {
       name?: string;
@@ -148,7 +149,7 @@ export class MeetingRepository {
     return this.prisma.$transaction(async (tx) => {
       const rows = await tx.$queryRaw<
         Array<{ id: bigint; deletedAt: Date | null }>
-      >`SELECT id, "deletedAt" FROM "Meeting" WHERE id = ${meetingId} FOR UPDATE`;
+      >`SELECT id, "deletedAt" FROM "Meeting" WHERE id = ${meetingId} AND "clubId" = ${clubId} FOR UPDATE`;
       if (rows.length === 0 || rows[0].deletedAt !== null) {
         return {
           meeting: null,
@@ -261,6 +262,7 @@ export class MeetingRepository {
   }
 
   async joinMeeting(
+    clubId: bigint,
     meetingId: bigint,
     clubUserId: bigint,
   ): Promise<{
@@ -278,7 +280,7 @@ export class MeetingRepository {
           joinPolicy: MeetingJoinPolicy;
           deletedAt: Date | null;
         }>
-      >`SELECT id, capacity, "joinPolicy", "deletedAt" FROM "Meeting" WHERE id = ${meetingId} FOR UPDATE`;
+      >`SELECT id, capacity, "joinPolicy", "deletedAt" FROM "Meeting" WHERE id = ${meetingId} AND "clubId" = ${clubId} FOR UPDATE`;
 
       if (rows.length === 0 || rows[0].deletedAt !== null) {
         return {
@@ -350,18 +352,25 @@ export class MeetingRepository {
   }
 
   async leaveMeeting(
+    clubId: bigint,
     meetingId: bigint,
     clubUserId: bigint,
     deletedAt: Date,
   ): Promise<number> {
     const result = await this.prisma.meetingMember.updateMany({
-      where: { meetingId, clubUserId, deletedAt: null },
+      where: {
+        meetingId,
+        clubUserId,
+        deletedAt: null,
+        meeting: { clubId },
+      },
       data: { deletedAt },
     });
     return result.count;
   }
 
   async listActiveMembers(
+    clubId: bigint,
     meetingId: bigint,
     cursor: { joinedAt: Date; id: bigint } | null,
     take: number,
@@ -370,6 +379,7 @@ export class MeetingRepository {
       where: {
         meetingId,
         deletedAt: null,
+        meeting: { clubId },
         ...(cursor
           ? {
               OR: [

--- a/src/modules/club/services/meeting/meeting.service.spec.ts
+++ b/src/modules/club/services/meeting/meeting.service.spec.ts
@@ -495,6 +495,20 @@ describe('MeetingService', () => {
         service.joinMeeting(memberUserId, clubId, meetingId),
       ).rejects.toMatchObject({ internalCode: 'MEETING_NOT_FOUND' });
     });
+
+    it('APPROVAL_REQUIRED 정책이면 MEETING_APPROVAL_NOT_SUPPORTED', async () => {
+      findDetail.mockResolvedValue({
+        ...baseMeetingRow,
+        capacity: 10,
+        joinPolicy: MeetingJoinPolicy.APPROVAL_REQUIRED,
+      });
+      await expect(
+        service.joinMeeting(memberUserId, clubId, meetingId),
+      ).rejects.toMatchObject({
+        internalCode: 'MEETING_APPROVAL_NOT_SUPPORTED',
+      });
+      expect(joinMeeting).not.toHaveBeenCalled();
+    });
   });
 
   describe('leaveMeeting', () => {

--- a/src/modules/club/services/meeting/meeting.service.spec.ts
+++ b/src/modules/club/services/meeting/meeting.service.spec.ts
@@ -422,13 +422,15 @@ describe('MeetingService', () => {
       findActiveClubUser.mockResolvedValue({ id: memberClubUserId });
       findDetail.mockResolvedValue({ ...baseMeetingRow, capacity: 10 });
       findMemberByMeetingAndClubUser.mockResolvedValue(null);
-      countAttendees.mockResolvedValue(3);
       joinMeeting.mockResolvedValue({
-        id: 5001n,
-        meetingId,
-        clubUserId: memberClubUserId,
-        joinedAt: new Date('2026-05-01T11:05:00.000Z'),
-        deletedAt: null,
+        member: {
+          id: 5001n,
+          meetingId,
+          clubUserId: memberClubUserId,
+          joinedAt: new Date('2026-05-01T11:05:00.000Z'),
+          deletedAt: null,
+        },
+        capacityExceeded: false,
       });
     });
 
@@ -438,7 +440,7 @@ describe('MeetingService', () => {
       expect(result.clubUserId).toBe(Number(memberClubUserId));
       expect(result.userId).toBe(Number(memberUserId));
       expect(result.joinedAt).toMatch(/\+09:00$/);
-      expect(joinMeeting).toHaveBeenCalledWith(meetingId, memberClubUserId);
+      expect(joinMeeting).toHaveBeenCalledWith(meetingId, memberClubUserId, 10);
     });
 
     it('soft-deleted row가 있으면 revive (upsert)', async () => {
@@ -467,12 +469,14 @@ describe('MeetingService', () => {
       expect(joinMeeting).not.toHaveBeenCalled();
     });
 
-    it('정원 초과면 MEETING_CAPACITY_EXCEEDED', async () => {
-      countAttendees.mockResolvedValue(10);
+    it('트랜잭션 안에서 정원 초과로 판정되면 MEETING_CAPACITY_EXCEEDED', async () => {
+      joinMeeting.mockResolvedValue({
+        member: null,
+        capacityExceeded: true,
+      });
       await expect(
         service.joinMeeting(memberUserId, clubId, meetingId),
       ).rejects.toMatchObject({ internalCode: 'MEETING_CAPACITY_EXCEEDED' });
-      expect(joinMeeting).not.toHaveBeenCalled();
     });
 
     it('비멤버면 CLUB_FORBIDDEN_NOT_MEMBER', async () => {

--- a/src/modules/club/services/meeting/meeting.service.spec.ts
+++ b/src/modules/club/services/meeting/meeting.service.spec.ts
@@ -306,6 +306,7 @@ describe('MeetingService', () => {
       );
 
       expect(update).toHaveBeenCalledWith(
+        clubId,
         meetingId,
         expect.objectContaining({
           recurrenceType: RecurrenceType.DAILY,
@@ -454,7 +455,11 @@ describe('MeetingService', () => {
       expect(result.clubUserId).toBe(Number(memberClubUserId));
       expect(result.userId).toBe(Number(memberUserId));
       expect(result.joinedAt).toMatch(/\+09:00$/);
-      expect(joinMeeting).toHaveBeenCalledWith(meetingId, memberClubUserId);
+      expect(joinMeeting).toHaveBeenCalledWith(
+        clubId,
+        meetingId,
+        memberClubUserId,
+      );
     });
 
     it('정원 초과면 MEETING_CAPACITY_EXCEEDED', async () => {
@@ -621,7 +626,12 @@ describe('MeetingService', () => {
       expect(result.attendees).toHaveLength(2);
       expect(result.hasMore).toBe(true);
       expect(result.nextCursor).not.toBeNull();
-      expect(listActiveMembers).toHaveBeenCalledWith(meetingId, null, 3);
+      expect(listActiveMembers).toHaveBeenCalledWith(
+        clubId,
+        meetingId,
+        null,
+        3,
+      );
     });
 
     it('마지막 페이지면 hasMore=false, nextCursor=null', async () => {

--- a/src/modules/club/services/meeting/meeting.service.spec.ts
+++ b/src/modules/club/services/meeting/meeting.service.spec.ts
@@ -623,5 +623,29 @@ describe('MeetingService', () => {
         service.listAttendees(memberUserId, clubId, meetingId, {}),
       ).rejects.toMatchObject({ internalCode: 'MEETING_NOT_FOUND' });
     });
+
+    it('cursor의 id가 BigInt 파싱 불가면 VALIDATION_INVALID_FORMAT', async () => {
+      const payload = { joinedAt: '2026-05-01T20:07:00.000Z', id: 'abc' };
+      const cursor = Buffer.from(JSON.stringify(payload), 'utf8')
+        .toString('base64')
+        .replaceAll('+', '-')
+        .replaceAll('/', '_')
+        .replaceAll('=', '');
+      await expect(
+        service.listAttendees(memberUserId, clubId, meetingId, { cursor }),
+      ).rejects.toMatchObject({ internalCode: 'VALIDATION_INVALID_FORMAT' });
+    });
+
+    it('cursor의 joinedAt이 Invalid Date면 VALIDATION_INVALID_FORMAT', async () => {
+      const payload = { joinedAt: 'not-a-date', id: '5002' };
+      const cursor = Buffer.from(JSON.stringify(payload), 'utf8')
+        .toString('base64')
+        .replaceAll('+', '-')
+        .replaceAll('/', '_')
+        .replaceAll('=', '');
+      await expect(
+        service.listAttendees(memberUserId, clubId, meetingId, { cursor }),
+      ).rejects.toMatchObject({ internalCode: 'VALIDATION_INVALID_FORMAT' });
+    });
   });
 });

--- a/src/modules/club/services/meeting/meeting.service.spec.ts
+++ b/src/modules/club/services/meeting/meeting.service.spec.ts
@@ -1,5 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { DayOfWeek, MeetingJoinPolicy, RecurrenceType } from '@prisma/client';
+import {
+  ClubAuthority,
+  DayOfWeek,
+  MeetingJoinPolicy,
+  RecurrenceType,
+} from '@prisma/client';
 import { MeetingService } from './meeting.service';
 import { ClubRepository } from '../../repositories/club.repository';
 import {
@@ -23,6 +28,10 @@ describe('MeetingService', () => {
   const findAttendeesPreview = jest.fn();
   const isAttending = jest.fn();
   const softDeleteWithMembers = jest.fn();
+  const findMemberByMeetingAndClubUser = jest.fn();
+  const joinMeeting = jest.fn();
+  const leaveMeeting = jest.fn();
+  const listActiveMembers = jest.fn();
 
   const validDto: CreateMeetingRequestDto = {
     name: '매주하는 새벽등산',
@@ -74,6 +83,10 @@ describe('MeetingService', () => {
       findAttendeesPreview,
       isAttending,
       softDeleteWithMembers,
+      findMemberByMeetingAndClubUser,
+      joinMeeting,
+      leaveMeeting,
+      listActiveMembers,
     ].forEach((fn) => fn.mockReset());
 
     const module: TestingModule = await Test.createTestingModule({
@@ -93,6 +106,10 @@ describe('MeetingService', () => {
             findAttendeesPreview,
             isAttending,
             softDeleteWithMembers,
+            findMemberByMeetingAndClubUser,
+            joinMeeting,
+            leaveMeeting,
+            listActiveMembers,
           },
         },
       ],
@@ -106,7 +123,14 @@ describe('MeetingService', () => {
   });
 
   describe('createMeeting', () => {
-    it('호스트가 만들면 정모가 생성된다', async () => {
+    beforeEach(() => {
+      findActiveClubUser.mockResolvedValue({ id: 555n });
+      findAttendeesPreview.mockResolvedValue([
+        { userId: 42n, nickname: '호스트', profileImageUrl: 'u-host' },
+      ]);
+    });
+
+    it('호스트가 만들면 정모가 생성되고 호스트가 자동 참석된다', async () => {
       findById.mockResolvedValue({
         id: clubId,
         hostId: hostUserId,
@@ -118,11 +142,15 @@ describe('MeetingService', () => {
 
       expect(result.meetingId).toBe(Number(meetingId));
       expect(result.clubId).toBe(Number(clubId));
-      expect(result.attendeeCount).toBe(0);
+      expect(result.attendeeCount).toBe(1);
+      expect(result.isAttending).toBe(true);
+      expect(result.attendeesPreview).toHaveLength(1);
       expect(result.dateLabel).toBe('매주 목요일 오후 7시');
       expect(result.recurrence.type).toBe(RecurrenceType.WEEKLY);
       expect(result.recurrence.daysOfWeek).toEqual([DayOfWeek.THU]);
-      expect(create).toHaveBeenCalledTimes(1);
+      expect(create).toHaveBeenCalledWith(
+        expect.objectContaining({ hostClubUserId: 555n }),
+      );
     });
 
     it('호스트가 아니면 CLUB_FORBIDDEN_NOT_HOST', async () => {
@@ -156,6 +184,19 @@ describe('MeetingService', () => {
       await expect(
         service.createMeeting(hostUserId, clubId, validDto),
       ).rejects.toMatchObject({ internalCode: 'CLUB_NOT_FOUND' });
+    });
+
+    it('호스트의 ClubUser가 없으면 CLUB_FORBIDDEN_NOT_MEMBER', async () => {
+      findById.mockResolvedValue({
+        id: clubId,
+        hostId: hostUserId,
+        deletedAt: null,
+      });
+      findActiveClubUser.mockResolvedValue(null);
+      await expect(
+        service.createMeeting(hostUserId, clubId, validDto),
+      ).rejects.toMatchObject({ internalCode: 'CLUB_FORBIDDEN_NOT_MEMBER' });
+      expect(create).not.toHaveBeenCalled();
     });
   });
 
@@ -365,6 +406,222 @@ describe('MeetingService', () => {
       await expect(
         service.deleteMeeting(hostUserId, clubId, meetingId),
       ).rejects.toMatchObject({ internalCode: 'CLUB_NOT_FOUND' });
+    });
+  });
+
+  describe('joinMeeting', () => {
+    const memberUserId = 200n;
+    const memberClubUserId = 777n;
+
+    beforeEach(() => {
+      findById.mockResolvedValue({
+        id: clubId,
+        hostId: hostUserId,
+        deletedAt: null,
+      });
+      findActiveClubUser.mockResolvedValue({ id: memberClubUserId });
+      findDetail.mockResolvedValue({ ...baseMeetingRow, capacity: 10 });
+      findMemberByMeetingAndClubUser.mockResolvedValue(null);
+      countAttendees.mockResolvedValue(3);
+      joinMeeting.mockResolvedValue({
+        id: 5001n,
+        meetingId,
+        clubUserId: memberClubUserId,
+        joinedAt: new Date('2026-05-01T11:05:00.000Z'),
+        deletedAt: null,
+      });
+    });
+
+    it('정상 참석', async () => {
+      const result = await service.joinMeeting(memberUserId, clubId, meetingId);
+      expect(result.meetingMemberId).toBe(5001);
+      expect(result.clubUserId).toBe(Number(memberClubUserId));
+      expect(result.userId).toBe(Number(memberUserId));
+      expect(result.joinedAt).toMatch(/\+09:00$/);
+      expect(joinMeeting).toHaveBeenCalledWith(meetingId, memberClubUserId);
+    });
+
+    it('soft-deleted row가 있으면 revive (upsert)', async () => {
+      findMemberByMeetingAndClubUser.mockResolvedValue({
+        id: 5001n,
+        meetingId,
+        clubUserId: memberClubUserId,
+        joinedAt: new Date('2026-04-01T10:00:00.000Z'),
+        deletedAt: new Date('2026-04-15T10:00:00.000Z'),
+      });
+      await service.joinMeeting(memberUserId, clubId, meetingId);
+      expect(joinMeeting).toHaveBeenCalled();
+    });
+
+    it('이미 ACTIVE row면 MEETING_ALREADY_JOINED', async () => {
+      findMemberByMeetingAndClubUser.mockResolvedValue({
+        id: 5001n,
+        meetingId,
+        clubUserId: memberClubUserId,
+        joinedAt: new Date(),
+        deletedAt: null,
+      });
+      await expect(
+        service.joinMeeting(memberUserId, clubId, meetingId),
+      ).rejects.toMatchObject({ internalCode: 'MEETING_ALREADY_JOINED' });
+      expect(joinMeeting).not.toHaveBeenCalled();
+    });
+
+    it('정원 초과면 MEETING_CAPACITY_EXCEEDED', async () => {
+      countAttendees.mockResolvedValue(10);
+      await expect(
+        service.joinMeeting(memberUserId, clubId, meetingId),
+      ).rejects.toMatchObject({ internalCode: 'MEETING_CAPACITY_EXCEEDED' });
+      expect(joinMeeting).not.toHaveBeenCalled();
+    });
+
+    it('비멤버면 CLUB_FORBIDDEN_NOT_MEMBER', async () => {
+      findActiveClubUser.mockResolvedValue(null);
+      await expect(
+        service.joinMeeting(memberUserId, clubId, meetingId),
+      ).rejects.toMatchObject({ internalCode: 'CLUB_FORBIDDEN_NOT_MEMBER' });
+    });
+
+    it('클럽 없으면 CLUB_NOT_FOUND', async () => {
+      findById.mockResolvedValue(null);
+      await expect(
+        service.joinMeeting(memberUserId, clubId, meetingId),
+      ).rejects.toMatchObject({ internalCode: 'CLUB_NOT_FOUND' });
+    });
+
+    it('정모 없으면 MEETING_NOT_FOUND', async () => {
+      findDetail.mockResolvedValue(null);
+      await expect(
+        service.joinMeeting(memberUserId, clubId, meetingId),
+      ).rejects.toMatchObject({ internalCode: 'MEETING_NOT_FOUND' });
+    });
+  });
+
+  describe('leaveMeeting', () => {
+    const memberUserId = 200n;
+    const memberClubUserId = 777n;
+
+    beforeEach(() => {
+      findById.mockResolvedValue({
+        id: clubId,
+        hostId: hostUserId,
+        deletedAt: null,
+      });
+      findActiveClubUser.mockResolvedValue({ id: memberClubUserId });
+      findDetail.mockResolvedValue(baseMeetingRow);
+      leaveMeeting.mockResolvedValue(1);
+    });
+
+    it('정상 취소', async () => {
+      const result = await service.leaveMeeting(
+        memberUserId,
+        clubId,
+        meetingId,
+      );
+      expect(result.meetingId).toBe(Number(meetingId));
+      expect(result.userId).toBe(Number(memberUserId));
+      expect(result.canceledAt).toMatch(/\+09:00$/);
+    });
+
+    it('호스트 본인이면 MEETING_HOST_CANNOT_LEAVE', async () => {
+      await expect(
+        service.leaveMeeting(hostUserId, clubId, meetingId),
+      ).rejects.toMatchObject({ internalCode: 'MEETING_HOST_CANNOT_LEAVE' });
+      expect(leaveMeeting).not.toHaveBeenCalled();
+    });
+
+    it('미참석 상태면 MEETING_NOT_JOINED', async () => {
+      leaveMeeting.mockResolvedValue(0);
+      await expect(
+        service.leaveMeeting(memberUserId, clubId, meetingId),
+      ).rejects.toMatchObject({ internalCode: 'MEETING_NOT_JOINED' });
+    });
+
+    it('비멤버면 CLUB_FORBIDDEN_NOT_MEMBER', async () => {
+      findActiveClubUser.mockResolvedValue(null);
+      await expect(
+        service.leaveMeeting(memberUserId, clubId, meetingId),
+      ).rejects.toMatchObject({ internalCode: 'CLUB_FORBIDDEN_NOT_MEMBER' });
+    });
+
+    it('정모 없으면 MEETING_NOT_FOUND', async () => {
+      findDetail.mockResolvedValue(null);
+      await expect(
+        service.leaveMeeting(memberUserId, clubId, meetingId),
+      ).rejects.toMatchObject({ internalCode: 'MEETING_NOT_FOUND' });
+    });
+  });
+
+  describe('listAttendees', () => {
+    const memberUserId = 200n;
+    const memberClubUserId = 777n;
+
+    const makeRow = (id: bigint, joinedAtMs: number) => ({
+      id,
+      clubUserId: id,
+      joinedAt: new Date(joinedAtMs),
+      userId: id,
+      nickname: `user-${id}`,
+      profileImageUrl: `u-${id}`,
+      authority: ClubAuthority.GENERAL,
+    });
+
+    beforeEach(() => {
+      findById.mockResolvedValue({
+        id: clubId,
+        hostId: hostUserId,
+        deletedAt: null,
+      });
+      findActiveClubUser.mockResolvedValue({ id: memberClubUserId });
+      findDetail.mockResolvedValue(baseMeetingRow);
+      countAttendees.mockResolvedValue(14);
+    });
+
+    it('첫 페이지: size+1 받아서 hasMore 판정', async () => {
+      const rows = [makeRow(1n, 1000), makeRow(2n, 2000), makeRow(3n, 3000)];
+      listActiveMembers.mockResolvedValue(rows);
+
+      const result = await service.listAttendees(
+        memberUserId,
+        clubId,
+        meetingId,
+        { size: 2 },
+      );
+
+      expect(result.attendeeCount).toBe(14);
+      expect(result.attendees).toHaveLength(2);
+      expect(result.hasMore).toBe(true);
+      expect(result.nextCursor).not.toBeNull();
+      expect(listActiveMembers).toHaveBeenCalledWith(meetingId, null, 3);
+    });
+
+    it('마지막 페이지면 hasMore=false, nextCursor=null', async () => {
+      listActiveMembers.mockResolvedValue([makeRow(1n, 1000)]);
+
+      const result = await service.listAttendees(
+        memberUserId,
+        clubId,
+        meetingId,
+        { size: 10 },
+      );
+
+      expect(result.attendees).toHaveLength(1);
+      expect(result.hasMore).toBe(false);
+      expect(result.nextCursor).toBeNull();
+    });
+
+    it('비멤버면 CLUB_FORBIDDEN_NOT_MEMBER', async () => {
+      findActiveClubUser.mockResolvedValue(null);
+      await expect(
+        service.listAttendees(memberUserId, clubId, meetingId, {}),
+      ).rejects.toMatchObject({ internalCode: 'CLUB_FORBIDDEN_NOT_MEMBER' });
+    });
+
+    it('정모 없으면 MEETING_NOT_FOUND', async () => {
+      findDetail.mockResolvedValue(null);
+      await expect(
+        service.listAttendees(memberUserId, clubId, meetingId, {}),
+      ).rejects.toMatchObject({ internalCode: 'MEETING_NOT_FOUND' });
     });
   });
 });

--- a/src/modules/club/services/meeting/meeting.service.spec.ts
+++ b/src/modules/club/services/meeting/meeting.service.spec.ts
@@ -285,13 +285,17 @@ describe('MeetingService', () => {
         },
       };
       update.mockResolvedValue({
-        ...baseMeetingRow,
-        recurrenceType: RecurrenceType.DAILY,
-        daysOfWeek: [],
-        dayOfMonth: null,
-        hour: 7,
-        minute: 0,
-        updatedAt: new Date(),
+        meeting: {
+          ...baseMeetingRow,
+          recurrenceType: RecurrenceType.DAILY,
+          daysOfWeek: [],
+          dayOfMonth: null,
+          hour: 7,
+          minute: 0,
+          updatedAt: new Date(),
+        },
+        capacityBelowAttendees: false,
+        meetingMissing: false,
       });
 
       const result = await service.updateMeeting(
@@ -316,13 +320,27 @@ describe('MeetingService', () => {
     });
 
     it('capacity가 현재 참석자 수보다 작으면 MEETING_CAPACITY_BELOW_ATTENDEES', async () => {
-      countAttendees.mockResolvedValue(4);
+      update.mockResolvedValue({
+        meeting: null,
+        capacityBelowAttendees: true,
+        meetingMissing: false,
+      });
       await expect(
         service.updateMeeting(hostUserId, clubId, meetingId, { capacity: 3 }),
       ).rejects.toMatchObject({
         internalCode: 'MEETING_CAPACITY_BELOW_ATTENDEES',
       });
-      expect(update).not.toHaveBeenCalled();
+    });
+
+    it('정모가 없거나 삭제된 상태면 MEETING_NOT_FOUND', async () => {
+      update.mockResolvedValue({
+        meeting: null,
+        capacityBelowAttendees: false,
+        meetingMissing: true,
+      });
+      await expect(
+        service.updateMeeting(hostUserId, clubId, meetingId, { name: 'X' }),
+      ).rejects.toMatchObject({ internalCode: 'MEETING_NOT_FOUND' });
     });
 
     it('호스트가 아니면 CLUB_FORBIDDEN_NOT_HOST', async () => {
@@ -334,13 +352,6 @@ describe('MeetingService', () => {
       await expect(
         service.updateMeeting(hostUserId, clubId, meetingId, { capacity: 10 }),
       ).rejects.toMatchObject({ internalCode: 'CLUB_FORBIDDEN_NOT_HOST' });
-    });
-
-    it('정모가 없으면 MEETING_NOT_FOUND', async () => {
-      findDetail.mockResolvedValue(null);
-      await expect(
-        service.updateMeeting(hostUserId, clubId, meetingId, { capacity: 10 }),
-      ).rejects.toMatchObject({ internalCode: 'MEETING_NOT_FOUND' });
     });
   });
 
@@ -431,6 +442,9 @@ describe('MeetingService', () => {
           deletedAt: null,
         },
         capacityExceeded: false,
+        meetingMissing: false,
+        alreadyJoined: false,
+        approvalRequired: false,
       });
     });
 
@@ -440,43 +454,61 @@ describe('MeetingService', () => {
       expect(result.clubUserId).toBe(Number(memberClubUserId));
       expect(result.userId).toBe(Number(memberUserId));
       expect(result.joinedAt).toMatch(/\+09:00$/);
-      expect(joinMeeting).toHaveBeenCalledWith(meetingId, memberClubUserId, 10);
+      expect(joinMeeting).toHaveBeenCalledWith(meetingId, memberClubUserId);
     });
 
-    it('soft-deleted row가 있으면 revive (upsert)', async () => {
-      findMemberByMeetingAndClubUser.mockResolvedValue({
-        id: 5001n,
-        meetingId,
-        clubUserId: memberClubUserId,
-        joinedAt: new Date('2026-04-01T10:00:00.000Z'),
-        deletedAt: new Date('2026-04-15T10:00:00.000Z'),
-      });
-      await service.joinMeeting(memberUserId, clubId, meetingId);
-      expect(joinMeeting).toHaveBeenCalled();
-    });
-
-    it('이미 ACTIVE row면 MEETING_ALREADY_JOINED', async () => {
-      findMemberByMeetingAndClubUser.mockResolvedValue({
-        id: 5001n,
-        meetingId,
-        clubUserId: memberClubUserId,
-        joinedAt: new Date(),
-        deletedAt: null,
-      });
-      await expect(
-        service.joinMeeting(memberUserId, clubId, meetingId),
-      ).rejects.toMatchObject({ internalCode: 'MEETING_ALREADY_JOINED' });
-      expect(joinMeeting).not.toHaveBeenCalled();
-    });
-
-    it('트랜잭션 안에서 정원 초과로 판정되면 MEETING_CAPACITY_EXCEEDED', async () => {
+    it('정원 초과면 MEETING_CAPACITY_EXCEEDED', async () => {
       joinMeeting.mockResolvedValue({
         member: null,
         capacityExceeded: true,
+        meetingMissing: false,
+        alreadyJoined: false,
+        approvalRequired: false,
       });
       await expect(
         service.joinMeeting(memberUserId, clubId, meetingId),
       ).rejects.toMatchObject({ internalCode: 'MEETING_CAPACITY_EXCEEDED' });
+    });
+
+    it('정모가 없거나 삭제된 상태면 MEETING_NOT_FOUND', async () => {
+      joinMeeting.mockResolvedValue({
+        member: null,
+        capacityExceeded: false,
+        meetingMissing: true,
+        alreadyJoined: false,
+        approvalRequired: false,
+      });
+      await expect(
+        service.joinMeeting(memberUserId, clubId, meetingId),
+      ).rejects.toMatchObject({ internalCode: 'MEETING_NOT_FOUND' });
+    });
+
+    it('이미 ACTIVE 멤버면 MEETING_ALREADY_JOINED', async () => {
+      joinMeeting.mockResolvedValue({
+        member: null,
+        capacityExceeded: false,
+        meetingMissing: false,
+        alreadyJoined: true,
+        approvalRequired: false,
+      });
+      await expect(
+        service.joinMeeting(memberUserId, clubId, meetingId),
+      ).rejects.toMatchObject({ internalCode: 'MEETING_ALREADY_JOINED' });
+    });
+
+    it('joinPolicy=APPROVAL_REQUIRED면 MEETING_APPROVAL_NOT_SUPPORTED', async () => {
+      joinMeeting.mockResolvedValue({
+        member: null,
+        capacityExceeded: false,
+        meetingMissing: false,
+        alreadyJoined: false,
+        approvalRequired: true,
+      });
+      await expect(
+        service.joinMeeting(memberUserId, clubId, meetingId),
+      ).rejects.toMatchObject({
+        internalCode: 'MEETING_APPROVAL_NOT_SUPPORTED',
+      });
     });
 
     it('비멤버면 CLUB_FORBIDDEN_NOT_MEMBER', async () => {
@@ -491,27 +523,6 @@ describe('MeetingService', () => {
       await expect(
         service.joinMeeting(memberUserId, clubId, meetingId),
       ).rejects.toMatchObject({ internalCode: 'CLUB_NOT_FOUND' });
-    });
-
-    it('정모 없으면 MEETING_NOT_FOUND', async () => {
-      findDetail.mockResolvedValue(null);
-      await expect(
-        service.joinMeeting(memberUserId, clubId, meetingId),
-      ).rejects.toMatchObject({ internalCode: 'MEETING_NOT_FOUND' });
-    });
-
-    it('APPROVAL_REQUIRED 정책이면 MEETING_APPROVAL_NOT_SUPPORTED', async () => {
-      findDetail.mockResolvedValue({
-        ...baseMeetingRow,
-        capacity: 10,
-        joinPolicy: MeetingJoinPolicy.APPROVAL_REQUIRED,
-      });
-      await expect(
-        service.joinMeeting(memberUserId, clubId, meetingId),
-      ).rejects.toMatchObject({
-        internalCode: 'MEETING_APPROVAL_NOT_SUPPORTED',
-      });
-      expect(joinMeeting).not.toHaveBeenCalled();
     });
   });
 

--- a/src/modules/club/services/meeting/meeting.service.ts
+++ b/src/modules/club/services/meeting/meeting.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@nestjs/common';
-import { MeetingJoinPolicy } from '@prisma/client';
 import { AppException } from '../../../../common/errors/app.exception';
 import { toKstIso } from '../../../../common/utils/datetime.util';
 import { encodeCursor } from '../../../../common/utils/cursor.util';
@@ -132,22 +131,13 @@ export class MeetingService {
       throw new AppException('CLUB_FORBIDDEN_NOT_HOST');
     }
 
-    const existing = await this.meetingRepository.findDetail(clubId, meetingId);
-    if (!existing) {
-      throw new AppException('MEETING_NOT_FOUND');
-    }
-
-    if (dto.capacity !== undefined) {
-      const currentAttendees =
-        await this.meetingRepository.countAttendees(meetingId);
-      if (dto.capacity < currentAttendees) {
-        throw new AppException('MEETING_CAPACITY_BELOW_ATTENDEES');
-      }
-    }
-
     const { recurrence } = dto;
 
-    const updated = await this.meetingRepository.update(meetingId, {
+    const {
+      meeting: updated,
+      capacityBelowAttendees,
+      meetingMissing,
+    } = await this.meetingRepository.update(meetingId, {
       ...(dto.name !== undefined ? { name: dto.name } : {}),
       ...(dto.introText !== undefined ? { introText: dto.introText } : {}),
       ...(dto.spot !== undefined ? { spot: dto.spot } : {}),
@@ -164,6 +154,15 @@ export class MeetingService {
           }
         : {}),
     });
+    if (meetingMissing) {
+      throw new AppException('MEETING_NOT_FOUND');
+    }
+    if (capacityBelowAttendees) {
+      throw new AppException('MEETING_CAPACITY_BELOW_ATTENDEES');
+    }
+    if (!updated) {
+      throw new AppException('SERVER_TEMPORARY_ERROR');
+    }
 
     const [attendeeCount, attendeesPreview, clubUser] = await Promise.all([
       this.meetingRepository.countAttendees(meetingId),
@@ -230,30 +229,22 @@ export class MeetingService {
       throw new AppException('CLUB_FORBIDDEN_NOT_MEMBER');
     }
 
-    const meeting = await this.meetingRepository.findDetail(clubId, meetingId);
-    if (!meeting) {
+    const {
+      member,
+      capacityExceeded,
+      meetingMissing,
+      alreadyJoined,
+      approvalRequired,
+    } = await this.meetingRepository.joinMeeting(meetingId, clubUser.id);
+    if (meetingMissing) {
       throw new AppException('MEETING_NOT_FOUND');
     }
-
-    if (meeting.joinPolicy === MeetingJoinPolicy.APPROVAL_REQUIRED) {
+    if (approvalRequired) {
       throw new AppException('MEETING_APPROVAL_NOT_SUPPORTED');
     }
-
-    const existing =
-      await this.meetingRepository.findMemberByMeetingAndClubUser(
-        meetingId,
-        clubUser.id,
-      );
-    if (existing && existing.deletedAt === null) {
+    if (alreadyJoined) {
       throw new AppException('MEETING_ALREADY_JOINED');
     }
-
-    const { member, capacityExceeded } =
-      await this.meetingRepository.joinMeeting(
-        meetingId,
-        clubUser.id,
-        meeting.capacity,
-      );
     if (capacityExceeded) {
       throw new AppException('MEETING_CAPACITY_EXCEEDED');
     }

--- a/src/modules/club/services/meeting/meeting.service.ts
+++ b/src/modules/club/services/meeting/meeting.service.ts
@@ -137,7 +137,7 @@ export class MeetingService {
       meeting: updated,
       capacityBelowAttendees,
       meetingMissing,
-    } = await this.meetingRepository.update(meetingId, {
+    } = await this.meetingRepository.update(clubId, meetingId, {
       ...(dto.name !== undefined ? { name: dto.name } : {}),
       ...(dto.introText !== undefined ? { introText: dto.introText } : {}),
       ...(dto.spot !== undefined ? { spot: dto.spot } : {}),
@@ -235,7 +235,11 @@ export class MeetingService {
       meetingMissing,
       alreadyJoined,
       approvalRequired,
-    } = await this.meetingRepository.joinMeeting(meetingId, clubUser.id);
+    } = await this.meetingRepository.joinMeeting(
+      clubId,
+      meetingId,
+      clubUser.id,
+    );
     if (meetingMissing) {
       throw new AppException('MEETING_NOT_FOUND');
     }
@@ -290,6 +294,7 @@ export class MeetingService {
 
     const deletedAt = new Date();
     const affected = await this.meetingRepository.leaveMeeting(
+      clubId,
       meetingId,
       clubUser.id,
       deletedAt,
@@ -334,7 +339,12 @@ export class MeetingService {
 
     const [attendeeCount, rows] = await Promise.all([
       this.meetingRepository.countAttendees(meetingId),
-      this.meetingRepository.listActiveMembers(meetingId, cursor, size + 1),
+      this.meetingRepository.listActiveMembers(
+        clubId,
+        meetingId,
+        cursor,
+        size + 1,
+      ),
     ]);
 
     const hasMore = rows.length > size;

--- a/src/modules/club/services/meeting/meeting.service.ts
+++ b/src/modules/club/services/meeting/meeting.service.ts
@@ -1,8 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { AppException } from '../../../../common/errors/app.exception';
 import { toKstIso } from '../../../../common/utils/datetime.util';
+import { encodeCursor } from '../../../../common/utils/cursor.util';
 import { ClubRepository } from '../../repositories/club.repository';
 import {
+  AttendeeListRow,
   AttendeePreviewRow,
   MeetingDetailRow,
   MeetingRepository,
@@ -12,6 +14,10 @@ import {
   CreateMeetingResponseDto,
   DeleteMeetingResponseDto,
   GetMeetingDetailResponseDto,
+  JoinMeetingResponseDto,
+  LeaveMeetingResponseDto,
+  ListAttendeesQueryDto,
+  ListAttendeesResponseDto,
   UpdateMeetingRequestDto,
   UpdateMeetingResponseDto,
 } from '../../dtos/meeting.dto';
@@ -20,6 +26,7 @@ import {
   formatDateLabel,
   Recurrence,
 } from '../../utils/recurrence.util';
+import { decodeAttendeesCursor } from '../../utils/cursor.util';
 
 @Injectable()
 export class MeetingService {
@@ -41,9 +48,18 @@ export class MeetingService {
       throw new AppException('CLUB_FORBIDDEN_NOT_HOST');
     }
 
+    const hostClubUser = await this.clubRepository.findActiveClubUser(
+      userId,
+      clubId,
+    );
+    if (!hostClubUser) {
+      throw new AppException('CLUB_FORBIDDEN_NOT_MEMBER');
+    }
+
     const { recurrence } = dto;
     const created = await this.meetingRepository.create({
       clubId,
+      hostClubUserId: hostClubUser.id,
       name: dto.name,
       introText: dto.introText,
       spot: dto.spot,
@@ -57,7 +73,11 @@ export class MeetingService {
       minute: recurrence.minute,
     });
 
-    return this.buildMeetingDetail(created, 0, [], false);
+    const hostPreview = await this.meetingRepository.findAttendeesPreview(
+      created.id,
+      4,
+    );
+    return this.buildMeetingDetail(created, 1, hostPreview, true);
   }
 
   async getMeetingDetail(
@@ -188,6 +208,176 @@ export class MeetingService {
       meetingId: Number(meetingId),
       clubId: Number(clubId),
       deletedAt: toKstIso(deletedAt),
+    };
+  }
+
+  async joinMeeting(
+    userId: bigint,
+    clubId: bigint,
+    meetingId: bigint,
+  ): Promise<JoinMeetingResponseDto> {
+    const club = await this.clubRepository.findById(clubId);
+    if (!club || club.deletedAt) {
+      throw new AppException('CLUB_NOT_FOUND');
+    }
+
+    const clubUser = await this.clubRepository.findActiveClubUser(
+      userId,
+      clubId,
+    );
+    if (!clubUser) {
+      throw new AppException('CLUB_FORBIDDEN_NOT_MEMBER');
+    }
+
+    const meeting = await this.meetingRepository.findDetail(clubId, meetingId);
+    if (!meeting) {
+      throw new AppException('MEETING_NOT_FOUND');
+    }
+
+    const existing =
+      await this.meetingRepository.findMemberByMeetingAndClubUser(
+        meetingId,
+        clubUser.id,
+      );
+    if (existing && existing.deletedAt === null) {
+      throw new AppException('MEETING_ALREADY_JOINED');
+    }
+
+    const attendeeCount =
+      await this.meetingRepository.countAttendees(meetingId);
+    if (attendeeCount >= meeting.capacity) {
+      throw new AppException('MEETING_CAPACITY_EXCEEDED');
+    }
+
+    const member = await this.meetingRepository.joinMeeting(
+      meetingId,
+      clubUser.id,
+    );
+
+    return {
+      meetingMemberId: Number(member.id),
+      meetingId: Number(member.meetingId),
+      clubUserId: Number(member.clubUserId),
+      userId: Number(userId),
+      joinedAt: toKstIso(member.joinedAt),
+    };
+  }
+
+  async leaveMeeting(
+    userId: bigint,
+    clubId: bigint,
+    meetingId: bigint,
+  ): Promise<LeaveMeetingResponseDto> {
+    const club = await this.clubRepository.findById(clubId);
+    if (!club || club.deletedAt) {
+      throw new AppException('CLUB_NOT_FOUND');
+    }
+
+    if (club.hostId === userId) {
+      throw new AppException('MEETING_HOST_CANNOT_LEAVE');
+    }
+
+    const clubUser = await this.clubRepository.findActiveClubUser(
+      userId,
+      clubId,
+    );
+    if (!clubUser) {
+      throw new AppException('CLUB_FORBIDDEN_NOT_MEMBER');
+    }
+
+    const meeting = await this.meetingRepository.findDetail(clubId, meetingId);
+    if (!meeting) {
+      throw new AppException('MEETING_NOT_FOUND');
+    }
+
+    const deletedAt = new Date();
+    const affected = await this.meetingRepository.leaveMeeting(
+      meetingId,
+      clubUser.id,
+      deletedAt,
+    );
+    if (affected === 0) {
+      throw new AppException('MEETING_NOT_JOINED');
+    }
+
+    return {
+      meetingId: Number(meetingId),
+      userId: Number(userId),
+      canceledAt: toKstIso(deletedAt),
+    };
+  }
+
+  async listAttendees(
+    userId: bigint,
+    clubId: bigint,
+    meetingId: bigint,
+    query: ListAttendeesQueryDto,
+  ): Promise<ListAttendeesResponseDto> {
+    const club = await this.clubRepository.findById(clubId);
+    if (!club || club.deletedAt) {
+      throw new AppException('CLUB_NOT_FOUND');
+    }
+
+    const clubUser = await this.clubRepository.findActiveClubUser(
+      userId,
+      clubId,
+    );
+    if (!clubUser) {
+      throw new AppException('CLUB_FORBIDDEN_NOT_MEMBER');
+    }
+
+    const meeting = await this.meetingRepository.findDetail(clubId, meetingId);
+    if (!meeting) {
+      throw new AppException('MEETING_NOT_FOUND');
+    }
+
+    const size = query.size ?? 30;
+    const cursorPayload = query.cursor
+      ? decodeAttendeesCursor(query.cursor)
+      : null;
+    const cursor = cursorPayload
+      ? {
+          joinedAt: new Date(cursorPayload.joinedAt),
+          id: BigInt(cursorPayload.id),
+        }
+      : null;
+
+    const [attendeeCount, rows] = await Promise.all([
+      this.meetingRepository.countAttendees(meetingId),
+      this.meetingRepository.listActiveMembers(meetingId, cursor, size + 1),
+    ]);
+
+    const hasMore = rows.length > size;
+    const page = hasMore ? rows.slice(0, size) : rows;
+
+    const nextCursor =
+      hasMore && page.length > 0
+        ? encodeCursor({
+            joinedAt: page[page.length - 1].joinedAt.toISOString(),
+            id: page[page.length - 1].id.toString(),
+          })
+        : null;
+
+    return {
+      meetingId: Number(meetingId),
+      attendeeCount,
+      attendees: page.map((row) => this.buildAttendeeItem(row)),
+      nextCursor,
+      hasMore,
+    };
+  }
+
+  private buildAttendeeItem(row: AttendeeListRow) {
+    return {
+      meetingMemberId: Number(row.id),
+      clubUserId: Number(row.clubUserId),
+      user: {
+        userId: Number(row.userId),
+        nickname: row.nickname,
+        profileImageUrl: row.profileImageUrl,
+        authority: row.authority,
+      },
+      joinedAt: toKstIso(row.joinedAt),
     };
   }
 

--- a/src/modules/club/services/meeting/meeting.service.ts
+++ b/src/modules/club/services/meeting/meeting.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { MeetingJoinPolicy } from '@prisma/client';
 import { AppException } from '../../../../common/errors/app.exception';
 import { toKstIso } from '../../../../common/utils/datetime.util';
 import { encodeCursor } from '../../../../common/utils/cursor.util';
@@ -232,6 +233,10 @@ export class MeetingService {
     const meeting = await this.meetingRepository.findDetail(clubId, meetingId);
     if (!meeting) {
       throw new AppException('MEETING_NOT_FOUND');
+    }
+
+    if (meeting.joinPolicy === MeetingJoinPolicy.APPROVAL_REQUIRED) {
+      throw new AppException('MEETING_APPROVAL_NOT_SUPPORTED');
     }
 
     const existing =

--- a/src/modules/club/services/meeting/meeting.service.ts
+++ b/src/modules/club/services/meeting/meeting.service.ts
@@ -332,15 +332,7 @@ export class MeetingService {
     }
 
     const size = query.size ?? 30;
-    const cursorPayload = query.cursor
-      ? decodeAttendeesCursor(query.cursor)
-      : null;
-    const cursor = cursorPayload
-      ? {
-          joinedAt: new Date(cursorPayload.joinedAt),
-          id: BigInt(cursorPayload.id),
-        }
-      : null;
+    const cursor = query.cursor ? decodeAttendeesCursor(query.cursor) : null;
 
     const [attendeeCount, rows] = await Promise.all([
       this.meetingRepository.countAttendees(meetingId),

--- a/src/modules/club/services/meeting/meeting.service.ts
+++ b/src/modules/club/services/meeting/meeting.service.ts
@@ -248,16 +248,18 @@ export class MeetingService {
       throw new AppException('MEETING_ALREADY_JOINED');
     }
 
-    const attendeeCount =
-      await this.meetingRepository.countAttendees(meetingId);
-    if (attendeeCount >= meeting.capacity) {
+    const { member, capacityExceeded } =
+      await this.meetingRepository.joinMeeting(
+        meetingId,
+        clubUser.id,
+        meeting.capacity,
+      );
+    if (capacityExceeded) {
       throw new AppException('MEETING_CAPACITY_EXCEEDED');
     }
-
-    const member = await this.meetingRepository.joinMeeting(
-      meetingId,
-      clubUser.id,
-    );
+    if (!member) {
+      throw new AppException('SERVER_TEMPORARY_ERROR');
+    }
 
     return {
       meetingMemberId: Number(member.id),

--- a/src/modules/club/utils/cursor.util.ts
+++ b/src/modules/club/utils/cursor.util.ts
@@ -1,16 +1,30 @@
 import { AppException } from '../../../common/errors/app.exception';
 import { decodeCursorRaw } from '../../../common/utils/cursor.util';
 
-export type AttendeesCursorPayload = {
-  joinedAt: string;
-  id: string;
+export type AttendeesCursor = {
+  joinedAt: Date;
+  id: bigint;
 };
 
-export function decodeAttendeesCursor(cursor: string): AttendeesCursorPayload {
+export function decodeAttendeesCursor(cursor: string): AttendeesCursor {
   const parsed = decodeCursorRaw(cursor);
-  if (typeof parsed.joinedAt === 'string' && typeof parsed.id === 'string') {
-    return { joinedAt: parsed.joinedAt, id: parsed.id };
+  if (typeof parsed.joinedAt !== 'string' || typeof parsed.id !== 'string') {
+    throwInvalid();
   }
+  const joinedAt = new Date(parsed.joinedAt);
+  if (Number.isNaN(joinedAt.getTime())) {
+    throwInvalid();
+  }
+  let id: bigint;
+  try {
+    id = BigInt(parsed.id);
+  } catch {
+    throwInvalid();
+  }
+  return { joinedAt, id };
+}
+
+function throwInvalid(): never {
   throw new AppException('VALIDATION_INVALID_FORMAT', {
     message: 'cursor 형식이 올바르지 않습니다.',
   });

--- a/src/modules/club/utils/cursor.util.ts
+++ b/src/modules/club/utils/cursor.util.ts
@@ -1,0 +1,17 @@
+import { AppException } from '../../../common/errors/app.exception';
+import { decodeCursorRaw } from '../../../common/utils/cursor.util';
+
+export type AttendeesCursorPayload = {
+  joinedAt: string;
+  id: string;
+};
+
+export function decodeAttendeesCursor(cursor: string): AttendeesCursorPayload {
+  const parsed = decodeCursorRaw(cursor);
+  if (typeof parsed.joinedAt === 'string' && typeof parsed.id === 'string') {
+    return { joinedAt: parsed.joinedAt, id: parsed.id };
+  }
+  throw new AppException('VALIDATION_INVALID_FORMAT', {
+    message: 'cursor 형식이 올바르지 않습니다.',
+  });
+}


### PR DESCRIPTION
## 이슈 번호
close #197 

## 주요 변경사항
### 신규 API
  - `POST /v1/clubs/:clubId/meetings/:meetingId/attendees/me` — 정모 참석 (AUTO 정책만)
  - `DELETE /v1/clubs/:clubId/meetings/:meetingId/attendees/me` — 참석 취소 (soft delete, 호스트 본인 정모 불가)
  - `GET /v1/clubs/:clubId/meetings/:meetingId/attendees` — 참석자 목록 (cursor pagination, joinedAt ASC + id tie-break)

### 기존 동작 변경
  - `createMeeting`: 트랜잭션 안에서 호스트의 `ClubUser`를 `MeetingMember`로 자동 참석 처리
  - `joinMeeting` / `updateMeeting`: capacity / joinPolicy / deletedAt / 기존 멤버 검사를 `Meeting FOR UPDATE` row lock 트랜잭션 안에서 직접 수행 → 동시성 race 차단, repository를 truth source로 단일화
  - 재참석은 soft-deleted row를 `deletedAt = null` + `joinedAt = now()`로 revive (upsert)

### 검증/에러 처리
  - `decodeAttendeesCursor`가 Date/BigInt 파싱까지 책임지도록 보강 → 잘못된 cursor는 500 대신 `VALID-001` (422)
  - `RecurrenceShapeConstraint`의 `daysOfWeek` 금지 체크를 `!== undefined && !== null` 기준으로 통일 (scalar/빈 배열도 거절)
  - 신규 에러 코드 5개
    - `MEETING-004 MEETING_CAPACITY_EXCEEDED` (409)
    - `MEETING-005 MEETING_ALREADY_JOINED` (409)
    - `MEETING-006 MEETING_NOT_JOINED` (404)
    - `MEETING-007 MEETING_HOST_CANNOT_LEAVE` (403)
    - `MEETING-008 MEETING_APPROVAL_NOT_SUPPORTED` (501)
 ### 공통 유틸 리팩터
  - `src/common/utils/cursor.util.ts` 신규 — `encodeCursor<T>` / `decodeCursorRaw` primitive 추출
  - chat util은 thin wrapper로 축소, `decodeCursor` union을 `decodeMessageCursor` / `decodeRoomCursor`로 분리
  - `src/modules/club/utils/cursor.util.ts` 신규 — attendees용 `decodeAttendeesCursor`

## 테스트 결과 (스크린샷)
**정모 참석 성공**
<img width="1385" height="812" alt="image" src="https://github.com/user-attachments/assets/7d8a07a0-9f29-4cd9-861a-ba88536d6a75" />

**동호회 멤버가 아닌 유저가 정모 참석 시도**
<img width="1381" height="813" alt="image" src="https://github.com/user-attachments/assets/e18f0073-c9a1-4fe7-9027-dc0949cdaabc" />

**이미 참석 중인 유저의 요청**
<img width="1385" height="813" alt="image" src="https://github.com/user-attachments/assets/0b32d1e2-5bd2-4d76-86af-cee217ebbc1c" />

**재참석 요청**
<img width="1377" height="811" alt="image" src="https://github.com/user-attachments/assets/fc453798-b015-42d8-8d16-026033dd609b" />

**존재하지 않은 정모에 참석 요청**
<img width="1383" height="811" alt="image" src="https://github.com/user-attachments/assets/f4efaa7e-e92a-46af-b016-913d31fddc97" />

**삭제된 정모에 참석 요청**
<img width="1381" height="810" alt="image" src="https://github.com/user-attachments/assets/e8b93d9f-e2d4-4c22-8df4-745ffb903b77" />

**인원 제한**
<img width="1387" height="812" alt="image" src="https://github.com/user-attachments/assets/d629a71a-679d-466c-bd38-572e2e7f78c1" />

**승인 필요 정모에 참석 요청**
<img width="1382" height="813" alt="image" src="https://github.com/user-attachments/assets/ec448d6f-8615-4b05-bc25-f64321bb9f35" />

**정모 참석 취소 성공**
<img width="1380" height="813" alt="image" src="https://github.com/user-attachments/assets/5e3a13fe-1f59-4454-b9fe-974035519266" />

**참석하지 않은 유저가 취소 요청**
<img width="1387" height="811" alt="image" src="https://github.com/user-attachments/assets/b187f445-9f6f-4357-9c19-e686ea98b1c4" />

**중복 취소 요청**
<img width="1380" height="812" alt="image" src="https://github.com/user-attachments/assets/08cf55f6-8776-4cc2-96c5-f56b97aa2b70" />

**호스트가 본인 정모 취소 요청**
<img width="1386" height="812" alt="image" src="https://github.com/user-attachments/assets/f1df7dd1-d031-4440-a816-b56fc56d7ddf" />

**존재하지 않은 정모에 참석 취소 요청**
<img width="1390" height="805" alt="image" src="https://github.com/user-attachments/assets/eb989e98-e3d3-431e-91c4-02be2c4481b2" />

**삭제된 정모에 참석 취소 요청**
<img width="1380" height="813" alt="image" src="https://github.com/user-attachments/assets/bc602d85-7533-4dc0-a5ad-cc5a117ef5a7" />

**동호회 멤버가 아닌 유저가 참석 취소 요청**
<img width="1384" height="814" alt="image" src="https://github.com/user-attachments/assets/e1be60cd-1a66-4854-9e7d-025e5afd727a" />

**정모 참석자 목록 조회 성공**
<img width="1383" height="749" alt="image" src="https://github.com/user-attachments/assets/5febf146-0eaf-4119-a6ac-c6357ee0963f" />

**존재하지 않은 정모의 참석자 목록 조회 요청**
<img width="1384" height="811" alt="image" src="https://github.com/user-attachments/assets/2614e56b-b2d8-4177-b453-f43617853727" />

**동호회 멤버가 아닌 유저가 참석자 목록 조회 요청**
<img width="1382" height="814" alt="image" src="https://github.com/user-attachments/assets/7f7262d6-000d-414b-80b0-7fcbe8bf457e" />

## 참고 및 개선사항
  - `APPROVAL_REQUIRED` 정책은 디자인이 없어서 추후에 논의 후 구현 예정
  - chat 모듈 영향: `decodeCursor` union이 두 함수로 분리됨. 타입 안전성↑, 호출자 minor 수정 (mechanical)
