### PR TITLE
[EUM-14] [Feat] 댓글 api 구현

### DIFF
--- a/prisma/dbml/schema.dbml
+++ b/prisma/dbml/schema.dbml
@@ -528,6 +528,7 @@ Enum NotificationType {
   CHAT
   HEART
   ARTICLE
+  COMMENT
   PROFILE
   REMIND
   UPDATE

--- a/prisma/migrations/20260627000000_add_comment_notification_type/migration.sql
+++ b/prisma/migrations/20260627000000_add_comment_notification_type/migration.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "NotificationType" ADD VALUE IF NOT EXISTS 'COMMENT';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -59,6 +59,7 @@ enum NotificationType {
   CHAT
   HEART
   ARTICLE
+  COMMENT
   PROFILE
   REMIND
   UPDATE

--- a/src/common/errors/error-codes.ts
+++ b/src/common/errors/error-codes.ts
@@ -193,6 +193,28 @@ export const ERROR_DEFINITIONS = {
     message: '클럽 회원만 이용할 수 있는 기능이에요',
   },
 
+  // COMMENT
+  COMMENT_PARENT_NOT_FOUND: {
+    status: HttpStatus.NOT_FOUND,
+    code: 'COMMENT-001',
+    message: '부모 댓글을 찾을 수 없습니다.',
+  },
+  COMMENT_DEPTH_EXCEEDED: {
+    status: HttpStatus.BAD_REQUEST,
+    code: 'COMMENT-002',
+    message: '대댓글까지만 작성할 수 있습니다.',
+  },
+  COMMENT_NOT_FOUND: {
+    status: HttpStatus.NOT_FOUND,
+    code: 'COMMENT-003',
+    message: '댓글을 찾을 수 없습니다.',
+  },
+  COMMENT_FORBIDDEN_NOT_AUTHOR: {
+    status: HttpStatus.FORBIDDEN,
+    code: 'COMMENT-004',
+    message: '댓글 작성자만 삭제할 수 있습니다.',
+  },
+
   // CLUB
   CLUB_NOT_FOUND: {
     status: HttpStatus.NOT_FOUND,

--- a/src/modules/app/app.module.ts
+++ b/src/modules/app/app.module.ts
@@ -15,6 +15,7 @@ import { OnboardingModule } from '../onboarding/onboarding.module';
 import { ClubModule } from '../club/club.module';
 import { WebsocketCommonModule } from 'src/infra/websocket/websocket-common.module';
 import { ArticleModule } from '../article/article.module';
+import { CommentModule } from '../comment/comment.module';
 
 @Module({
   imports: [
@@ -41,6 +42,7 @@ import { ArticleModule } from '../article/article.module';
     NotificationModule,
     OnboardingModule,
     ClubModule,
+    CommentModule,
     AuthModule,
     UserModule,
     ArticleModule,

--- a/src/modules/club/club.module.ts
+++ b/src/modules/club/club.module.ts
@@ -10,5 +10,6 @@ import { MeetingRepository } from './repositories/meeting.repository';
   imports: [AuthModule, PrismaModule],
   controllers: [MeetingController],
   providers: [MeetingService, ClubRepository, MeetingRepository],
+  exports: [ClubRepository],
 })
 export class ClubModule {}

--- a/src/modules/comment/comment.module.ts
+++ b/src/modules/comment/comment.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { CommentController } from './controllers/comment.controller';
+import { CommentService } from './services/comment.service';
+import { CommentRepository } from './repositories/comment.repository';
+import { PrismaModule } from '../../infra/prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [CommentController],
+  providers: [CommentService, CommentRepository],
+  exports: [CommentService],
+})
+export class CommentModule {}

--- a/src/modules/comment/comment.module.ts
+++ b/src/modules/comment/comment.module.ts
@@ -4,10 +4,11 @@ import { CommentService } from './services/comment.service';
 import { CommentRepository } from './repositories/comment.repository';
 import { PrismaModule } from '../../infra/prisma/prisma.module';
 import { AuthModule } from '../auth/auth.module';
+import { ClubModule } from '../club/club.module';
 import { NotificationModule } from '../notification/notification.module';
 
 @Module({
-  imports: [PrismaModule, AuthModule, NotificationModule],
+  imports: [PrismaModule, AuthModule, ClubModule, NotificationModule],
   controllers: [CommentController],
   providers: [CommentService, CommentRepository],
   exports: [CommentService],

--- a/src/modules/comment/comment.module.ts
+++ b/src/modules/comment/comment.module.ts
@@ -3,9 +3,10 @@ import { CommentController } from './controllers/comment.controller';
 import { CommentService } from './services/comment.service';
 import { CommentRepository } from './repositories/comment.repository';
 import { PrismaModule } from '../../infra/prisma/prisma.module';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, AuthModule],
   controllers: [CommentController],
   providers: [CommentService, CommentRepository],
   exports: [CommentService],

--- a/src/modules/comment/comment.module.ts
+++ b/src/modules/comment/comment.module.ts
@@ -4,9 +4,10 @@ import { CommentService } from './services/comment.service';
 import { CommentRepository } from './repositories/comment.repository';
 import { PrismaModule } from '../../infra/prisma/prisma.module';
 import { AuthModule } from '../auth/auth.module';
+import { NotificationModule } from '../notification/notification.module';
 
 @Module({
-  imports: [PrismaModule, AuthModule],
+  imports: [PrismaModule, AuthModule, NotificationModule],
   controllers: [CommentController],
   providers: [CommentService, CommentRepository],
   exports: [CommentService],

--- a/src/modules/comment/controllers/comment.controller.spec.ts
+++ b/src/modules/comment/controllers/comment.controller.spec.ts
@@ -1,0 +1,25 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CommentController } from './comment.controller';
+import { CommentService } from '../services/comment.service';
+
+describe('CommentController', () => {
+  let controller: CommentController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CommentController],
+      providers: [
+        {
+          provide: CommentService,
+          useValue: {},
+        },
+      ],
+    }).compile();
+
+    controller = module.get<CommentController>(CommentController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/modules/comment/controllers/comment.controller.spec.ts
+++ b/src/modules/comment/controllers/comment.controller.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { CommentController } from './comment.controller';
 import { CommentService } from '../services/comment.service';
+import { AccessTokenGuard } from '../../auth/guards/access-token.guard';
 
 describe('CommentController', () => {
   let controller: CommentController;
@@ -14,7 +15,10 @@ describe('CommentController', () => {
           useValue: {},
         },
       ],
-    }).compile();
+    })
+      .overrideGuard(AccessTokenGuard)
+      .useValue({ canActivate: jest.fn(() => true) })
+      .compile();
 
     controller = module.get<CommentController>(CommentController);
   });

--- a/src/modules/comment/controllers/comment.controller.ts
+++ b/src/modules/comment/controllers/comment.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   Post,
   Query,
+  UseGuards,
 } from '@nestjs/common';
 import {
   ApiBadRequestResponse,
@@ -31,10 +32,8 @@ import {
   ListCommentsQueryDto,
   ListCommentsResponseDto,
 } from '../dtos/comment.dto';
-
-// TODO(auth): 인증 복구 PR 머지 후 아래 import/데코레이터를 되살리고 하드코딩 userId를 제거하세요.
-// import { AccessTokenGuard } from '../../auth/guards/access-token.guard';
-// import { RequiredUserId } from '../../auth/decorators';
+import { AccessTokenGuard } from '../../auth/guards/access-token.guard';
+import { RequiredUserId } from '../../auth/decorators';
 
 type ApiSuccessExample<T> = {
   resultType: 'SUCCESS';
@@ -57,8 +56,7 @@ function successExample<T>(path: string, data: T): ApiSuccessExample<T> {
 
 @ApiTags('Comments')
 @ApiBearerAuth('access-token')
-// TODO(auth): 인증 복구 PR 머지 후 주석 해제하세요.
-// @UseGuards(AccessTokenGuard)
+@UseGuards(AccessTokenGuard)
 @Controller('clubs/:clubId/articles/:articleId/comments')
 export class CommentController {
   constructor(private readonly commentService: CommentService) {}
@@ -67,7 +65,7 @@ export class CommentController {
   @ApiOperation({
     summary: '댓글 목록 조회',
     description:
-      '댓글은 날짜 내림차순으로만 정렬합니다. TODO(auth): 현재 인증 복구 전이라 userId=1로 임시 하드코딩되어 있습니다.',
+      '댓글은 날짜 내림차순으로만 정렬합니다.',
   })
   @ApiParam({ name: 'clubId', example: 1 })
   @ApiParam({ name: 'articleId', example: 1 })
@@ -127,7 +125,7 @@ export class CommentController {
     },
   })
   @ApiUnauthorizedResponse({
-    description: 'TODO(auth): 인증 복구 후 로그인 필요 응답',
+    description: '로그인 필요 응답',
   })
   @ApiForbiddenResponse({
     description: '클럽 멤버가 아니어서 댓글 조회 권한이 없음',
@@ -139,15 +137,11 @@ export class CommentController {
     description: 'cursor 또는 limit 형식 오류',
   })
   async listComments(
-    // TODO(auth): 인증 복구 PR 머지 후 아래 데코레이터로 교체하세요.
-    // @RequiredUserId() userId: number,
+    @RequiredUserId() userId: number,
     @Param('clubId', new ParsePositiveIntPipe()) clubId: number,
     @Param('articleId', new ParsePositiveIntPipe()) articleId: number,
     @Query() query: ListCommentsQueryDto,
   ): Promise<ListCommentsResponseDto> {
-    // TODO(auth): 임시 하드코딩. AuthGuard/RequiredUserId 복구 후 제거하세요.
-    const userId = 1;
-
     return this.commentService.listComments(userId, clubId, articleId, query);
   }
 
@@ -155,7 +149,7 @@ export class CommentController {
   @ApiOperation({
     summary: '댓글 작성',
     description:
-      'TODO(auth): 현재 인증 복구 전이라 userId=1로 임시 하드코딩되어 있습니다.',
+      '댓글을 작성합니다. 대댓글까지만 작성 가능합니다.',
   })
   @ApiParam({ name: 'clubId', example: 1 })
   @ApiParam({ name: 'articleId', example: 1 })
@@ -179,7 +173,7 @@ export class CommentController {
     },
   })
   @ApiUnauthorizedResponse({
-    description: 'TODO(auth): 인증 복구 후 로그인 필요 응답',
+    description: '로그인 필요 응답',
   })
   @ApiForbiddenResponse({
     description: '클럽 멤버가 아니어서 댓글 작성 권한이 없음',
@@ -190,14 +184,11 @@ export class CommentController {
   @ApiUnprocessableEntityResponse({ description: '입력값 형식 오류' })
   @ApiBadRequestResponse({ description: '대댓글까지만 작성 가능' })
   async createComment(
-    // TODO(auth): 인증 복구 PR 머지 후 아래 데코레이터로 교체하세요.
-    // @RequiredUserId() userId: number,
+    @RequiredUserId() userId: number,
     @Param('clubId', new ParsePositiveIntPipe()) clubId: number,
     @Param('articleId', new ParsePositiveIntPipe()) articleId: number,
     @Body() dto: CreateCommentRequestDto,
   ): Promise<CreateCommentResponseDto> {
-    // TODO(auth): 임시 하드코딩. AuthGuard/RequiredUserId 복구 후 제거하세요.
-    const userId = 1;
 
     return this.commentService.createComment(userId, clubId, articleId, dto);
   }
@@ -206,11 +197,11 @@ export class CommentController {
   @ApiOperation({
     summary: '댓글 삭제',
     description:
-      '댓글 작성자만 삭제할 수 있습니다. TODO(auth): 현재 인증 복구 전이라 userId=1로 임시 하드코딩되어 있습니다.',
+      '댓글 작성자만 삭제할 수 있습니다. 부모 댓글이 삭제되는 경우 대댓글도 함께 삭제됩니다.',
   })
   @ApiParam({ name: 'clubId', example: 1 })
-  @ApiParam({ name: 'articleId', example: 1024 })
-  @ApiParam({ name: 'commentId', example: 555 })
+  @ApiParam({ name: 'articleId', example: 1 })
+  @ApiParam({ name: 'commentId', example: 1 })
   @ApiOkResponse({
     description: '댓글 삭제 성공',
     schema: {
@@ -224,24 +215,21 @@ export class CommentController {
     },
   })
   @ApiUnauthorizedResponse({
-    description: 'TODO(auth): 인증 복구 후 로그인 필요 응답',
+    description: '로그인 필요 응답',
   })
   @ApiForbiddenResponse({
-    description: '클럽 멤버가 아니거나 댓글 작성자가 아니어서 삭제 권한이 없음',
+    description: '댓글 작성자가 아니어서 삭제 권한이 없음',
   })
   @ApiNotFoundResponse({
     description: '클럽, 게시글, 또는 댓글을 찾을 수 없음',
   })
   @ApiUnprocessableEntityResponse({ description: '파라미터 형식 오류' })
   async deleteComment(
-    // TODO(auth): 인증 복구 PR 머지 후 아래 데코레이터로 교체하세요.
-    // @RequiredUserId() userId: number,
+    @RequiredUserId() userId: number,
     @Param('clubId', new ParsePositiveIntPipe()) clubId: number,
     @Param('articleId', new ParsePositiveIntPipe()) articleId: number,
     @Param('commentId', new ParsePositiveIntPipe()) commentId: number,
   ): Promise<DeleteCommentResponseDto> {
-    // TODO(auth): 임시 하드코딩. AuthGuard/RequiredUserId 복구 후 제거하세요.
-    const userId = 1;
 
     return this.commentService.deleteComment(
       userId,

--- a/src/modules/comment/controllers/comment.controller.ts
+++ b/src/modules/comment/controllers/comment.controller.ts
@@ -1,0 +1,253 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Query,
+} from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiBearerAuth,
+  ApiBody,
+  ApiCreatedResponse,
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiTags,
+  ApiUnauthorizedResponse,
+  ApiUnprocessableEntityResponse,
+} from '@nestjs/swagger';
+import { ParsePositiveIntPipe } from '../../../common/pipes/parse-positive-int.pipe';
+import { CommentService } from '../services/comment.service';
+import {
+  CreateCommentRequestDto,
+  CreateCommentResponseDto,
+  DeleteCommentResponseDto,
+  ListCommentsQueryDto,
+  ListCommentsResponseDto,
+} from '../dtos/comment.dto';
+
+// TODO(auth): 인증 복구 PR 머지 후 아래 import/데코레이터를 되살리고 하드코딩 userId를 제거하세요.
+// import { AccessTokenGuard } from '../../auth/guards/access-token.guard';
+// import { RequiredUserId } from '../../auth/decorators';
+
+type ApiSuccessExample<T> = {
+  resultType: 'SUCCESS';
+  success: { data: T };
+  error: null;
+  meta: { timestamp: string; path: string };
+};
+
+function successExample<T>(path: string, data: T): ApiSuccessExample<T> {
+  return {
+    resultType: 'SUCCESS',
+    success: { data },
+    error: null,
+    meta: {
+      timestamp: '2026-05-01T15:20:00.000Z',
+      path,
+    },
+  };
+}
+
+@ApiTags('Comments')
+@ApiBearerAuth('access-token')
+// TODO(auth): 인증 복구 PR 머지 후 주석 해제하세요.
+// @UseGuards(AccessTokenGuard)
+@Controller('clubs/:clubId/articles/:articleId/comments')
+export class CommentController {
+  constructor(private readonly commentService: CommentService) {}
+
+  @Get()
+  @ApiOperation({
+    summary: '댓글 목록 조회',
+    description:
+      '댓글은 날짜 내림차순으로만 정렬합니다. TODO(auth): 현재 인증 복구 전이라 userId=1로 임시 하드코딩되어 있습니다.',
+  })
+  @ApiParam({ name: 'clubId', example: 1 })
+  @ApiParam({ name: 'articleId', example: 1 })
+  @ApiQuery({
+    name: 'cursor',
+    required: false,
+    description: '이전 응답의 nextCursor. 첫 조회 시 생략',
+    example: 'eyJpZCI6NTU0fQ==',
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    description: '가져올 댓글 개수. 기본 20, 최대 100',
+    example: 20,
+  })
+  @ApiOkResponse({
+    description: '댓글 목록 조회 성공',
+    schema: {
+      example: successExample('/api/v1/clubs/1/articles/1/comments', {
+        articleId: 1024,
+        totalCount: 8,
+        comments: [
+          {
+            commentId: 555,
+            parentCommentId: null,
+            depth: 0,
+            contents: '공감 가는 글이네요 :)',
+            isMine: false,
+            author: {
+              userId: 7,
+              nickname: '보이스마스터',
+              profileImageUrl: 'https://cdn.example.com/profile/7.jpg',
+              authority: 'HOST',
+            },
+            createdAt: '2026-05-01T15:20:00.000Z',
+            replies: [
+              {
+                commentId: 556,
+                parentCommentId: 555,
+                depth: 1,
+                contents: '감사합니다!',
+                isMine: true,
+                author: {
+                  userId: 42,
+                  nickname: '달콤한목소리',
+                  profileImageUrl: 'https://cdn.example.com/profile/42.jpg',
+                  authority: 'GENERAL',
+                },
+                createdAt: '2026-05-01T15:25:00.000Z',
+              },
+            ],
+          },
+        ],
+        nextCursor: 'eyJpZCI6NTU0fQ==',
+        hasMore: true,
+      }),
+    },
+  })
+  @ApiUnauthorizedResponse({
+    description: 'TODO(auth): 인증 복구 후 로그인 필요 응답',
+  })
+  @ApiForbiddenResponse({
+    description: '클럽 멤버가 아니어서 댓글 조회 권한이 없음',
+  })
+  @ApiNotFoundResponse({
+    description: '클럽 또는 게시글을 찾을 수 없음',
+  })
+  @ApiUnprocessableEntityResponse({
+    description: 'cursor 또는 limit 형식 오류',
+  })
+  async listComments(
+    // TODO(auth): 인증 복구 PR 머지 후 아래 데코레이터로 교체하세요.
+    // @RequiredUserId() userId: number,
+    @Param('clubId', new ParsePositiveIntPipe()) clubId: number,
+    @Param('articleId', new ParsePositiveIntPipe()) articleId: number,
+    @Query() query: ListCommentsQueryDto,
+  ): Promise<ListCommentsResponseDto> {
+    // TODO(auth): 임시 하드코딩. AuthGuard/RequiredUserId 복구 후 제거하세요.
+    const userId = 1;
+
+    return this.commentService.listComments(userId, clubId, articleId, query);
+  }
+
+  @Post()
+  @ApiOperation({
+    summary: '댓글 작성',
+    description:
+      'TODO(auth): 현재 인증 복구 전이라 userId=1로 임시 하드코딩되어 있습니다.',
+  })
+  @ApiParam({ name: 'clubId', example: 1 })
+  @ApiParam({ name: 'articleId', example: 1 })
+  @ApiBody({ type: CreateCommentRequestDto })
+  @ApiCreatedResponse({
+    description: '댓글 작성 성공',
+    schema: {
+      example: successExample('/api/v1/clubs/1/articles/1/comments', {
+        commentId: 555,
+        articleId: 1024,
+        parentCommentId: null,
+        depth: 0,
+        contents: '공감 가는 글이네요 :)',
+        author: {
+          userId: 42,
+          nickname: '달콤한목소리',
+          profileImageUrl: 'https://cdn.example.com/profile/42.jpg',
+        },
+        createdAt: '2026-05-01T15:20:00.000Z',
+      }),
+    },
+  })
+  @ApiUnauthorizedResponse({
+    description: 'TODO(auth): 인증 복구 후 로그인 필요 응답',
+  })
+  @ApiForbiddenResponse({
+    description: '클럽 멤버가 아니어서 댓글 작성 권한이 없음',
+  })
+  @ApiNotFoundResponse({
+    description: '클럽, 게시글, 또는 부모 댓글을 찾을 수 없음',
+  })
+  @ApiUnprocessableEntityResponse({ description: '입력값 형식 오류' })
+  @ApiBadRequestResponse({ description: '대댓글까지만 작성 가능' })
+  async createComment(
+    // TODO(auth): 인증 복구 PR 머지 후 아래 데코레이터로 교체하세요.
+    // @RequiredUserId() userId: number,
+    @Param('clubId', new ParsePositiveIntPipe()) clubId: number,
+    @Param('articleId', new ParsePositiveIntPipe()) articleId: number,
+    @Body() dto: CreateCommentRequestDto,
+  ): Promise<CreateCommentResponseDto> {
+    // TODO(auth): 임시 하드코딩. AuthGuard/RequiredUserId 복구 후 제거하세요.
+    const userId = 1;
+
+    return this.commentService.createComment(userId, clubId, articleId, dto);
+  }
+
+  @Delete(':commentId')
+  @ApiOperation({
+    summary: '댓글 삭제',
+    description:
+      '댓글 작성자만 삭제할 수 있습니다. TODO(auth): 현재 인증 복구 전이라 userId=1로 임시 하드코딩되어 있습니다.',
+  })
+  @ApiParam({ name: 'clubId', example: 1 })
+  @ApiParam({ name: 'articleId', example: 1024 })
+  @ApiParam({ name: 'commentId', example: 555 })
+  @ApiOkResponse({
+    description: '댓글 삭제 성공',
+    schema: {
+      example: successExample(
+        '/api/v1/clubs/1/articles/1024/comments/555',
+        {
+          commentId: 555,
+          deletedAt: '2026-05-01T15:25:00.000Z',
+        },
+      ),
+    },
+  })
+  @ApiUnauthorizedResponse({
+    description: 'TODO(auth): 인증 복구 후 로그인 필요 응답',
+  })
+  @ApiForbiddenResponse({
+    description: '클럽 멤버가 아니거나 댓글 작성자가 아니어서 삭제 권한이 없음',
+  })
+  @ApiNotFoundResponse({
+    description: '클럽, 게시글, 또는 댓글을 찾을 수 없음',
+  })
+  @ApiUnprocessableEntityResponse({ description: '파라미터 형식 오류' })
+  async deleteComment(
+    // TODO(auth): 인증 복구 PR 머지 후 아래 데코레이터로 교체하세요.
+    // @RequiredUserId() userId: number,
+    @Param('clubId', new ParsePositiveIntPipe()) clubId: number,
+    @Param('articleId', new ParsePositiveIntPipe()) articleId: number,
+    @Param('commentId', new ParsePositiveIntPipe()) commentId: number,
+  ): Promise<DeleteCommentResponseDto> {
+    // TODO(auth): 임시 하드코딩. AuthGuard/RequiredUserId 복구 후 제거하세요.
+    const userId = 1;
+
+    return this.commentService.deleteComment(
+      userId,
+      clubId,
+      articleId,
+      commentId,
+    );
+  }
+}

--- a/src/modules/comment/controllers/comment.controller.ts
+++ b/src/modules/comment/controllers/comment.controller.ts
@@ -64,8 +64,7 @@ export class CommentController {
   @Get()
   @ApiOperation({
     summary: '댓글 목록 조회',
-    description:
-      '댓글은 날짜 내림차순으로만 정렬합니다.',
+    description: '댓글은 날짜 내림차순으로만 정렬합니다.',
   })
   @ApiParam({ name: 'clubId', example: 1 })
   @ApiParam({ name: 'articleId', example: 1 })
@@ -148,8 +147,7 @@ export class CommentController {
   @Post()
   @ApiOperation({
     summary: '댓글 작성',
-    description:
-      '댓글을 작성합니다. 대댓글까지만 작성 가능합니다.',
+    description: '댓글을 작성합니다. 대댓글까지만 작성 가능합니다.',
   })
   @ApiParam({ name: 'clubId', example: 1 })
   @ApiParam({ name: 'articleId', example: 1 })
@@ -189,7 +187,6 @@ export class CommentController {
     @Param('articleId', new ParsePositiveIntPipe()) articleId: number,
     @Body() dto: CreateCommentRequestDto,
   ): Promise<CreateCommentResponseDto> {
-
     return this.commentService.createComment(userId, clubId, articleId, dto);
   }
 
@@ -205,13 +202,10 @@ export class CommentController {
   @ApiOkResponse({
     description: '댓글 삭제 성공',
     schema: {
-      example: successExample(
-        '/api/v1/clubs/1/articles/1024/comments/555',
-        {
-          commentId: 555,
-          deletedAt: '2026-05-01T15:25:00.000Z',
-        },
-      ),
+      example: successExample('/api/v1/clubs/1/articles/1024/comments/555', {
+        commentId: 555,
+        deletedAt: '2026-05-01T15:25:00.000Z',
+      }),
     },
   })
   @ApiUnauthorizedResponse({
@@ -230,7 +224,6 @@ export class CommentController {
     @Param('articleId', new ParsePositiveIntPipe()) articleId: number,
     @Param('commentId', new ParsePositiveIntPipe()) commentId: number,
   ): Promise<DeleteCommentResponseDto> {
-
     return this.commentService.deleteComment(
       userId,
       clubId,

--- a/src/modules/comment/dtos/comment.dto.ts
+++ b/src/modules/comment/dtos/comment.dto.ts
@@ -1,0 +1,206 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import {
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+  ValidateIf,
+} from 'class-validator';
+import { ClubAuthority, Prisma } from '@prisma/client';
+
+type CommentWithAuthor = Prisma.CommentGetPayload<{
+  include: {
+    user: {
+      select: {
+        id: true;
+        nickname: true;
+        profileImageUrl: true;
+      };
+    };
+  };
+}>;
+
+export class CreateCommentRequestDto {
+  @ApiProperty({ example: '공감 가는 글이네요 :)' })
+  @IsString()
+  @IsNotEmpty()
+  contents!: string;
+
+  @ApiProperty({
+    example: null,
+    nullable: true,
+    description: '대댓글이면 부모 댓글 id, 일반 댓글이면 null',
+  })
+  @ValidateIf((dto: CreateCommentRequestDto) => dto.parentCommentId !== null)
+  @Transform(({ value }) => (value === null ? null : Number(value)))
+  @IsInt()
+  @Min(1)
+  parentCommentId!: number | null;
+}
+
+export class CommentAuthorDto {
+  @ApiProperty({ example: 42 })
+  userId!: number;
+
+  @ApiProperty({ example: '달콤한목소리' })
+  nickname!: string;
+
+  @ApiProperty({ example: 'https://cdn.example.com/profile/42.jpg' })
+  profileImageUrl!: string;
+}
+
+export class CreateCommentResponseDto {
+  @ApiProperty({ example: 555 })
+  commentId!: number;
+
+  @ApiProperty({ example: 1024 })
+  articleId!: number;
+
+  @ApiProperty({ example: null, nullable: true })
+  parentCommentId!: number | null;
+
+  @ApiProperty({ example: 0 })
+  depth!: number;
+
+  @ApiProperty({ example: '공감 가는 글이네요 :)' })
+  contents!: string;
+
+  @ApiProperty({ type: CommentAuthorDto })
+  author!: CommentAuthorDto | null;
+
+  @ApiProperty({ example: '2026-05-01T15:20:00.000Z' })
+  createdAt!: string;
+
+  static from(entity: CommentWithAuthor): CreateCommentResponseDto {
+    return {
+      commentId: Number(entity.id),
+      articleId: Number(entity.articleId),
+      parentCommentId:
+        entity.parentCommentId === null ? null : Number(entity.parentCommentId),
+      depth: entity.depth,
+      contents: entity.contents,
+      author: entity.user
+        ? {
+            userId: Number(entity.user.id),
+            nickname: entity.user.nickname,
+            profileImageUrl: entity.user.profileImageUrl,
+          }
+        : null,
+      createdAt: entity.createdAt.toISOString(),
+    };
+  }
+}
+
+export class ListCommentsQueryDto {
+  @ApiProperty({
+    required: false,
+    example: 'eyJpZCI6NTU0fQ==',
+    description: '이전 응답의 nextCursor',
+  })
+  @IsOptional()
+  @IsString()
+  cursor?: string;
+
+  @ApiProperty({
+    required: false,
+    example: 20,
+    description: '가져올 댓글 개수. 기본 20, 최대 100',
+  })
+  @IsOptional()
+  @Transform(({ value }) => Number(value))
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number;
+}
+
+export class CommentListAuthorDto {
+  @ApiProperty({ example: 7 })
+  userId!: number;
+
+  @ApiProperty({ example: '보이스마스터' })
+  nickname!: string;
+
+  @ApiProperty({ example: 'https://cdn.example.com/profile/7.jpg' })
+  profileImageUrl!: string;
+
+  @ApiProperty({ enum: ClubAuthority, example: ClubAuthority.HOST })
+  authority!: ClubAuthority;
+}
+
+export class CommentReplyResponseDto {
+  @ApiProperty({ example: 556 })
+  commentId!: number;
+
+  @ApiProperty({ example: 555 })
+  parentCommentId!: number;
+
+  @ApiProperty({ example: 1 })
+  depth!: number;
+
+  @ApiProperty({ example: '감사합니다!' })
+  contents!: string;
+
+  @ApiProperty({ example: true })
+  isMine!: boolean;
+
+  @ApiProperty({ type: CommentListAuthorDto })
+  author!: CommentListAuthorDto | null;
+
+  @ApiProperty({ example: '2026-05-01T15:25:00.000Z' })
+  createdAt!: string;
+}
+
+export class CommentListItemResponseDto {
+  @ApiProperty({ example: 555 })
+  commentId!: number;
+
+  @ApiProperty({ example: null, nullable: true })
+  parentCommentId!: number | null;
+
+  @ApiProperty({ example: 0 })
+  depth!: number;
+
+  @ApiProperty({ example: '공감 가는 글이네요 :)' })
+  contents!: string;
+
+  @ApiProperty({ example: false })
+  isMine!: boolean;
+
+  @ApiProperty({ type: CommentListAuthorDto })
+  author!: CommentListAuthorDto | null;
+
+  @ApiProperty({ example: '2026-05-01T15:20:00.000Z' })
+  createdAt!: string;
+
+  @ApiProperty({ type: [CommentReplyResponseDto] })
+  replies!: CommentReplyResponseDto[];
+}
+
+export class ListCommentsResponseDto {
+  @ApiProperty({ example: 1024 })
+  articleId!: number;
+
+  @ApiProperty({ example: 8 })
+  totalCount!: number;
+
+  @ApiProperty({ type: [CommentListItemResponseDto] })
+  comments!: CommentListItemResponseDto[];
+
+  @ApiProperty({ example: 'eyJpZCI6NTU0fQ==', nullable: true })
+  nextCursor!: string | null;
+
+  @ApiProperty({ example: true })
+  hasMore!: boolean;
+}
+
+export class DeleteCommentResponseDto {
+  @ApiProperty({ example: 555 })
+  commentId!: number;
+
+  @ApiProperty({ example: '2026-05-01T15:25:00.000Z' })
+  deletedAt!: string;
+}

--- a/src/modules/comment/repositories/comment.repository.ts
+++ b/src/modules/comment/repositories/comment.repository.ts
@@ -23,7 +23,15 @@ export class CommentRepository {
         clubId,
         deletedAt: null,
       },
-      select: { id: true },
+      select: {
+        id: true,
+        userId: true,
+        user: {
+          select: {
+            nickname: true,
+          },
+        },
+      },
     });
   }
 

--- a/src/modules/comment/repositories/comment.repository.ts
+++ b/src/modules/comment/repositories/comment.repository.ts
@@ -1,20 +1,10 @@
 import { Injectable } from '@nestjs/common';
-import { ClubUserStatus, Prisma } from '@prisma/client';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../../infra/prisma/prisma.service';
 
 @Injectable()
 export class CommentRepository {
   constructor(private readonly prisma: PrismaService) {}
-
-  findClubById(clubId: bigint) {
-    return this.prisma.club.findUnique({
-      where: { id: clubId },
-      select: {
-        id: true,
-        deletedAt: true,
-      },
-    });
-  }
 
   findArticleByClubId(clubId: bigint, articleId: bigint) {
     return this.prisma.article.findFirst({
@@ -32,18 +22,6 @@ export class CommentRepository {
           },
         },
       },
-    });
-  }
-
-  findActiveClubUser(clubId: bigint, userId: bigint) {
-    return this.prisma.clubUser.findFirst({
-      where: {
-        userId,
-        clubId,
-        status: ClubUserStatus.ACTIVE,
-        leftAt: null,
-      },
-      select: { id: true },
     });
   }
 

--- a/src/modules/comment/repositories/comment.repository.ts
+++ b/src/modules/comment/repositories/comment.repository.ts
@@ -49,6 +49,12 @@ export class CommentRepository {
       select: {
         id: true,
         depth: true,
+        userId: true,
+        user: {
+          select: {
+            nickname: true,
+          },
+        },
       },
     });
   }

--- a/src/modules/comment/repositories/comment.repository.ts
+++ b/src/modules/comment/repositories/comment.repository.ts
@@ -63,6 +63,8 @@ export class CommentRepository {
       select: {
         id: true,
         userId: true,
+        parentCommentId: true,
+        depth: true,
       },
     });
   }
@@ -98,7 +100,16 @@ export class CommentRepository {
         articleId,
         parentCommentId: null,
         depth: 0,
-        deletedAt: null,
+        OR: [
+          { deletedAt: null },
+          {
+            replies: {
+              some: {
+                deletedAt: null,
+              },
+            },
+          },
+        ],
       },
       select: {
         id: true,
@@ -118,16 +129,33 @@ export class CommentRepository {
         articleId: params.articleId,
         parentCommentId: null,
         depth: 0,
-        deletedAt: null,
-        ...(params.cursor && {
-          OR: [
-            { createdAt: { lt: params.cursor.createdAt } },
-            {
-              createdAt: params.cursor.createdAt,
-              id: { lt: params.cursor.id },
-            },
-          ],
-        }),
+        AND: [
+          {
+            OR: [
+              { deletedAt: null },
+              {
+                replies: {
+                  some: {
+                    deletedAt: null,
+                  },
+                },
+              },
+            ],
+          },
+          ...(params.cursor
+            ? [
+                {
+                  OR: [
+                    { createdAt: { lt: params.cursor.createdAt } },
+                    {
+                      createdAt: params.cursor.createdAt,
+                      id: { lt: params.cursor.id },
+                    },
+                  ],
+                },
+              ]
+            : []),
+        ],
       },
       orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
       take: params.limit + 1,
@@ -169,10 +197,35 @@ export class CommentRepository {
     });
   }
 
+  existsActiveReply(parentCommentId: bigint) {
+    return this.prisma.comment.findFirst({
+      where: {
+        parentCommentId,
+        deletedAt: null,
+      },
+      select: { id: true },
+    });
+  }
+
   softDeleteComment(commentId: bigint, deletedAt: Date) {
     return this.prisma.comment.update({
       where: { id: commentId },
       data: { deletedAt },
+      select: {
+        id: true,
+        deletedAt: true,
+      },
+    });
+  }
+
+  softDeleteParentCommentWithReplies(commentId: bigint, deletedAt: Date) {
+    return this.prisma.comment.update({
+      where: { id: commentId },
+      data: {
+        contents: '(삭제된 댓글입니다)',
+        userId: null,
+        deletedAt,
+      },
       select: {
         id: true,
         deletedAt: true,

--- a/src/modules/comment/repositories/comment.repository.ts
+++ b/src/modules/comment/repositories/comment.repository.ts
@@ -1,0 +1,182 @@
+import { Injectable } from '@nestjs/common';
+import { ClubUserStatus, Prisma } from '@prisma/client';
+import { PrismaService } from '../../../infra/prisma/prisma.service';
+
+@Injectable()
+export class CommentRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  findClubById(clubId: bigint) {
+    return this.prisma.club.findUnique({
+      where: { id: clubId },
+      select: {
+        id: true,
+        deletedAt: true,
+      },
+    });
+  }
+
+  findArticleByClubId(clubId: bigint, articleId: bigint) {
+    return this.prisma.article.findFirst({
+      where: {
+        id: articleId,
+        clubId,
+        deletedAt: null,
+      },
+      select: { id: true },
+    });
+  }
+
+  findActiveClubUser(clubId: bigint, userId: bigint) {
+    return this.prisma.clubUser.findFirst({
+      where: {
+        userId,
+        clubId,
+        status: ClubUserStatus.ACTIVE,
+        leftAt: null,
+      },
+      select: { id: true },
+    });
+  }
+
+  findParentComment(articleId: bigint, parentCommentId: bigint) {
+    return this.prisma.comment.findFirst({
+      where: {
+        id: parentCommentId,
+        articleId,
+        deletedAt: null,
+      },
+      select: {
+        id: true,
+        depth: true,
+      },
+    });
+  }
+
+  findCommentByArticleId(articleId: bigint, commentId: bigint) {
+    return this.prisma.comment.findFirst({
+      where: {
+        id: commentId,
+        articleId,
+        deletedAt: null,
+      },
+      select: {
+        id: true,
+        userId: true,
+      },
+    });
+  }
+
+  createComment(data: Prisma.CommentUncheckedCreateInput) {
+    return this.prisma.comment.create({
+      data,
+      include: {
+        user: {
+          select: {
+            id: true,
+            nickname: true,
+            profileImageUrl: true,
+          },
+        },
+      },
+    });
+  }
+
+  countComments(articleId: bigint) {
+    return this.prisma.comment.count({
+      where: {
+        articleId,
+        deletedAt: null,
+      },
+    });
+  }
+
+  findCommentCursor(articleId: bigint, commentId: bigint) {
+    return this.prisma.comment.findFirst({
+      where: {
+        id: commentId,
+        articleId,
+        parentCommentId: null,
+        depth: 0,
+        deletedAt: null,
+      },
+      select: {
+        id: true,
+        createdAt: true,
+      },
+    });
+  }
+
+  findCommentsWithReplies(params: {
+    clubId: bigint;
+    articleId: bigint;
+    limit: number;
+    cursor?: { id: bigint; createdAt: Date };
+  }) {
+    return this.prisma.comment.findMany({
+      where: {
+        articleId: params.articleId,
+        parentCommentId: null,
+        depth: 0,
+        deletedAt: null,
+        ...(params.cursor && {
+          OR: [
+            { createdAt: { lt: params.cursor.createdAt } },
+            {
+              createdAt: params.cursor.createdAt,
+              id: { lt: params.cursor.id },
+            },
+          ],
+        }),
+      },
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+      take: params.limit + 1,
+      include: {
+        user: {
+          select: {
+            id: true,
+            nickname: true,
+            profileImageUrl: true,
+            clubUsers: {
+              where: { clubId: params.clubId },
+              select: { authority: true },
+              take: 1,
+            },
+          },
+        },
+        replies: {
+          where: {
+            depth: 1,
+            deletedAt: null,
+          },
+          orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+          include: {
+            user: {
+              select: {
+                id: true,
+                nickname: true,
+                profileImageUrl: true,
+                clubUsers: {
+                  where: { clubId: params.clubId },
+                  select: { authority: true },
+                  take: 1,
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+  }
+
+  softDeleteComment(commentId: bigint, deletedAt: Date) {
+    return this.prisma.comment.update({
+      where: { id: commentId },
+      data: { deletedAt },
+      select: {
+        id: true,
+        deletedAt: true,
+      },
+    });
+  }
+}

--- a/src/modules/comment/services/comment.service.spec.ts
+++ b/src/modules/comment/services/comment.service.spec.ts
@@ -16,7 +16,9 @@ describe('CommentService', () => {
     findCommentCursor: jest.fn(),
     findCommentsWithReplies: jest.fn(),
     findCommentByArticleId: jest.fn(),
+    existsActiveReply: jest.fn(),
     softDeleteComment: jest.fn(),
+    softDeleteParentCommentWithReplies: jest.fn(),
   };
 
   const userId = 1;
@@ -247,6 +249,8 @@ describe('CommentService', () => {
     repository.findCommentByArticleId.mockResolvedValue({
       id: 555n,
       userId: 2n,
+      parentCommentId: null,
+      depth: 0,
     });
 
     await expect(
@@ -255,16 +259,22 @@ describe('CommentService', () => {
       internalCode: 'COMMENT_FORBIDDEN_NOT_AUTHOR',
     });
     expect(repository.findActiveClubUser).not.toHaveBeenCalled();
+    expect(repository.existsActiveReply).not.toHaveBeenCalled();
     expect(repository.softDeleteComment).not.toHaveBeenCalled();
+    expect(
+      repository.softDeleteParentCommentWithReplies,
+    ).not.toHaveBeenCalled();
   });
 
-  it('댓글을 삭제한다', async () => {
+  it('자식 댓글은 그대로 soft delete 한다', async () => {
     const deletedAt = new Date('2026-05-01T15:25:00.000Z');
     repository.findClubById.mockResolvedValue({ id: 1n, deletedAt: null });
     repository.findArticleByClubId.mockResolvedValue({ id: 1n });
     repository.findCommentByArticleId.mockResolvedValue({
       id: 555n,
       userId: 1n,
+      parentCommentId: 100n,
+      depth: 1,
     });
     repository.softDeleteComment.mockResolvedValue({
       id: 555n,
@@ -278,7 +288,73 @@ describe('CommentService', () => {
       deletedAt: deletedAt.toISOString(),
     });
     expect(repository.findActiveClubUser).not.toHaveBeenCalled();
+    expect(repository.existsActiveReply).not.toHaveBeenCalled();
     expect(repository.softDeleteComment).toHaveBeenCalledWith(
+      555n,
+      expect.any(Date),
+    );
+    expect(
+      repository.softDeleteParentCommentWithReplies,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('자식 댓글이 없는 부모 댓글은 그대로 soft delete 한다', async () => {
+    const deletedAt = new Date('2026-05-01T15:25:00.000Z');
+    repository.findClubById.mockResolvedValue({ id: 1n, deletedAt: null });
+    repository.findArticleByClubId.mockResolvedValue({ id: 1n });
+    repository.findCommentByArticleId.mockResolvedValue({
+      id: 555n,
+      userId: 1n,
+      parentCommentId: null,
+      depth: 0,
+    });
+    repository.existsActiveReply.mockResolvedValue(null);
+    repository.softDeleteComment.mockResolvedValue({
+      id: 555n,
+      deletedAt,
+    });
+
+    const result = await service.deleteComment(userId, clubId, articleId, 555);
+
+    expect(result).toEqual({
+      commentId: 555,
+      deletedAt: deletedAt.toISOString(),
+    });
+    expect(repository.existsActiveReply).toHaveBeenCalledWith(555n);
+    expect(repository.softDeleteComment).toHaveBeenCalledWith(
+      555n,
+      expect.any(Date),
+    );
+    expect(
+      repository.softDeleteParentCommentWithReplies,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('자식 댓글이 있는 부모 댓글은 내용과 작성자를 마스킹하고 soft delete 한다', async () => {
+    const deletedAt = new Date('2026-05-01T15:25:00.000Z');
+    repository.findClubById.mockResolvedValue({ id: 1n, deletedAt: null });
+    repository.findArticleByClubId.mockResolvedValue({ id: 1n });
+    repository.findCommentByArticleId.mockResolvedValue({
+      id: 555n,
+      userId: 1n,
+      parentCommentId: null,
+      depth: 0,
+    });
+    repository.existsActiveReply.mockResolvedValue({ id: 556n });
+    repository.softDeleteParentCommentWithReplies.mockResolvedValue({
+      id: 555n,
+      deletedAt,
+    });
+
+    const result = await service.deleteComment(userId, clubId, articleId, 555);
+
+    expect(result).toEqual({
+      commentId: 555,
+      deletedAt: deletedAt.toISOString(),
+    });
+    expect(repository.existsActiveReply).toHaveBeenCalledWith(555n);
+    expect(repository.softDeleteComment).not.toHaveBeenCalled();
+    expect(repository.softDeleteParentCommentWithReplies).toHaveBeenCalledWith(
       555n,
       expect.any(Date),
     );

--- a/src/modules/comment/services/comment.service.spec.ts
+++ b/src/modules/comment/services/comment.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
 import { ClubAuthority, NotificationType } from '@prisma/client';
 import { CommentService } from './comment.service';
 import { CommentRepository } from '../repositories/comment.repository';
@@ -127,6 +128,50 @@ describe('CommentService', () => {
       '댓글작성자님이 게시글작성자님의 게시물에 댓글을 남겼어요.',
       1,
     );
+  });
+
+  it('알림 생성에 실패해도 댓글 작성 응답은 성공한다', async () => {
+    const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+
+    repository.findClubById.mockResolvedValue({ id: 1n, deletedAt: null });
+    repository.findArticleByClubId.mockResolvedValue({
+      id: 1n,
+      userId: 2n,
+      user: { nickname: '게시글작성자' },
+    });
+    repository.findActiveClubUser.mockResolvedValue({ id: 10n });
+    repository.createComment.mockResolvedValue({
+      id: 555n,
+      articleId: 1n,
+      parentCommentId: null,
+      depth: 0,
+      contents: '공감 가는 글이네요 :)',
+      createdAt: new Date('2026-05-01T15:20:00.000Z'),
+      user: {
+        id: 1n,
+        nickname: '댓글작성자',
+        profileImageUrl: 'https://cdn.example.com/profile/1.jpg',
+      },
+    });
+    notificationService.createNotification.mockRejectedValue(
+      new Error('notification failed'),
+    );
+
+    const result = await service.createComment(userId, clubId, articleId, {
+      contents: '공감 가는 글이네요 :)',
+      parentCommentId: null,
+    });
+
+    expect(result).toMatchObject({
+      commentId: 555,
+      articleId,
+      contents: '공감 가는 글이네요 :)',
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('createComment notification failed'),
+    );
+
+    warnSpy.mockRestore();
   });
 
   it('답글을 작성하면 부모 댓글 작성자에게 알림을 생성한다', async () => {

--- a/src/modules/comment/services/comment.service.spec.ts
+++ b/src/modules/comment/services/comment.service.spec.ts
@@ -227,10 +227,23 @@ describe('CommentService', () => {
     );
   });
 
+  it('클럽 멤버가 아니면 댓글 목록 조회가 거부된다', async () => {
+    repository.findClubById.mockResolvedValue({ id: 1n, deletedAt: null });
+    repository.findArticleByClubId.mockResolvedValue({ id: 1n });
+    repository.findActiveClubUser.mockResolvedValue(null);
+
+    await expect(
+      service.listComments(userId, clubId, articleId, {}),
+    ).rejects.toMatchObject({
+      internalCode: 'CLUB_FORBIDDEN_NOT_MEMBER',
+    });
+    expect(repository.countComments).not.toHaveBeenCalled();
+    expect(repository.findCommentsWithReplies).not.toHaveBeenCalled();
+  });
+
   it('댓글 작성자가 아니면 삭제가 거부된다', async () => {
     repository.findClubById.mockResolvedValue({ id: 1n, deletedAt: null });
     repository.findArticleByClubId.mockResolvedValue({ id: 1n });
-    repository.findActiveClubUser.mockResolvedValue({ id: 10n });
     repository.findCommentByArticleId.mockResolvedValue({
       id: 555n,
       userId: 2n,
@@ -241,6 +254,7 @@ describe('CommentService', () => {
     ).rejects.toMatchObject({
       internalCode: 'COMMENT_FORBIDDEN_NOT_AUTHOR',
     });
+    expect(repository.findActiveClubUser).not.toHaveBeenCalled();
     expect(repository.softDeleteComment).not.toHaveBeenCalled();
   });
 
@@ -248,7 +262,6 @@ describe('CommentService', () => {
     const deletedAt = new Date('2026-05-01T15:25:00.000Z');
     repository.findClubById.mockResolvedValue({ id: 1n, deletedAt: null });
     repository.findArticleByClubId.mockResolvedValue({ id: 1n });
-    repository.findActiveClubUser.mockResolvedValue({ id: 10n });
     repository.findCommentByArticleId.mockResolvedValue({
       id: 555n,
       userId: 1n,
@@ -264,6 +277,7 @@ describe('CommentService', () => {
       commentId: 555,
       deletedAt: deletedAt.toISOString(),
     });
+    expect(repository.findActiveClubUser).not.toHaveBeenCalled();
     expect(repository.softDeleteComment).toHaveBeenCalledWith(
       555n,
       expect.any(Date),

--- a/src/modules/comment/services/comment.service.spec.ts
+++ b/src/modules/comment/services/comment.service.spec.ts
@@ -4,14 +4,13 @@ import { ClubAuthority, NotificationType } from '@prisma/client';
 import { CommentService } from './comment.service';
 import { CommentRepository } from '../repositories/comment.repository';
 import { AppException } from '../../../common/errors/app.exception';
+import { ClubRepository } from '../../club/repositories/club.repository';
 import { NotificationService } from '../../notification/services/notification.service';
 
 describe('CommentService', () => {
   let service: CommentService;
   const repository = {
-    findClubById: jest.fn(),
     findArticleByClubId: jest.fn(),
-    findActiveClubUser: jest.fn(),
     findParentComment: jest.fn(),
     createComment: jest.fn(),
     countComments: jest.fn(),
@@ -21,6 +20,10 @@ describe('CommentService', () => {
     existsActiveReply: jest.fn(),
     softDeleteComment: jest.fn(),
     softDeleteParentCommentWithReplies: jest.fn(),
+  };
+  const clubRepository = {
+    findById: jest.fn(),
+    findActiveClubUser: jest.fn(),
   };
   const notificationService = {
     createNotification: jest.fn(),
@@ -32,6 +35,7 @@ describe('CommentService', () => {
 
   beforeEach(async () => {
     Object.values(repository).forEach((mock) => mock.mockReset());
+    Object.values(clubRepository).forEach((mock) => mock.mockReset());
     Object.values(notificationService).forEach((mock) => mock.mockReset());
 
     const module: TestingModule = await Test.createTestingModule({
@@ -40,6 +44,10 @@ describe('CommentService', () => {
         {
           provide: CommentRepository,
           useValue: repository,
+        },
+        {
+          provide: ClubRepository,
+          useValue: clubRepository,
         },
         {
           provide: NotificationService,
@@ -56,9 +64,9 @@ describe('CommentService', () => {
   });
 
   it('댓글을 작성한다', async () => {
-    repository.findClubById.mockResolvedValue({ id: 1n, deletedAt: null });
+    clubRepository.findById.mockResolvedValue({ id: 1n, deletedAt: null });
     repository.findArticleByClubId.mockResolvedValue({ id: 1n });
-    repository.findActiveClubUser.mockResolvedValue({ id: 10n });
+    clubRepository.findActiveClubUser.mockResolvedValue({ id: 10n });
     repository.createComment.mockResolvedValue({
       id: 555n,
       articleId: 1n,
@@ -95,13 +103,13 @@ describe('CommentService', () => {
   });
 
   it('게시글에 댓글을 작성하면 게시글 작성자에게 알림을 생성한다', async () => {
-    repository.findClubById.mockResolvedValue({ id: 1n, deletedAt: null });
+    clubRepository.findById.mockResolvedValue({ id: 1n, deletedAt: null });
     repository.findArticleByClubId.mockResolvedValue({
       id: 1n,
       userId: 2n,
       user: { nickname: '게시글작성자' },
     });
-    repository.findActiveClubUser.mockResolvedValue({ id: 10n });
+    clubRepository.findActiveClubUser.mockResolvedValue({ id: 10n });
     repository.createComment.mockResolvedValue({
       id: 555n,
       articleId: 1n,
@@ -133,13 +141,13 @@ describe('CommentService', () => {
   it('알림 생성에 실패해도 댓글 작성 응답은 성공한다', async () => {
     const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
 
-    repository.findClubById.mockResolvedValue({ id: 1n, deletedAt: null });
+    clubRepository.findById.mockResolvedValue({ id: 1n, deletedAt: null });
     repository.findArticleByClubId.mockResolvedValue({
       id: 1n,
       userId: 2n,
       user: { nickname: '게시글작성자' },
     });
-    repository.findActiveClubUser.mockResolvedValue({ id: 10n });
+    clubRepository.findActiveClubUser.mockResolvedValue({ id: 10n });
     repository.createComment.mockResolvedValue({
       id: 555n,
       articleId: 1n,
@@ -175,9 +183,9 @@ describe('CommentService', () => {
   });
 
   it('답글을 작성하면 부모 댓글 작성자에게 알림을 생성한다', async () => {
-    repository.findClubById.mockResolvedValue({ id: 1n, deletedAt: null });
+    clubRepository.findById.mockResolvedValue({ id: 1n, deletedAt: null });
     repository.findArticleByClubId.mockResolvedValue({ id: 1n });
-    repository.findActiveClubUser.mockResolvedValue({ id: 10n });
+    clubRepository.findActiveClubUser.mockResolvedValue({ id: 10n });
     repository.findParentComment.mockResolvedValue({
       id: 555n,
       depth: 0,
@@ -213,9 +221,9 @@ describe('CommentService', () => {
   });
 
   it('내 댓글에 내가 답글을 작성하면 알림을 생성하지 않는다', async () => {
-    repository.findClubById.mockResolvedValue({ id: 1n, deletedAt: null });
+    clubRepository.findById.mockResolvedValue({ id: 1n, deletedAt: null });
     repository.findArticleByClubId.mockResolvedValue({ id: 1n });
-    repository.findActiveClubUser.mockResolvedValue({ id: 10n });
+    clubRepository.findActiveClubUser.mockResolvedValue({ id: 10n });
     repository.findParentComment.mockResolvedValue({
       id: 555n,
       depth: 0,
@@ -245,9 +253,9 @@ describe('CommentService', () => {
   });
 
   it('클럽 멤버가 아니면 댓글 작성이 거부된다', async () => {
-    repository.findClubById.mockResolvedValue({ id: 1n, deletedAt: null });
+    clubRepository.findById.mockResolvedValue({ id: 1n, deletedAt: null });
     repository.findArticleByClubId.mockResolvedValue({ id: 1n });
-    repository.findActiveClubUser.mockResolvedValue(null);
+    clubRepository.findActiveClubUser.mockResolvedValue(null);
 
     await expect(
       service.createComment(userId, clubId, articleId, {
@@ -261,9 +269,9 @@ describe('CommentService', () => {
   });
 
   it('부모 댓글이 대댓글이면 COMMENT_DEPTH_EXCEEDED', async () => {
-    repository.findClubById.mockResolvedValue({ id: 1n, deletedAt: null });
+    clubRepository.findById.mockResolvedValue({ id: 1n, deletedAt: null });
     repository.findArticleByClubId.mockResolvedValue({ id: 1n });
-    repository.findActiveClubUser.mockResolvedValue({ id: 10n });
+    clubRepository.findActiveClubUser.mockResolvedValue({ id: 10n });
     repository.findParentComment.mockResolvedValue({ id: 2n, depth: 1 });
 
     await expect(
@@ -278,9 +286,9 @@ describe('CommentService', () => {
   });
 
   it('댓글 목록을 조회한다', async () => {
-    repository.findClubById.mockResolvedValue({ id: 1n, deletedAt: null });
+    clubRepository.findById.mockResolvedValue({ id: 1n, deletedAt: null });
     repository.findArticleByClubId.mockResolvedValue({ id: 1n });
-    repository.findActiveClubUser.mockResolvedValue({ id: 10n });
+    clubRepository.findActiveClubUser.mockResolvedValue({ id: 10n });
     repository.countComments.mockResolvedValue(2);
     repository.findCommentsWithReplies.mockResolvedValue([
       {
@@ -342,9 +350,9 @@ describe('CommentService', () => {
   });
 
   it('limit보다 결과가 많으면 nextCursor와 hasMore를 내려준다', async () => {
-    repository.findClubById.mockResolvedValue({ id: 1n, deletedAt: null });
+    clubRepository.findById.mockResolvedValue({ id: 1n, deletedAt: null });
     repository.findArticleByClubId.mockResolvedValue({ id: 1n });
-    repository.findActiveClubUser.mockResolvedValue({ id: 10n });
+    clubRepository.findActiveClubUser.mockResolvedValue({ id: 10n });
     repository.countComments.mockResolvedValue(2);
     repository.findCommentsWithReplies.mockResolvedValue([
       {
@@ -391,9 +399,9 @@ describe('CommentService', () => {
   });
 
   it('클럽 멤버가 아니면 댓글 목록 조회가 거부된다', async () => {
-    repository.findClubById.mockResolvedValue({ id: 1n, deletedAt: null });
+    clubRepository.findById.mockResolvedValue({ id: 1n, deletedAt: null });
     repository.findArticleByClubId.mockResolvedValue({ id: 1n });
-    repository.findActiveClubUser.mockResolvedValue(null);
+    clubRepository.findActiveClubUser.mockResolvedValue(null);
 
     await expect(
       service.listComments(userId, clubId, articleId, {}),
@@ -405,7 +413,7 @@ describe('CommentService', () => {
   });
 
   it('댓글 작성자가 아니면 삭제가 거부된다', async () => {
-    repository.findClubById.mockResolvedValue({ id: 1n, deletedAt: null });
+    clubRepository.findById.mockResolvedValue({ id: 1n, deletedAt: null });
     repository.findArticleByClubId.mockResolvedValue({ id: 1n });
     repository.findCommentByArticleId.mockResolvedValue({
       id: 555n,
@@ -419,7 +427,7 @@ describe('CommentService', () => {
     ).rejects.toMatchObject({
       internalCode: 'COMMENT_FORBIDDEN_NOT_AUTHOR',
     });
-    expect(repository.findActiveClubUser).not.toHaveBeenCalled();
+    expect(clubRepository.findActiveClubUser).not.toHaveBeenCalled();
     expect(repository.existsActiveReply).not.toHaveBeenCalled();
     expect(repository.softDeleteComment).not.toHaveBeenCalled();
     expect(
@@ -429,7 +437,7 @@ describe('CommentService', () => {
 
   it('자식 댓글은 그대로 soft delete 한다', async () => {
     const deletedAt = new Date('2026-05-01T15:25:00.000Z');
-    repository.findClubById.mockResolvedValue({ id: 1n, deletedAt: null });
+    clubRepository.findById.mockResolvedValue({ id: 1n, deletedAt: null });
     repository.findArticleByClubId.mockResolvedValue({ id: 1n });
     repository.findCommentByArticleId.mockResolvedValue({
       id: 555n,
@@ -448,7 +456,7 @@ describe('CommentService', () => {
       commentId: 555,
       deletedAt: deletedAt.toISOString(),
     });
-    expect(repository.findActiveClubUser).not.toHaveBeenCalled();
+    expect(clubRepository.findActiveClubUser).not.toHaveBeenCalled();
     expect(repository.existsActiveReply).not.toHaveBeenCalled();
     expect(repository.softDeleteComment).toHaveBeenCalledWith(
       555n,
@@ -461,7 +469,7 @@ describe('CommentService', () => {
 
   it('자식 댓글이 없는 부모 댓글은 그대로 soft delete 한다', async () => {
     const deletedAt = new Date('2026-05-01T15:25:00.000Z');
-    repository.findClubById.mockResolvedValue({ id: 1n, deletedAt: null });
+    clubRepository.findById.mockResolvedValue({ id: 1n, deletedAt: null });
     repository.findArticleByClubId.mockResolvedValue({ id: 1n });
     repository.findCommentByArticleId.mockResolvedValue({
       id: 555n,
@@ -493,7 +501,7 @@ describe('CommentService', () => {
 
   it('자식 댓글이 있는 부모 댓글은 내용과 작성자를 마스킹하고 soft delete 한다', async () => {
     const deletedAt = new Date('2026-05-01T15:25:00.000Z');
-    repository.findClubById.mockResolvedValue({ id: 1n, deletedAt: null });
+    clubRepository.findById.mockResolvedValue({ id: 1n, deletedAt: null });
     repository.findArticleByClubId.mockResolvedValue({ id: 1n });
     repository.findCommentByArticleId.mockResolvedValue({
       id: 555n,

--- a/src/modules/comment/services/comment.service.spec.ts
+++ b/src/modules/comment/services/comment.service.spec.ts
@@ -1,0 +1,272 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ClubAuthority } from '@prisma/client';
+import { CommentService } from './comment.service';
+import { CommentRepository } from '../repositories/comment.repository';
+import { AppException } from '../../../common/errors/app.exception';
+
+describe('CommentService', () => {
+  let service: CommentService;
+  const repository = {
+    findClubById: jest.fn(),
+    findArticleByClubId: jest.fn(),
+    findActiveClubUser: jest.fn(),
+    findParentComment: jest.fn(),
+    createComment: jest.fn(),
+    countComments: jest.fn(),
+    findCommentCursor: jest.fn(),
+    findCommentsWithReplies: jest.fn(),
+    findCommentByArticleId: jest.fn(),
+    softDeleteComment: jest.fn(),
+  };
+
+  const userId = 1;
+  const clubId = 1;
+  const articleId = 1;
+
+  beforeEach(async () => {
+    Object.values(repository).forEach((mock) => mock.mockReset());
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CommentService,
+        {
+          provide: CommentRepository,
+          useValue: repository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<CommentService>(CommentService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('댓글을 작성한다', async () => {
+    repository.findClubById.mockResolvedValue({ id: 1n, deletedAt: null });
+    repository.findArticleByClubId.mockResolvedValue({ id: 1n });
+    repository.findActiveClubUser.mockResolvedValue({ id: 10n });
+    repository.createComment.mockResolvedValue({
+      id: 555n,
+      articleId: 1n,
+      parentCommentId: null,
+      depth: 0,
+      contents: '공감 가는 글이네요 :)',
+      createdAt: new Date('2026-05-01T15:20:00.000Z'),
+      user: {
+        id: 1n,
+        nickname: '달콤한목소리',
+        profileImageUrl: 'https://cdn.example.com/profile/1.jpg',
+      },
+    });
+
+    const result = await service.createComment(userId, clubId, articleId, {
+      contents: '공감 가는 글이네요 :)',
+      parentCommentId: null,
+    });
+
+    expect(result).toMatchObject({
+      commentId: 555,
+      articleId,
+      depth: 0,
+      contents: '공감 가는 글이네요 :)',
+    });
+    expect(repository.createComment).toHaveBeenCalledWith({
+      articleId: 1n,
+      userId: 1n,
+      contents: '공감 가는 글이네요 :)',
+      parentCommentId: null,
+      depth: 0,
+    });
+  });
+
+  it('클럽 멤버가 아니면 댓글 작성이 거부된다', async () => {
+    repository.findClubById.mockResolvedValue({ id: 1n, deletedAt: null });
+    repository.findArticleByClubId.mockResolvedValue({ id: 1n });
+    repository.findActiveClubUser.mockResolvedValue(null);
+
+    await expect(
+      service.createComment(userId, clubId, articleId, {
+        contents: '댓글',
+        parentCommentId: null,
+      }),
+    ).rejects.toMatchObject({
+      internalCode: 'CLUB_FORBIDDEN_NOT_MEMBER',
+    } satisfies Partial<AppException>);
+    expect(repository.createComment).not.toHaveBeenCalled();
+  });
+
+  it('부모 댓글이 대댓글이면 COMMENT_DEPTH_EXCEEDED', async () => {
+    repository.findClubById.mockResolvedValue({ id: 1n, deletedAt: null });
+    repository.findArticleByClubId.mockResolvedValue({ id: 1n });
+    repository.findActiveClubUser.mockResolvedValue({ id: 10n });
+    repository.findParentComment.mockResolvedValue({ id: 2n, depth: 1 });
+
+    await expect(
+      service.createComment(userId, clubId, articleId, {
+        contents: '대대댓글',
+        parentCommentId: 2,
+      }),
+    ).rejects.toMatchObject({
+      internalCode: 'COMMENT_DEPTH_EXCEEDED',
+    });
+    expect(repository.createComment).not.toHaveBeenCalled();
+  });
+
+  it('댓글 목록을 조회한다', async () => {
+    repository.findClubById.mockResolvedValue({ id: 1n, deletedAt: null });
+    repository.findArticleByClubId.mockResolvedValue({ id: 1n });
+    repository.findActiveClubUser.mockResolvedValue({ id: 10n });
+    repository.countComments.mockResolvedValue(2);
+    repository.findCommentsWithReplies.mockResolvedValue([
+      {
+        id: 555n,
+        articleId: 1n,
+        parentCommentId: null,
+        depth: 0,
+        contents: '부모 댓글',
+        userId: 2n,
+        createdAt: new Date('2026-05-01T15:20:00.000Z'),
+        user: {
+          id: 2n,
+          nickname: '보이스마스터',
+          profileImageUrl: 'https://cdn.example.com/profile/2.jpg',
+          clubUsers: [{ authority: ClubAuthority.HOST }],
+        },
+        replies: [
+          {
+            id: 556n,
+            articleId: 1n,
+            parentCommentId: 555n,
+            depth: 1,
+            contents: '대댓글',
+            userId: 1n,
+            createdAt: new Date('2026-05-01T15:25:00.000Z'),
+            user: {
+              id: 1n,
+              nickname: '달콤한목소리',
+              profileImageUrl: 'https://cdn.example.com/profile/1.jpg',
+              clubUsers: [{ authority: ClubAuthority.GENERAL }],
+            },
+          },
+        ],
+      },
+    ]);
+
+    const result = await service.listComments(userId, clubId, articleId, {});
+
+    expect(result).toMatchObject({
+      articleId,
+      totalCount: 2,
+      hasMore: false,
+      nextCursor: null,
+      comments: [
+        {
+          commentId: 555,
+          isMine: false,
+          author: { authority: ClubAuthority.HOST },
+          replies: [
+            {
+              commentId: 556,
+              isMine: true,
+              author: { authority: ClubAuthority.GENERAL },
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('limit보다 결과가 많으면 nextCursor와 hasMore를 내려준다', async () => {
+    repository.findClubById.mockResolvedValue({ id: 1n, deletedAt: null });
+    repository.findArticleByClubId.mockResolvedValue({ id: 1n });
+    repository.findActiveClubUser.mockResolvedValue({ id: 10n });
+    repository.countComments.mockResolvedValue(2);
+    repository.findCommentsWithReplies.mockResolvedValue([
+      {
+        id: 555n,
+        parentCommentId: null,
+        depth: 0,
+        contents: '첫 댓글',
+        userId: 1n,
+        createdAt: new Date('2026-05-01T15:20:00.000Z'),
+        user: {
+          id: 1n,
+          nickname: '나',
+          profileImageUrl: 'https://cdn.example.com/profile/1.jpg',
+          clubUsers: [{ authority: ClubAuthority.GENERAL }],
+        },
+        replies: [],
+      },
+      {
+        id: 554n,
+        parentCommentId: null,
+        depth: 0,
+        contents: '다음 댓글',
+        userId: 2n,
+        createdAt: new Date('2026-05-01T15:19:00.000Z'),
+        user: {
+          id: 2n,
+          nickname: '상대',
+          profileImageUrl: 'https://cdn.example.com/profile/2.jpg',
+          clubUsers: [{ authority: ClubAuthority.GENERAL }],
+        },
+        replies: [],
+      },
+    ]);
+
+    const result = await service.listComments(userId, clubId, articleId, {
+      limit: 1,
+    });
+
+    expect(result.hasMore).toBe(true);
+    expect(result.comments).toHaveLength(1);
+    expect(result.nextCursor).toBe(
+      Buffer.from(JSON.stringify({ id: 555 }), 'utf8').toString('base64'),
+    );
+  });
+
+  it('댓글 작성자가 아니면 삭제가 거부된다', async () => {
+    repository.findClubById.mockResolvedValue({ id: 1n, deletedAt: null });
+    repository.findArticleByClubId.mockResolvedValue({ id: 1n });
+    repository.findActiveClubUser.mockResolvedValue({ id: 10n });
+    repository.findCommentByArticleId.mockResolvedValue({
+      id: 555n,
+      userId: 2n,
+    });
+
+    await expect(
+      service.deleteComment(userId, clubId, articleId, 555),
+    ).rejects.toMatchObject({
+      internalCode: 'COMMENT_FORBIDDEN_NOT_AUTHOR',
+    });
+    expect(repository.softDeleteComment).not.toHaveBeenCalled();
+  });
+
+  it('댓글을 삭제한다', async () => {
+    const deletedAt = new Date('2026-05-01T15:25:00.000Z');
+    repository.findClubById.mockResolvedValue({ id: 1n, deletedAt: null });
+    repository.findArticleByClubId.mockResolvedValue({ id: 1n });
+    repository.findActiveClubUser.mockResolvedValue({ id: 10n });
+    repository.findCommentByArticleId.mockResolvedValue({
+      id: 555n,
+      userId: 1n,
+    });
+    repository.softDeleteComment.mockResolvedValue({
+      id: 555n,
+      deletedAt,
+    });
+
+    const result = await service.deleteComment(userId, clubId, articleId, 555);
+
+    expect(result).toEqual({
+      commentId: 555,
+      deletedAt: deletedAt.toISOString(),
+    });
+    expect(repository.softDeleteComment).toHaveBeenCalledWith(
+      555n,
+      expect.any(Date),
+    );
+  });
+});

--- a/src/modules/comment/services/comment.service.spec.ts
+++ b/src/modules/comment/services/comment.service.spec.ts
@@ -1,8 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { ClubAuthority } from '@prisma/client';
+import { ClubAuthority, NotificationType } from '@prisma/client';
 import { CommentService } from './comment.service';
 import { CommentRepository } from '../repositories/comment.repository';
 import { AppException } from '../../../common/errors/app.exception';
+import { NotificationService } from '../../notification/services/notification.service';
 
 describe('CommentService', () => {
   let service: CommentService;
@@ -20,6 +21,9 @@ describe('CommentService', () => {
     softDeleteComment: jest.fn(),
     softDeleteParentCommentWithReplies: jest.fn(),
   };
+  const notificationService = {
+    createNotification: jest.fn(),
+  };
 
   const userId = 1;
   const clubId = 1;
@@ -27,6 +31,7 @@ describe('CommentService', () => {
 
   beforeEach(async () => {
     Object.values(repository).forEach((mock) => mock.mockReset());
+    Object.values(notificationService).forEach((mock) => mock.mockReset());
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -34,6 +39,10 @@ describe('CommentService', () => {
         {
           provide: CommentRepository,
           useValue: repository,
+        },
+        {
+          provide: NotificationService,
+          useValue: notificationService,
         },
       ],
     }).compile();
@@ -81,6 +90,77 @@ describe('CommentService', () => {
       parentCommentId: null,
       depth: 0,
     });
+    expect(notificationService.createNotification).not.toHaveBeenCalled();
+  });
+
+  it('답글을 작성하면 부모 댓글 작성자에게 알림을 생성한다', async () => {
+    repository.findClubById.mockResolvedValue({ id: 1n, deletedAt: null });
+    repository.findArticleByClubId.mockResolvedValue({ id: 1n });
+    repository.findActiveClubUser.mockResolvedValue({ id: 10n });
+    repository.findParentComment.mockResolvedValue({
+      id: 555n,
+      depth: 0,
+      userId: 2n,
+      user: { nickname: '부모작성자' },
+    });
+    repository.createComment.mockResolvedValue({
+      id: 556n,
+      articleId: 1n,
+      parentCommentId: 555n,
+      depth: 1,
+      contents: '답글',
+      createdAt: new Date('2026-05-01T15:20:00.000Z'),
+      user: {
+        id: 1n,
+        nickname: '자식작성자',
+        profileImageUrl: 'https://cdn.example.com/profile/1.jpg',
+      },
+    });
+
+    await service.createComment(userId, clubId, articleId, {
+      contents: '답글',
+      parentCommentId: 555,
+    });
+
+    expect(notificationService.createNotification).toHaveBeenCalledWith(
+      2,
+      NotificationType.UPDATE,
+      '내 댓글에 답글이 달렸어요.',
+      '자식작성자님이 부모작성자님의 댓글에 답글을 남겼어요.',
+      1,
+    );
+  });
+
+  it('내 댓글에 내가 답글을 작성하면 알림을 생성하지 않는다', async () => {
+    repository.findClubById.mockResolvedValue({ id: 1n, deletedAt: null });
+    repository.findArticleByClubId.mockResolvedValue({ id: 1n });
+    repository.findActiveClubUser.mockResolvedValue({ id: 10n });
+    repository.findParentComment.mockResolvedValue({
+      id: 555n,
+      depth: 0,
+      userId: 1n,
+      user: { nickname: '내댓글' },
+    });
+    repository.createComment.mockResolvedValue({
+      id: 556n,
+      articleId: 1n,
+      parentCommentId: 555n,
+      depth: 1,
+      contents: '답글',
+      createdAt: new Date('2026-05-01T15:20:00.000Z'),
+      user: {
+        id: 1n,
+        nickname: '나',
+        profileImageUrl: 'https://cdn.example.com/profile/1.jpg',
+      },
+    });
+
+    await service.createComment(userId, clubId, articleId, {
+      contents: '답글',
+      parentCommentId: 555,
+    });
+
+    expect(notificationService.createNotification).not.toHaveBeenCalled();
   });
 
   it('클럽 멤버가 아니면 댓글 작성이 거부된다', async () => {

--- a/src/modules/comment/services/comment.service.spec.ts
+++ b/src/modules/comment/services/comment.service.spec.ts
@@ -93,6 +93,42 @@ describe('CommentService', () => {
     expect(notificationService.createNotification).not.toHaveBeenCalled();
   });
 
+  it('게시글에 댓글을 작성하면 게시글 작성자에게 알림을 생성한다', async () => {
+    repository.findClubById.mockResolvedValue({ id: 1n, deletedAt: null });
+    repository.findArticleByClubId.mockResolvedValue({
+      id: 1n,
+      userId: 2n,
+      user: { nickname: '게시글작성자' },
+    });
+    repository.findActiveClubUser.mockResolvedValue({ id: 10n });
+    repository.createComment.mockResolvedValue({
+      id: 555n,
+      articleId: 1n,
+      parentCommentId: null,
+      depth: 0,
+      contents: '공감 가는 글이네요 :)',
+      createdAt: new Date('2026-05-01T15:20:00.000Z'),
+      user: {
+        id: 1n,
+        nickname: '댓글작성자',
+        profileImageUrl: 'https://cdn.example.com/profile/1.jpg',
+      },
+    });
+
+    await service.createComment(userId, clubId, articleId, {
+      contents: '공감 가는 글이네요 :)',
+      parentCommentId: null,
+    });
+
+    expect(notificationService.createNotification).toHaveBeenCalledWith(
+      2,
+      NotificationType.COMMENT,
+      '내 게시물에 댓글이 달렸어요.',
+      '댓글작성자님이 게시글작성자님의 게시물에 댓글을 남겼어요.',
+      1,
+    );
+  });
+
   it('답글을 작성하면 부모 댓글 작성자에게 알림을 생성한다', async () => {
     repository.findClubById.mockResolvedValue({ id: 1n, deletedAt: null });
     repository.findArticleByClubId.mockResolvedValue({ id: 1n });
@@ -124,7 +160,7 @@ describe('CommentService', () => {
 
     expect(notificationService.createNotification).toHaveBeenCalledWith(
       2,
-      NotificationType.UPDATE,
+      NotificationType.COMMENT,
       '내 댓글에 답글이 달렸어요.',
       '자식작성자님이 부모작성자님의 댓글에 답글을 남겼어요.',
       1,

--- a/src/modules/comment/services/comment.service.ts
+++ b/src/modules/comment/services/comment.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { NotificationType } from '@prisma/client';
 import { AppException } from '../../../common/errors/app.exception';
 import { NotificationService } from '../../notification/services/notification.service';
@@ -21,6 +21,8 @@ type CommentReplyEntity = CommentListEntity['replies'][number];
 
 @Injectable()
 export class CommentService {
+  private readonly logger = new Logger(CommentService.name);
+
   constructor(
     private readonly commentRepository: CommentRepository,
     private readonly notificationService: NotificationService,
@@ -85,26 +87,48 @@ export class CommentService {
       Number(parentComment.userId) !== userId &&
       comment.user
     ) {
-      await this.notificationService.createNotification(
-        Number(parentComment.userId),
-        NotificationType.COMMENT,
-        '내 댓글에 답글이 달렸어요.',
-        `${comment.user.nickname}님이 ${parentComment.user?.nickname ?? '회원'}님의 댓글에 답글을 남겼어요.`,
-        userId,
-      );
+      await this.createCommentNotification({
+        receiverId: Number(parentComment.userId),
+        title: '내 댓글에 답글이 달렸어요.',
+        body: `${comment.user.nickname}님이 ${parentComment.user?.nickname ?? '회원'}님의 댓글에 답글을 남겼어요.`,
+        senderId: userId,
+        context: 'reply',
+      });
     }
 
     if (article.userId && Number(article.userId) !== userId && comment.user) {
-      await this.notificationService.createNotification(
-        Number(article.userId),
-        NotificationType.COMMENT,
-        '내 게시물에 댓글이 달렸어요.',
-        `${comment.user.nickname}님이 ${article.user?.nickname ?? '회원'}님의 게시물에 댓글을 남겼어요.`,
-        userId,
-      );
+      await this.createCommentNotification({
+        receiverId: Number(article.userId),
+        title: '내 게시물에 댓글이 달렸어요.',
+        body: `${comment.user.nickname}님이 ${article.user?.nickname ?? '회원'}님의 게시물에 댓글을 남겼어요.`,
+        senderId: userId,
+        context: 'article',
+      });
     }
 
     return CreateCommentResponseDto.from(comment);
+  }
+
+  private async createCommentNotification(params: {
+    receiverId: number;
+    title: string;
+    body: string;
+    senderId: number;
+    context: 'article' | 'reply';
+  }): Promise<void> {
+    try {
+      await this.notificationService.createNotification(
+        params.receiverId,
+        NotificationType.COMMENT,
+        params.title,
+        params.body,
+        params.senderId,
+      );
+    } catch (e) {
+      this.logger.warn(
+        `createComment notification failed context=${params.context} receiverId=${params.receiverId}: ${String(e)}`,
+      );
+    }
   }
 
   async listComments(

--- a/src/modules/comment/services/comment.service.ts
+++ b/src/modules/comment/services/comment.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { NotificationType } from '@prisma/client';
 import { AppException } from '../../../common/errors/app.exception';
+import { ClubRepository } from '../../club/repositories/club.repository';
 import { NotificationService } from '../../notification/services/notification.service';
 import {
   CommentListAuthorDto,
@@ -25,6 +26,7 @@ export class CommentService {
 
   constructor(
     private readonly commentRepository: CommentRepository,
+    private readonly clubRepository: ClubRepository,
     private readonly notificationService: NotificationService,
   ) {}
 
@@ -34,7 +36,7 @@ export class CommentService {
     articleId: number,
     dto: CreateCommentRequestDto,
   ): Promise<CreateCommentResponseDto> {
-    const club = await this.commentRepository.findClubById(BigInt(clubId));
+    const club = await this.clubRepository.findById(BigInt(clubId));
 
     if (!club || club.deletedAt) {
       throw new AppException('CLUB_NOT_FOUND');
@@ -49,9 +51,9 @@ export class CommentService {
       throw new AppException('ARTICLE_NOT_FOUND');
     }
 
-    const clubUser = await this.commentRepository.findActiveClubUser(
-      BigInt(clubId),
+    const clubUser = await this.clubRepository.findActiveClubUser(
       BigInt(userId),
+      BigInt(clubId),
     );
 
     if (!clubUser) {
@@ -224,9 +226,9 @@ export class CommentService {
   ) {
     await this.validateArticleExists(clubId, articleId);
 
-    const clubUser = await this.commentRepository.findActiveClubUser(
-      BigInt(clubId),
+    const clubUser = await this.clubRepository.findActiveClubUser(
       BigInt(userId),
+      BigInt(clubId),
     );
 
     if (!clubUser) {
@@ -238,7 +240,7 @@ export class CommentService {
     clubId: number,
     articleId: number,
   ): Promise<void> {
-    const club = await this.commentRepository.findClubById(BigInt(clubId));
+    const club = await this.clubRepository.findById(BigInt(clubId));
 
     if (!club || club.deletedAt) {
       throw new AppException('CLUB_NOT_FOUND');

--- a/src/modules/comment/services/comment.service.ts
+++ b/src/modules/comment/services/comment.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@nestjs/common';
+import { NotificationType } from '@prisma/client';
 import { AppException } from '../../../common/errors/app.exception';
+import { NotificationService } from '../../notification/services/notification.service';
 import {
   CommentListAuthorDto,
   CommentListItemResponseDto,
@@ -19,7 +21,10 @@ type CommentReplyEntity = CommentListEntity['replies'][number];
 
 @Injectable()
 export class CommentService {
-  constructor(private readonly commentRepository: CommentRepository) {}
+  constructor(
+    private readonly commentRepository: CommentRepository,
+    private readonly notificationService: NotificationService,
+  ) {}
 
   async createComment(
     userId: number,
@@ -74,6 +79,20 @@ export class CommentService {
         dto.parentCommentId === null ? null : BigInt(dto.parentCommentId),
       depth: parentComment ? parentComment.depth + 1 : 0,
     });
+
+    if (
+      parentComment?.userId &&
+      Number(parentComment.userId) !== userId &&
+      comment.user
+    ) {
+      await this.notificationService.createNotification(
+        Number(parentComment.userId),
+        NotificationType.UPDATE,
+        '내 댓글에 답글이 달렸어요.',
+        `${comment.user.nickname}님이 ${parentComment.user?.nickname ?? '회원'}님의 댓글에 답글을 남겼어요.`,
+        userId,
+      );
+    }
 
     return CreateCommentResponseDto.from(comment);
   }
@@ -257,9 +276,17 @@ export class CommentService {
 
   private decodeCursor(cursor: string): number {
     try {
-      const decoded = JSON.parse(
+      const decoded: unknown = JSON.parse(
         Buffer.from(cursor, 'base64').toString('utf8'),
       );
+      if (
+        typeof decoded !== 'object' ||
+        decoded === null ||
+        !('id' in decoded)
+      ) {
+        throw new Error('invalid cursor payload');
+      }
+
       const id = Number(decoded?.id);
 
       if (!Number.isInteger(id) || id <= 0) {

--- a/src/modules/comment/services/comment.service.ts
+++ b/src/modules/comment/services/comment.service.ts
@@ -1,0 +1,260 @@
+import { Injectable } from '@nestjs/common';
+import { AppException } from '../../../common/errors/app.exception';
+import {
+  CommentListAuthorDto,
+  CommentListItemResponseDto,
+  CommentReplyResponseDto,
+  CreateCommentRequestDto,
+  CreateCommentResponseDto,
+  DeleteCommentResponseDto,
+  ListCommentsQueryDto,
+  ListCommentsResponseDto,
+} from '../dtos/comment.dto';
+import { CommentRepository } from '../repositories/comment.repository';
+
+type CommentListEntity = Awaited<
+  ReturnType<CommentRepository['findCommentsWithReplies']>
+>[number];
+type CommentReplyEntity = CommentListEntity['replies'][number];
+
+@Injectable()
+export class CommentService {
+  constructor(private readonly commentRepository: CommentRepository) {}
+
+  async createComment(
+    userId: number,
+    clubId: number,
+    articleId: number,
+    dto: CreateCommentRequestDto,
+  ): Promise<CreateCommentResponseDto> {
+    const club = await this.commentRepository.findClubById(BigInt(clubId));
+
+    if (!club || club.deletedAt) {
+      throw new AppException('CLUB_NOT_FOUND');
+    }
+
+    const article = await this.commentRepository.findArticleByClubId(
+      BigInt(clubId),
+      BigInt(articleId),
+    );
+
+    if (!article) {
+      throw new AppException('ARTICLE_NOT_FOUND');
+    }
+
+    const clubUser = await this.commentRepository.findActiveClubUser(
+      BigInt(clubId),
+      BigInt(userId),
+    );
+
+    if (!clubUser) {
+      throw new AppException('CLUB_FORBIDDEN_NOT_MEMBER');
+    }
+
+    const parentComment = dto.parentCommentId
+      ? await this.commentRepository.findParentComment(
+          BigInt(articleId),
+          BigInt(dto.parentCommentId),
+        )
+      : null;
+
+    if (dto.parentCommentId && !parentComment) {
+      throw new AppException('COMMENT_PARENT_NOT_FOUND');
+    }
+
+    if (parentComment && parentComment.depth >= 1) {
+      throw new AppException('COMMENT_DEPTH_EXCEEDED');
+    }
+
+    const comment = await this.commentRepository.createComment({
+      articleId: BigInt(articleId),
+      userId: BigInt(userId),
+      contents: dto.contents,
+      parentCommentId:
+        dto.parentCommentId === null ? null : BigInt(dto.parentCommentId),
+      depth: parentComment ? parentComment.depth + 1 : 0,
+    });
+
+    return CreateCommentResponseDto.from(comment);
+  }
+
+  async listComments(
+    userId: number,
+    clubId: number,
+    articleId: number,
+    query: ListCommentsQueryDto,
+  ): Promise<ListCommentsResponseDto> {
+    await this.validateReadableArticle(userId, clubId, articleId);
+
+    const limit = query.limit ?? 20;
+    const cursorId = query.cursor ? this.decodeCursor(query.cursor) : null;
+    const cursor = cursorId
+      ? await this.commentRepository.findCommentCursor(
+          BigInt(articleId),
+          BigInt(cursorId),
+        )
+      : null;
+
+    if (query.cursor && !cursor) {
+      throw new AppException('VALIDATION_INVALID_FORMAT', {
+        details: { field: 'cursor' },
+      });
+    }
+
+    const [totalCount, comments] = await Promise.all([
+      this.commentRepository.countComments(BigInt(articleId)),
+      this.commentRepository.findCommentsWithReplies({
+        clubId: BigInt(clubId),
+        articleId: BigInt(articleId),
+        limit,
+        cursor: cursor ?? undefined,
+      }),
+    ]);
+
+    const hasMore = comments.length > limit;
+    const items = hasMore ? comments.slice(0, limit) : comments;
+    const last = items[items.length - 1];
+
+    return {
+      articleId,
+      totalCount,
+      comments: items.map((comment) => this.toCommentItem(comment, userId)),
+      nextCursor: hasMore && last ? this.encodeCursor(Number(last.id)) : null,
+      hasMore,
+    };
+  }
+
+  async deleteComment(
+    userId: number,
+    clubId: number,
+    articleId: number,
+    commentId: number,
+  ): Promise<DeleteCommentResponseDto> {
+    await this.validateReadableArticle(userId, clubId, articleId);
+
+    const comment = await this.commentRepository.findCommentByArticleId(
+      BigInt(articleId),
+      BigInt(commentId),
+    );
+
+    if (!comment) {
+      throw new AppException('COMMENT_NOT_FOUND');
+    }
+
+    if (comment.userId === null || Number(comment.userId) !== userId) {
+      throw new AppException('COMMENT_FORBIDDEN_NOT_AUTHOR');
+    }
+
+    const deletedAt = new Date();
+    const deleted = await this.commentRepository.softDeleteComment(
+      BigInt(commentId),
+      deletedAt,
+    );
+
+    return {
+      commentId: Number(deleted.id),
+      deletedAt: deleted.deletedAt?.toISOString() ?? deletedAt.toISOString(),
+    };
+  }
+
+  private async validateReadableArticle(
+    userId: number,
+    clubId: number,
+    articleId: number,
+  ) {
+    const club = await this.commentRepository.findClubById(BigInt(clubId));
+
+    if (!club || club.deletedAt) {
+      throw new AppException('CLUB_NOT_FOUND');
+    }
+
+    const article = await this.commentRepository.findArticleByClubId(
+      BigInt(clubId),
+      BigInt(articleId),
+    );
+
+    if (!article) {
+      throw new AppException('ARTICLE_NOT_FOUND');
+    }
+
+    const clubUser = await this.commentRepository.findActiveClubUser(
+      BigInt(clubId),
+      BigInt(userId),
+    );
+
+    if (!clubUser) {
+      throw new AppException('CLUB_FORBIDDEN_NOT_MEMBER');
+    }
+  }
+
+  private toCommentItem(
+    comment: CommentListEntity,
+    userId: number,
+  ): CommentListItemResponseDto {
+    return {
+      commentId: Number(comment.id),
+      parentCommentId: null,
+      depth: comment.depth,
+      contents: comment.contents,
+      isMine: comment.userId !== null && Number(comment.userId) === userId,
+      author: this.toAuthor(comment.user),
+      createdAt: comment.createdAt.toISOString(),
+      replies: comment.replies.map((reply) => this.toReply(reply, userId)),
+    };
+  }
+
+  private toReply(
+    reply: CommentReplyEntity,
+    userId: number,
+  ): CommentReplyResponseDto {
+    return {
+      commentId: Number(reply.id),
+      parentCommentId: Number(reply.parentCommentId),
+      depth: reply.depth,
+      contents: reply.contents,
+      isMine: reply.userId !== null && Number(reply.userId) === userId,
+      author: this.toAuthor(reply.user),
+      createdAt: reply.createdAt.toISOString(),
+    };
+  }
+
+  private toAuthor(
+    user: CommentListEntity['user'],
+  ): CommentListAuthorDto | null {
+    if (!user) {
+      return null;
+    }
+
+    const clubUser = user.clubUsers[0];
+
+    return {
+      userId: Number(user.id),
+      nickname: user.nickname,
+      profileImageUrl: user.profileImageUrl,
+      authority: clubUser.authority,
+    };
+  }
+
+  private encodeCursor(commentId: number): string {
+    return Buffer.from(JSON.stringify({ id: commentId }), 'utf8').toString(
+      'base64',
+    );
+  }
+
+  private decodeCursor(cursor: string): number {
+    try {
+      const decoded = JSON.parse(Buffer.from(cursor, 'base64').toString('utf8'));
+      const id = Number(decoded?.id);
+
+      if (!Number.isInteger(id) || id <= 0) {
+        throw new Error('invalid cursor id');
+      }
+
+      return id;
+    } catch {
+      throw new AppException('VALIDATION_INVALID_FORMAT', {
+        details: { field: 'cursor' },
+      });
+    }
+  }
+}

--- a/src/modules/comment/services/comment.service.ts
+++ b/src/modules/comment/services/comment.service.ts
@@ -146,10 +146,17 @@ export class CommentService {
     }
 
     const deletedAt = new Date();
-    const deleted = await this.commentRepository.softDeleteComment(
-      BigInt(commentId),
-      deletedAt,
-    );
+    const isParentComment =
+      comment.parentCommentId === null && comment.depth === 0;
+    const activeReply = isParentComment
+      ? await this.commentRepository.existsActiveReply(comment.id)
+      : null;
+    const deleted = activeReply
+      ? await this.commentRepository.softDeleteParentCommentWithReplies(
+          comment.id,
+          deletedAt,
+        )
+      : await this.commentRepository.softDeleteComment(comment.id, deletedAt);
 
     return {
       commentId: Number(deleted.id),
@@ -250,7 +257,9 @@ export class CommentService {
 
   private decodeCursor(cursor: string): number {
     try {
-      const decoded = JSON.parse(Buffer.from(cursor, 'base64').toString('utf8'));
+      const decoded = JSON.parse(
+        Buffer.from(cursor, 'base64').toString('utf8'),
+      );
       const id = Number(decoded?.id);
 
       if (!Number.isInteger(id) || id <= 0) {

--- a/src/modules/comment/services/comment.service.ts
+++ b/src/modules/comment/services/comment.service.ts
@@ -130,7 +130,7 @@ export class CommentService {
     articleId: number,
     commentId: number,
   ): Promise<DeleteCommentResponseDto> {
-    await this.validateReadableArticle(userId, clubId, articleId);
+    await this.validateArticleExists(clubId, articleId);
 
     const comment = await this.commentRepository.findCommentByArticleId(
       BigInt(articleId),
@@ -162,6 +162,22 @@ export class CommentService {
     clubId: number,
     articleId: number,
   ) {
+    await this.validateArticleExists(clubId, articleId);
+
+    const clubUser = await this.commentRepository.findActiveClubUser(
+      BigInt(clubId),
+      BigInt(userId),
+    );
+
+    if (!clubUser) {
+      throw new AppException('CLUB_FORBIDDEN_NOT_MEMBER');
+    }
+  }
+
+  private async validateArticleExists(
+    clubId: number,
+    articleId: number,
+  ): Promise<void> {
     const club = await this.commentRepository.findClubById(BigInt(clubId));
 
     if (!club || club.deletedAt) {
@@ -175,15 +191,6 @@ export class CommentService {
 
     if (!article) {
       throw new AppException('ARTICLE_NOT_FOUND');
-    }
-
-    const clubUser = await this.commentRepository.findActiveClubUser(
-      BigInt(clubId),
-      BigInt(userId),
-    );
-
-    if (!clubUser) {
-      throw new AppException('CLUB_FORBIDDEN_NOT_MEMBER');
     }
   }
 

--- a/src/modules/comment/services/comment.service.ts
+++ b/src/modules/comment/services/comment.service.ts
@@ -87,9 +87,19 @@ export class CommentService {
     ) {
       await this.notificationService.createNotification(
         Number(parentComment.userId),
-        NotificationType.UPDATE,
+        NotificationType.COMMENT,
         '내 댓글에 답글이 달렸어요.',
         `${comment.user.nickname}님이 ${parentComment.user?.nickname ?? '회원'}님의 댓글에 답글을 남겼어요.`,
+        userId,
+      );
+    }
+
+    if (article.userId && Number(article.userId) !== userId && comment.user) {
+      await this.notificationService.createNotification(
+        Number(article.userId),
+        NotificationType.COMMENT,
+        '내 게시물에 댓글이 달렸어요.',
+        `${comment.user.nickname}님이 ${article.user?.nickname ?? '회원'}님의 게시물에 댓글을 남겼어요.`,
         userId,
       );
     }


### PR DESCRIPTION
## 이슈 번호
close # 198

## 주요 변경사항
- 댓글 생성(권한: 해당 동호회 소속 유저 모두)
- 댓글 삭제(권한: 댓글 작성자)
- 댓글 조회(권한: 해당 동호회 소속 유저 모두, 날짜 내림차순 정렬(최신순))
를 구현하였습니다.
- 내 댓글에 답글이 달린 경우 알림 생성 로직을 추가했습니다.



## 테스트 결과 (스크린샷)
- 모두 미인증 시 로그인 필요 에러가 발생합니다.

# 1. 댓글 생성 

### 성공 응답
<img width="1401" height="471" alt="image" src="https://github.com/user-attachments/assets/5007c7a4-16e1-42a6-b1cd-6d91d2607d20" />

### 알림 로직: 대댓글이 달린 경우 부모 댓글 작성자에게 알림이 발송됩니다.
<img width="866" height="86" alt="image" src="https://github.com/user-attachments/assets/91bdc61f-24f6-4a5d-95d5-580abd922bb1" />
알림 타입: comment
제목: '내 댓글에 답글이 달렸어요.'
내용: '(답글 작성자)님이 (나)님의 댓글에 답글을 달았어요.'

### 알림 로직: 댓글을 단 게시물 소유자에게 알림이 발송됩니다.
<img width="894" height="73" alt="image" src="https://github.com/user-attachments/assets/ca263265-89e6-40ae-94f1-e7687f4bc716" />
알림 타입: comment
제목: '내 게시물에 댓글이 달렸어요.'
내용: '(댓글 작성자)님이 (게시물 작성자)님의 게시물에 댓글을 남겼어요.'

### 실패 응답: 해당 동호회 소속이 아닌 경우
<img width="1419" height="464" alt="image" src="https://github.com/user-attachments/assets/6b5ca289-3e21-4dd7-81ae-5c374e71c451" />

### 실패 응답: 게시물을 찾을 수 없는 경우
<img width="1408" height="461" alt="image" src="https://github.com/user-attachments/assets/d4d87f19-1a8d-4d1b-9cb3-4508ed0bb56d" />

### 실패 응답: (대댓글의 경우)부모 댓글이 삭제되었거나, 부모 댓글을 찾을 수 없는 경우
<img width="1415" height="467" alt="image" src="https://github.com/user-attachments/assets/b774a4ba-15b8-4862-b00c-e521ab834c8f" />

# 2. 댓글 삭제
<img width="1444" height="478" alt="image" src="https://github.com/user-attachments/assets/13b12e15-8f1a-4850-9db1-d95aee7a3be5" />

# 3. 댓글 조회
<img width="1414" height="451" alt="image" src="https://github.com/user-attachments/assets/f44ed23a-1c7b-4b5d-99b8-a3cccb2164c3" />
커서: Base64 인코딩, null인 경우 처음부터 조회

### 실패 응답: 게시물이 존재하지 않는 경우
<img width="1427" height="454" alt="image" src="https://github.com/user-attachments/assets/9b074267-d7e6-418f-9a89-68bc9932773d" />

### 실패 응답: 해당 동호회 소속이 아닌 경우
<img width="1409" height="423" alt="image" src="https://github.com/user-attachments/assets/f6468631-0bc8-41c0-8fcd-2e95dcb81d80" />



## 참고 및 개선사항
- 댓글 수정은 화면 설계서에서 확인할 수 없어 구현하지 않았습니다. 
