### PR TITLE
[Feat] Fastapi 헬스체크 api 추가 및 에러 로그 디테일 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Response:
 FastAPI 상태 확인용 엔드포인트입니다.
 
 ```http
-GET /api/v1/health/fatapi
+GET /api/v1/health/fastapi
 ```
 
 ---

--- a/src/config/env.schema.ts
+++ b/src/config/env.schema.ts
@@ -14,7 +14,7 @@ export const envSchema = z.object({
   AWS_ACCESS_KEY_ID: z.string().min(1).optional(),
   AWS_SECRET_ACCESS_KEY: z.string().min(1).optional(),
   AWS_S3_BUCKET: z.string().min(1),
-  FASTAPI_BASE_URL: z.string().url().default('http://localhost:8000'),
+  FASTAPI_BASE_URL: z.string().url().default('http://fastapi.eum.local:8000'),
   FASTAPI_TIMEOUT_MS: z.coerce.number().int().positive().default(10000),
   FASTAPI_PROFILE_ANALYSIS_PATH: z
     .string()
@@ -28,6 +28,10 @@ export const envSchema = z.object({
     .string()
     .min(1)
     .default('/api/v1/recommendation/clubs'),
+  FASTAPI_HEALTH_URL: z
+    .string()
+    .url()
+    .default('http://fastapi.eum.local:8000/health'),
   FASTAPI_HEALTH_PATH: z.string().min(1).default('/health'),
   KAKAO_CLIENT_ID: z.string().min(1),
   KAKAO_CLIENT_SECRET: z.string().min(1),

--- a/src/modules/health/health.controller.spec.ts
+++ b/src/modules/health/health.controller.spec.ts
@@ -42,4 +42,24 @@ describe('HealthController', () => {
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.send).toHaveBeenCalledWith({ status: 'ok' });
   });
+
+  it('keeps typo alias for FastAPI health response', async () => {
+    healthService.proxyFastApiHealth.mockResolvedValue({
+      statusCode: 200,
+      contentType: null,
+      body: { status: 'ok' },
+    });
+
+    const res = {
+      type: jest.fn().mockReturnThis(),
+      status: jest.fn().mockReturnThis(),
+      send: jest.fn(),
+    };
+
+    await controller.proxyFastApiHealthTypoAlias(res as never);
+
+    expect(res.type).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.send).toHaveBeenCalledWith({ status: 'ok' });
+  });
 });

--- a/src/modules/health/health.controller.spec.ts
+++ b/src/modules/health/health.controller.spec.ts
@@ -42,24 +42,4 @@ describe('HealthController', () => {
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.send).toHaveBeenCalledWith({ status: 'ok' });
   });
-
-  it('keeps typo alias for FastAPI health response', async () => {
-    healthService.proxyFastApiHealth.mockResolvedValue({
-      statusCode: 200,
-      contentType: null,
-      body: { status: 'ok' },
-    });
-
-    const res = {
-      type: jest.fn().mockReturnThis(),
-      status: jest.fn().mockReturnThis(),
-      send: jest.fn(),
-    };
-
-    await controller.proxyFastApiHealthTypoAlias(res as never);
-
-    expect(res.type).not.toHaveBeenCalled();
-    expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.send).toHaveBeenCalledWith({ status: 'ok' });
-  });
 });

--- a/src/modules/health/health.controller.ts
+++ b/src/modules/health/health.controller.ts
@@ -33,10 +33,4 @@ export class HealthController {
 
     return res.status(result.statusCode).send(result.body);
   }
-
-  @Get('fatapi')
-  @ApiOperation({ summary: 'FastAPI health check (deprecated typo alias)' })
-  async proxyFastApiHealthTypoAlias(@Res() res: Response) {
-    return this.proxyFastApiHealth(res);
-  }
 }

--- a/src/modules/health/health.controller.ts
+++ b/src/modules/health/health.controller.ts
@@ -14,7 +14,7 @@ export class HealthController {
     return { status: 'ok' };
   }
 
-  @Get('fatapi')
+  @Get('fastapi')
   @ApiOperation({ summary: 'FastAPI health check' })
   @ApiOkResponse({
     description: 'FastAPI health response',
@@ -32,5 +32,11 @@ export class HealthController {
     }
 
     return res.status(result.statusCode).send(result.body);
+  }
+
+  @Get('fatapi')
+  @ApiOperation({ summary: 'FastAPI health check (deprecated typo alias)' })
+  async proxyFastApiHealthTypoAlias(@Res() res: Response) {
+    return this.proxyFastApiHealth(res);
   }
 }

--- a/src/modules/health/health.service.spec.ts
+++ b/src/modules/health/health.service.spec.ts
@@ -12,7 +12,9 @@ describe('HealthService', () => {
     configService.getOrThrow.mockReturnValue('http://fastapi:8000');
     configService.get.mockImplementation(
       (key: string, defaultValue: unknown) =>
-        key === 'FASTAPI_HEALTH_PATH' ? '/api/v1/health' : defaultValue,
+        key === 'FASTAPI_HEALTH_URL'
+          ? 'http://fastapi.eum.local:8000/health'
+          : defaultValue,
     );
   });
 
@@ -39,7 +41,7 @@ describe('HealthService', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock.mock.calls[0]?.[0]).toBe(
-      'http://fastapi:8000/api/v1/health',
+      'http://fastapi.eum.local:8000/health',
     );
     const requestInit = fetchMock.mock.calls[0]?.[1] as RequestInit;
     expect(requestInit.method).toBe('GET');

--- a/src/modules/health/health.service.ts
+++ b/src/modules/health/health.service.ts
@@ -10,31 +10,36 @@ export type FastApiHealthProxyResponse = {
 
 @Injectable()
 export class HealthService {
-  private readonly baseUrl: string;
   private readonly timeoutMs: number;
-  private readonly healthPath: string;
+  private readonly healthUrl: string;
 
   constructor(private readonly configService: ConfigService) {
-    this.baseUrl = this.configService.getOrThrow<string>('FASTAPI_BASE_URL');
     this.timeoutMs = this.configService.get<number>(
       'FASTAPI_TIMEOUT_MS',
       10000,
     );
-    this.healthPath = this.configService.get<string>(
-      'FASTAPI_HEALTH_PATH',
-      '/health',
+    this.healthUrl = this.configService.get<string>(
+      'FASTAPI_HEALTH_URL',
+      'http://fastapi.eum.local:8000/health',
     );
   }
 
   async proxyFastApiHealth(): Promise<FastApiHealthProxyResponse> {
     let response: Response;
     try {
-      response = await fetch(this.buildUrl(this.healthPath), {
+      response = await fetch(this.healthUrl, {
         method: 'GET',
         signal: AbortSignal.timeout(this.timeoutMs),
       });
     } catch (error) {
-      throw new AppException('NETWORK_CONNECTION_FAILED', { details: error });
+      throw new AppException('NETWORK_CONNECTION_FAILED', {
+        details: {
+          method: 'GET',
+          url: this.healthUrl,
+          timeoutMs: this.timeoutMs,
+          error: this.serializeError(error),
+        },
+      });
     }
 
     const contentType = response.headers.get('content-type');
@@ -47,10 +52,24 @@ export class HealthService {
     };
   }
 
-  private buildUrl(path: string): string {
-    const normalizedBaseUrl = this.baseUrl.replace(/\/+$/, '');
-    const normalizedPath = path.startsWith('/') ? path : `/${path}`;
-    return `${normalizedBaseUrl}${normalizedPath}`;
+  private serializeError(error: unknown): Record<string, unknown> {
+    if (error instanceof Error) {
+      return {
+        name: error.name,
+        message: error.message,
+        cause: this.readProperty(error, 'cause'),
+      };
+    }
+
+    return { message: String(error) };
+  }
+
+  private readProperty(target: unknown, key: string): unknown {
+    if (typeof target !== 'object' || target === null) {
+      return undefined;
+    }
+
+    return (target as Record<string, unknown>)[key];
   }
 
   private parseBody(bodyText: string, contentType: string | null): unknown {

--- a/src/modules/onboarding/controllers/onboarding.controller.spec.ts
+++ b/src/modules/onboarding/controllers/onboarding.controller.spec.ts
@@ -27,7 +27,6 @@ describe('OnboardingController', () => {
     gender: 'F',
     birthDate: '1972-03-01',
     areaCode: '1168000000',
-    introText: '안녕하세요',
     introAudioUrl: 'https://cdn.example.com/intro.m4a',
   };
 

--- a/src/modules/onboarding/controllers/onboarding.controller.ts
+++ b/src/modules/onboarding/controllers/onboarding.controller.ts
@@ -91,8 +91,43 @@ export class OnboardingController {
     description:
       '동호회 소개 텍스트/음성을 FastAPI로 분석한 뒤, 클럽 vibeVector와 키워드를 저장합니다.',
   })
-  @ApiBody({ type: AnalyzeClubVibeRequestDto })
-  @ApiOkResponse({ type: AnalyzeClubVibeResponseDto })
+  @ApiBody({
+    type: AnalyzeClubVibeRequestDto,
+    examples: {
+      default: {
+        summary: '동호회 바이브 분석 요청',
+        value: {
+          analysis_type: 'profile',
+          clubId: 12,
+          transcript:
+            '저희 모임은 퇴근 후 가볍게 러닝하고 서로 기록을 공유하는 분위기입니다.',
+        },
+      },
+    },
+  })
+  @ApiOkResponse({
+    type: AnalyzeClubVibeResponseDto,
+    description:
+      '동호회 바이브 분석 성공. FastAPI 분석 결과를 반환하고 vibeVector는 클럽에 저장합니다.',
+    schema: {
+      example: {
+        clubId: 12,
+        matchedKeywords: [
+          {
+            category: 'ACTIVITY',
+            id: 3,
+            keyword: '활동적',
+            score: 0.82,
+          },
+        ],
+        summary: '퇴근 후 러닝 기록을 공유하는 활동적인 모임입니다.',
+        transcript:
+          '저희 모임은 퇴근 후 가볍게 러닝하고 서로 기록을 공유하는 분위기입니다.',
+        vectorId: '12',
+        vibeVector: [0.12, -0.04, 0.31],
+      },
+    },
+  })
   async analyzeClubVibe(
     @RequiredUserId() userId: number,
     @Body() dto: AnalyzeClubVibeRequestDto,

--- a/src/modules/onboarding/controllers/onboarding.controller.ts
+++ b/src/modules/onboarding/controllers/onboarding.controller.ts
@@ -23,10 +23,45 @@ export class OnboardingController {
   @ApiOperation({
     summary: '온보딩 프로필 등록',
     description:
-      '프로필 텍스트/음성을 기반으로 FastAPI 분석을 수행한 뒤, 분석 결과와 함께 사용자 프로필을 저장합니다.',
+      '자기소개 음성 URL을 기반으로 FastAPI 분석을 수행한 뒤, 분석 결과와 함께 사용자 프로필을 저장합니다. introText는 요청으로 받지 않고 FastAPI가 반환한 transcript를 저장합니다. 응답에는 FastAPI 분석 결과 중 vibeVector와 vectorId를 제외한 matchedKeywords, summary, transcript를 반환합니다.',
   })
-  @ApiBody({ type: CreateProfileRequestDto })
-  @ApiOkResponse({ type: CreateProfileResponseDto })
+  @ApiBody({
+    type: CreateProfileRequestDto,
+    examples: {
+      default: {
+        summary: '온보딩 프로필 등록 요청',
+        value: {
+          nickname: '루씨',
+          gender: 'F',
+          birthDate: '1972-03-01',
+          areaCode: '1168000000',
+          introAudioUrl: 'https://cdn.example.com/onboarding/intro-101.m4a',
+        },
+      },
+    },
+  })
+  @ApiOkResponse({
+    type: CreateProfileResponseDto,
+    description:
+      '프로필 저장 성공. vibeVector는 서버에 저장하지만 응답에는 포함하지 않습니다.',
+    schema: {
+      example: {
+        userId: 101,
+        matchedKeywords: [
+          {
+            category: 'PERSONALITY',
+            id: 21,
+            keyword: '차분함',
+            score: 0.86,
+          },
+        ],
+        summary: '조용한 공간에서 독서와 산책을 즐기는 차분한 성향입니다.',
+        transcript:
+          '저는 조용한 카페에서 책 읽는 걸 좋아하고, 주말에는 가볍게 산책하는 편입니다.',
+        profileCompleted: true,
+      },
+    },
+  })
   async createUserProfile(
     @RequiredUserId() userId: number,
     @Body() dto: CreateProfileRequestDto,

--- a/src/modules/onboarding/dtos/onboarding.dto.ts
+++ b/src/modules/onboarding/dtos/onboarding.dto.ts
@@ -28,7 +28,11 @@ export class CreateProfileDto {
   @IsString()
   areaCode: string;
 
-  @ApiProperty({ example: '안녕하세요 ...', description: '자기소개 텍스트' })
+  @ApiProperty({
+    example:
+      '저는 조용한 카페에서 책 읽는 걸 좋아하고, 주말에는 가볍게 산책하는 편입니다.',
+    description: 'FastAPI 음성 분석 결과 transcript',
+  })
   @IsString()
   introText: string;
 
@@ -76,10 +80,6 @@ export class CreateProfileRequestDto {
   @IsString()
   areaCode: string;
 
-  @ApiProperty({ example: '안녕하세요 ...', description: '자기소개 텍스트' })
-  @IsString()
-  introText: string;
-
   @ApiProperty({
     example: 'https://cdn/.../intro.m4a',
     description: '자기소개 음성 URL',
@@ -88,10 +88,43 @@ export class CreateProfileRequestDto {
   introAudioUrl: string;
 }
 
+export class ProfileMatchedKeywordDto {
+  @ApiProperty({ example: 'PERSONALITY', description: '키워드 카테고리' })
+  category: string;
+
+  @ApiProperty({ example: 21, description: '키워드 ID' })
+  id: number;
+
+  @ApiProperty({ example: '차분함', description: '매칭된 키워드' })
+  keyword: string;
+
+  @ApiProperty({ example: 0.86, description: '키워드 매칭 점수' })
+  score: number;
+}
+
 export class CreateProfileResponseDto {
   @ApiProperty({ example: 101, description: '사용자 ID' })
   @IsNumber()
   userId: number;
+
+  @ApiProperty({
+    type: [ProfileMatchedKeywordDto],
+    description: 'FastAPI 프로필 분석으로 매칭된 키워드 목록',
+  })
+  matchedKeywords: ProfileMatchedKeywordDto[];
+
+  @ApiProperty({
+    example: '조용한 공간에서 독서와 산책을 즐기는 차분한 성향입니다.',
+    description: 'FastAPI 프로필 분석 요약',
+  })
+  summary: string;
+
+  @ApiProperty({
+    example:
+      '저는 조용한 카페에서 책 읽는 걸 좋아하고, 주말에는 가볍게 산책하는 편입니다.',
+    description: 'FastAPI가 분석에 사용한 자기소개 transcript',
+  })
+  transcript: string;
 
   @ApiProperty({ example: true, description: '프로필 완료 여부' })
   profileCompleted: boolean;

--- a/src/modules/onboarding/dtos/onboarding.dto.ts
+++ b/src/modules/onboarding/dtos/onboarding.dto.ts
@@ -153,8 +153,17 @@ export class AnalyzeClubVibeRequestDto {
 }
 
 export class ClubMatchedKeywordDto {
-  @ApiProperty({ example: '등산' })
+  @ApiProperty({ example: 'ACTIVITY', description: '키워드 카테고리' })
+  category: string;
+
+  @ApiProperty({ example: 3, description: '키워드 ID' })
+  id: number;
+
+  @ApiProperty({ example: '활동적', description: '매칭된 키워드' })
   keyword: string;
+
+  @ApiProperty({ example: 0.82, description: '키워드 매칭 점수' })
+  score: number;
 }
 
 export class AnalyzeClubVibeResponseDto {
@@ -177,7 +186,4 @@ export class AnalyzeClubVibeResponseDto {
 
   @ApiProperty({ example: [0.12, -0.98] })
   vibeVector: number[];
-
-  @ApiProperty({ example: true, description: '클럽 업데이트 완료 여부' })
-  clubUpdated: boolean;
 }

--- a/src/modules/onboarding/services/onboarding-ai.service.spec.ts
+++ b/src/modules/onboarding/services/onboarding-ai.service.spec.ts
@@ -10,7 +10,6 @@ describe('OnboardingAiService', () => {
     gender: 'F',
     birthDate: '1972-03-01',
     areaCode: '1168000000',
-    introText: '안녕하세요',
     introAudioUrl: 'https://cdn.example.com/intro.m4a',
   };
 
@@ -90,7 +89,17 @@ describe('OnboardingAiService', () => {
         resultType: 'SUCCESS',
         success: {
           data: {
-            matchedKeywords: [{ keyword: '등산' }],
+            matchedKeywords: [
+              {
+                category: 'PERSONALITY',
+                id: 21,
+                keyword: '차분함',
+                score: 0.86,
+              },
+            ],
+            summary: '조용한 공간에서 독서와 산책을 즐기는 차분한 성향입니다.',
+            transcript:
+              '저는 조용한 카페에서 책 읽는 걸 좋아하고, 주말에는 가볍게 산책하는 편입니다.',
             vibeVector: [0.1, -0.2],
           },
         },
@@ -98,8 +107,27 @@ describe('OnboardingAiService', () => {
     );
 
     await expect(service.analyzeProfile(1, dto)).resolves.toEqual({
-      selectedKeywords: ['등산'],
+      matchedKeywords: [
+        {
+          category: 'PERSONALITY',
+          id: 21,
+          keyword: '차분함',
+          score: 0.86,
+        },
+      ],
+      selectedKeywords: ['차분함'],
+      summary: '조용한 공간에서 독서와 산책을 즐기는 차분한 성향입니다.',
+      transcript:
+        '저는 조용한 카페에서 책 읽는 걸 좋아하고, 주말에는 가볍게 산책하는 편입니다.',
       vibeVector: [0.1, -0.2],
+    });
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(typeof init?.body).toBe('string');
+    expect(JSON.parse(init?.body as string)).toEqual({
+      birthdate: '1972-03-01',
+      introAudioUrl: 'https://cdn.example.com/intro.m4a',
+      sex: 'F',
     });
   });
 

--- a/src/modules/onboarding/services/onboarding-ai.service.spec.ts
+++ b/src/modules/onboarding/services/onboarding-ai.service.spec.ts
@@ -131,7 +131,7 @@ describe('OnboardingAiService', () => {
     });
   });
 
-  it('sends transcript and analysis_type to FastAPI for club vibe analysis', async () => {
+  it('sends clubId, transcript, and analysis_type to FastAPI for club vibe analysis', async () => {
     fetchMock.mockResolvedValue(
       Response.json({
         resultType: 'SUCCESS',
@@ -141,7 +141,14 @@ describe('OnboardingAiService', () => {
             transcript: '함께 새벽 산행할 분들 모집해요.',
             summary: '새벽 산행 모임',
             vectorId: '12',
-            matchedKeywords: [{ keyword: '등산' }],
+            matchedKeywords: [
+              {
+                category: 'ACTIVITY',
+                id: 3,
+                keyword: '활동적',
+                score: 0.82,
+              },
+            ],
             vibeVector: [0.1, -0.2],
           },
         },
@@ -156,13 +163,22 @@ describe('OnboardingAiService', () => {
       }),
     ).resolves.toMatchObject({
       clubId: 12,
-      selectedKeywords: ['등산'],
+      matchedKeywords: [
+        {
+          category: 'ACTIVITY',
+          id: 3,
+          keyword: '활동적',
+          score: 0.82,
+        },
+      ],
+      selectedKeywords: ['활동적'],
       vibeVector: [0.1, -0.2],
     });
 
     const [, init] = fetchMock.mock.calls[0];
     expect(typeof init?.body).toBe('string');
     expect(JSON.parse(init?.body as string)).toEqual({
+      clubId: 12,
       transcript: '함께 새벽 산행할 분들 모집해요.',
       analysis_type: 'profile',
     });

--- a/src/modules/onboarding/services/onboarding-ai.service.ts
+++ b/src/modules/onboarding/services/onboarding-ai.service.ts
@@ -251,15 +251,18 @@ export class OnboardingAiService {
 
   private async callFastApi<T>(path: string, payload: unknown): Promise<T> {
     let response: Response;
+    const url = this.buildUrl(path);
     try {
-      response = await fetch(this.buildUrl(path), {
+      response = await fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
         signal: AbortSignal.timeout(this.timeoutMs),
       });
     } catch (error) {
-      throw new AppException('NETWORK_CONNECTION_FAILED', { details: error });
+      throw new AppException('NETWORK_CONNECTION_FAILED', {
+        details: this.buildFetchErrorDetails('POST', url, error),
+      });
     }
 
     if (!response.ok) {
@@ -298,7 +301,9 @@ export class OnboardingAiService {
         signal: AbortSignal.timeout(this.timeoutMs),
       });
     } catch (error) {
-      throw new AppException('NETWORK_CONNECTION_FAILED', { details: error });
+      throw new AppException('NETWORK_CONNECTION_FAILED', {
+        details: this.buildFetchErrorDetails('GET', url.toString(), error),
+      });
     }
 
     if (!response.ok) {
@@ -319,6 +324,61 @@ export class OnboardingAiService {
         },
       });
     }
+  }
+
+  private buildFetchErrorDetails(
+    method: 'GET' | 'POST',
+    url: string,
+    error: unknown,
+  ): Record<string, unknown> {
+    return {
+      method,
+      url,
+      timeoutMs: this.timeoutMs,
+      error: this.serializeError(error),
+    };
+  }
+
+  private serializeError(error: unknown, depth = 0): Record<string, unknown> {
+    if (depth > 2) {
+      return { message: String(error) };
+    }
+
+    if (error instanceof Error) {
+      const cause = this.readProperty(error, 'cause');
+      return {
+        name: error.name,
+        message: error.message,
+        code: this.readProperty(error, 'code'),
+        errno: this.readProperty(error, 'errno'),
+        syscall: this.readProperty(error, 'syscall'),
+        address: this.readProperty(error, 'address'),
+        port: this.readProperty(error, 'port'),
+        cause:
+          cause === undefined
+            ? undefined
+            : this.serializeError(cause, depth + 1),
+      };
+    }
+
+    if (typeof error === 'object' && error !== null) {
+      return Object.fromEntries(
+        Object.getOwnPropertyNames(error).map((key) => [
+          key,
+          this.readProperty(error, key),
+        ]),
+      );
+    }
+
+    return { message: String(error) };
+  }
+
+  private readProperty(target: unknown, key: string): unknown {
+    if (typeof target !== 'object' || target === null) {
+      return undefined;
+    }
+
+    return (target as Record<string, unknown>)[key];
   }
 
   private pickStringArray(...candidates: unknown[]): string[] {

--- a/src/modules/onboarding/services/onboarding-ai.service.ts
+++ b/src/modules/onboarding/services/onboarding-ai.service.ts
@@ -1,9 +1,24 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { AppException } from '../../../common/errors/app.exception';
-import { CreateProfileDto } from '../dtos/onboarding.dto';
+import { CreateProfileRequestDto } from '../dtos/onboarding.dto';
 
 type FastApiMatchesResponse = unknown;
+
+type ProfileMatchedKeyword = {
+  category: string;
+  id: number;
+  keyword: string;
+  score: number;
+};
+
+type ProfileAnalysisResult = {
+  matchedKeywords: ProfileMatchedKeyword[];
+  selectedKeywords: string[];
+  summary: string;
+  transcript: string;
+  vibeVector: number[];
+};
 
 @Injectable()
 export class OnboardingAiService {
@@ -40,8 +55,8 @@ export class OnboardingAiService {
 
   async analyzeProfile(
     userId: number,
-    dto: CreateProfileDto,
-  ): Promise<{ selectedKeywords: string[]; vibeVector: number[] }> {
+    dto: CreateProfileRequestDto,
+  ): Promise<ProfileAnalysisResult> {
     const result = await this.callFastApi<{
       resultType?: unknown;
       success?: {
@@ -52,6 +67,8 @@ export class OnboardingAiService {
           vibe_vector?: unknown;
           selectedKeywords?: unknown;
           selected_keywords?: unknown;
+          summary?: unknown;
+          transcript?: unknown;
         };
       };
       data?: {
@@ -61,25 +78,31 @@ export class OnboardingAiService {
         vibe_vector?: unknown;
         selectedKeywords?: unknown;
         selected_keywords?: unknown;
+        summary?: unknown;
+        transcript?: unknown;
       };
       selectedKeywords?: unknown;
       selected_keywords?: unknown;
+      summary?: unknown;
+      transcript?: unknown;
       vibeVector?: unknown;
       vibe_vector?: unknown;
     }>(this.profileAnalysisPath, {
-      transcript: dto.introText,
-      local_audio_path: dto.introAudioUrl,
-      analysis_type: 'profile',
-      user_id: userId,
+      birthdate: dto.birthDate,
+      introAudioUrl: dto.introAudioUrl,
+      sex: dto.gender,
     });
 
     this.assertFastApiSuccess(result, this.profileAnalysisPath);
 
     const payloadData = this.extractPayloadData(result);
 
-    const selectedKeywordsFromList = this.extractKeywordsFromMatchedKeywords(
+    const matchedKeywords = this.extractProfileMatchedKeywordObjects(
       payloadData.matchedKeywords,
+      payloadData.matched_keywords,
     );
+    const selectedKeywordsFromList =
+      this.extractKeywordsFromMatchedKeywords(matchedKeywords);
     const selectedKeywords = this.pickStringArray(
       payloadData.selectedKeywords,
       payloadData.selected_keywords,
@@ -97,7 +120,14 @@ export class OnboardingAiService {
     );
 
     return {
+      matchedKeywords,
       selectedKeywords,
+      summary:
+        typeof payloadData.summary === 'string' ? payloadData.summary : '',
+      transcript:
+        typeof payloadData.transcript === 'string'
+          ? payloadData.transcript
+          : '',
       vibeVector,
     };
   }
@@ -519,6 +549,43 @@ export class OnboardingAiService {
       })
       .filter((item): item is { keyword: string } => item !== null)
       .map((item) => ({ keyword: item.keyword.trim() }))
+      .filter((item) => item.keyword.length > 0);
+  }
+
+  private extractProfileMatchedKeywordObjects(
+    ...candidates: unknown[]
+  ): ProfileMatchedKeyword[] {
+    const matchedKeywords = candidates.find((candidate) =>
+      Array.isArray(candidate),
+    );
+    if (!Array.isArray(matchedKeywords)) {
+      return [];
+    }
+
+    return matchedKeywords
+      .map((item) => {
+        if (typeof item !== 'object' || item === null) {
+          return null;
+        }
+
+        const record = item as Record<string, unknown>;
+        if (
+          typeof record.category !== 'string' ||
+          typeof record.id !== 'number' ||
+          typeof record.keyword !== 'string' ||
+          typeof record.score !== 'number'
+        ) {
+          return null;
+        }
+
+        return {
+          category: record.category,
+          id: record.id,
+          keyword: record.keyword.trim(),
+          score: record.score,
+        };
+      })
+      .filter((item): item is ProfileMatchedKeyword => item !== null)
       .filter((item) => item.keyword.length > 0);
   }
 }

--- a/src/modules/onboarding/services/onboarding-ai.service.ts
+++ b/src/modules/onboarding/services/onboarding-ai.service.ts
@@ -5,7 +5,7 @@ import { CreateProfileRequestDto } from '../dtos/onboarding.dto';
 
 type FastApiMatchesResponse = unknown;
 
-type ProfileMatchedKeyword = {
+type AnalysisMatchedKeyword = {
   category: string;
   id: number;
   keyword: string;
@@ -13,7 +13,7 @@ type ProfileMatchedKeyword = {
 };
 
 type ProfileAnalysisResult = {
-  matchedKeywords: ProfileMatchedKeyword[];
+  matchedKeywords: AnalysisMatchedKeyword[];
   selectedKeywords: string[];
   summary: string;
   transcript: string;
@@ -141,7 +141,7 @@ export class OnboardingAiService {
     transcript: string;
     summary: string;
     vectorId: string;
-    matchedKeywords: { keyword: string }[];
+    matchedKeywords: AnalysisMatchedKeyword[];
     selectedKeywords: string[];
     vibeVector: number[];
   }> {
@@ -184,6 +184,7 @@ export class OnboardingAiService {
       vibeVector?: unknown;
       vibe_vector?: unknown;
     }>(this.clubVibeAnalysisPath, {
+      clubId: dto.clubId,
       transcript: dto.transcript,
       analysis_type: dto.analysis_type,
     });
@@ -191,7 +192,7 @@ export class OnboardingAiService {
     this.assertFastApiSuccess(result, this.clubVibeAnalysisPath);
 
     const payloadData = this.extractPayloadData(result);
-    const matchedKeywords = this.extractMatchedKeywordObjects(
+    const matchedKeywords = this.extractAnalysisMatchedKeywordObjects(
       payloadData.matchedKeywords,
       payloadData.matched_keywords,
     );
@@ -524,37 +525,15 @@ export class OnboardingAiService {
       .filter((keyword) => keyword.length > 0);
   }
 
-  private extractMatchedKeywordObjects(
-    ...candidates: unknown[]
-  ): { keyword: string }[] {
-    const matchedKeywords = candidates.find((candidate) =>
-      Array.isArray(candidate),
-    );
-    if (!Array.isArray(matchedKeywords)) {
-      return [];
-    }
-
-    return matchedKeywords
-      .map((item) => {
-        if (typeof item === 'string') {
-          return { keyword: item };
-        }
-        if (typeof item !== 'object' || item === null) {
-          return null;
-        }
-        const record = item as Record<string, unknown>;
-        return typeof record.keyword === 'string'
-          ? { keyword: record.keyword }
-          : null;
-      })
-      .filter((item): item is { keyword: string } => item !== null)
-      .map((item) => ({ keyword: item.keyword.trim() }))
-      .filter((item) => item.keyword.length > 0);
-  }
-
   private extractProfileMatchedKeywordObjects(
     ...candidates: unknown[]
-  ): ProfileMatchedKeyword[] {
+  ): AnalysisMatchedKeyword[] {
+    return this.extractAnalysisMatchedKeywordObjects(...candidates);
+  }
+
+  private extractAnalysisMatchedKeywordObjects(
+    ...candidates: unknown[]
+  ): AnalysisMatchedKeyword[] {
     const matchedKeywords = candidates.find((candidate) =>
       Array.isArray(candidate),
     );
@@ -585,7 +564,7 @@ export class OnboardingAiService {
           score: record.score,
         };
       })
-      .filter((item): item is ProfileMatchedKeyword => item !== null)
+      .filter((item): item is AnalysisMatchedKeyword => item !== null)
       .filter((item) => item.keyword.length > 0);
   }
 }

--- a/src/modules/onboarding/services/onboarding.service.ts
+++ b/src/modules/onboarding/services/onboarding.service.ts
@@ -70,7 +70,6 @@ export class OnboardingService {
       vectorId: analysis.vectorId,
       matchedKeywords: analysis.matchedKeywords,
       vibeVector: analysis.vibeVector,
-      clubUpdated: true,
     };
   }
 }

--- a/src/modules/onboarding/services/onboarding.service.ts
+++ b/src/modules/onboarding/services/onboarding.service.ts
@@ -26,6 +26,7 @@ export class OnboardingService {
     const analysis = await this.onboardingAiService.analyzeProfile(userId, dto);
     const profileDto: CreateProfileDto = {
       ...dto,
+      introText: analysis.transcript,
       selectedKeywords: analysis.selectedKeywords,
       vibeVector: analysis.vibeVector,
     };
@@ -34,6 +35,9 @@ export class OnboardingService {
 
     return {
       userId,
+      matchedKeywords: analysis.matchedKeywords,
+      summary: analysis.summary,
+      transcript: analysis.transcript,
       profileCompleted: true,
     };
   }


### PR DESCRIPTION
## 이슈 번호
close #213 

## 주요 변경사항
- Fastapi 헬스체크 api 추가
- 에러 로그 직렬화 추가
- env.schema 파일에서의 base fastapi url 로컬로 수정되어있던 것 수정.
- Fastapi의 응답 request body 통일 및 reponse body 응답값도 Fastapi의 값들 그대로 반환해주기 (vibevector 제외하고)

## 테스트 결과 (스크린샷)
<img width="596" height="370" alt="fastapi 호출시 fetch 에러로그 추가" src="https://github.com/user-attachments/assets/08914094-7e80-4533-942a-e5d18a974dce" />

> 에러로그 직렬화 추가


## 참고 및 개선사항
- 
