### PR TITLE
feat: 로컬 로그인 계정 seeding

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ FASTAPI_MATCH_RECOMMEND_PATH=/api/v1/recommendation/users
 FASTAPI_TIMEOUT_MS=10000
 ```
 
+로컬 seed에서 생성되는 `admin01`~`admin10` 로그인 계정의 비밀번호는 아래 환경변수로 설정합니다.
+
+```env
+LOCAL_AUTH_SEED_PASSWORD=<local-test-password>
+```
+
 ---
 
 ### 4️⃣ Run (Development)

--- a/prisma/dbml/schema.dbml
+++ b/prisma/dbml/schema.dbml
@@ -523,6 +523,7 @@ Enum BlockStatus {
 
 Enum AuthProvider {
   KAKAO
+  APPLE
   LOCAL
 }
 

--- a/prisma/migrations/20260630000000_add_apple_auth_provider/migration.sql
+++ b/prisma/migrations/20260630000000_add_apple_auth_provider/migration.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "AuthProvider" ADD VALUE 'APPLE';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,6 +40,7 @@ enum BlockStatus {
 
 enum AuthProvider {
   KAKAO
+  APPLE
   LOCAL
 }
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,5 +1,6 @@
 import { DayOfWeek, Prisma, PrismaClient, RecurrenceType } from '@prisma/client';
 import { PrismaPg } from '@prisma/adapter-pg';
+import { scryptSync } from 'crypto';
 import { parse } from 'csv-parse/sync';
 import * as dotenv from 'dotenv';
 import * as fs from 'fs';
@@ -68,6 +69,13 @@ function vectorLiteral(seed: number) {
   return `[${values.join(',')}]`;
 }
 
+function createLocalPasswordHash(password: string, username: string) {
+  const salt = Buffer.from(`seed-local-auth-${username}`);
+  const hash = scryptSync(password, salt, 64);
+
+  return `scrypt$${salt.toString('base64url')}$${hash.toString('base64url')}`;
+}
+
 async function resetDatabase() {
   if (process.env.NODE_ENV === 'production') {
     throw new Error('Refusing to reset database while NODE_ENV=production');
@@ -107,6 +115,7 @@ async function resetDatabase() {
       "Heart",
       "UserPhoto",
       "RefreshToken",
+      "LocalAuthAccount",
       "Club",
       "User"
     RESTART IDENTITY CASCADE
@@ -244,6 +253,23 @@ async function insertClubs() {
 
 async function insertDummyData() {
   await insertUsers();
+
+  await prisma.localAuthAccount.createMany({
+    data: Array.from({ length: DUMMY_COUNT }, (_, index) => {
+      const username = `admin${String(index + 1).padStart(2, '0')}`;
+
+      return {
+        id: BigInt(index + 1),
+        username,
+        passwordHash: createLocalPasswordHash('password123', username),
+        userId: BigInt(index + 1),
+        isActive: true,
+        createdAt: daysFromSeed(index),
+        updatedAt: daysFromSeed(index),
+      };
+    }),
+    skipDuplicates: true,
+  });
 
   await prisma.refreshToken.createMany({
     data: Array.from({ length: DUMMY_COUNT }, (_, index) => ({
@@ -591,6 +617,7 @@ async function insertDummyData() {
 async function resetSequences() {
   const tableNames = [
     'User',
+    'LocalAuthAccount',
     'RefreshToken',
     'UserPhoto',
     'Heart',

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -39,6 +39,15 @@ const REPORT_COUNT = DUMMY_COUNT * 2;
 const ADDRESS_CHUNK_SIZE = 5_000;
 const now = new Date('2026-01-10T09:00:00.000Z');
 
+function requiredEnv(name: string) {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new Error(`${name} must be set before running prisma seed.`);
+  }
+
+  return value;
+}
+
 function dataPath(fileName: string) {
   return path.join(DATA_DIR, fileName);
 }
@@ -254,6 +263,8 @@ async function insertClubs() {
 async function insertDummyData() {
   await insertUsers();
 
+  const localAuthSeedPassword = requiredEnv('LOCAL_AUTH_SEED_PASSWORD');
+
   await prisma.localAuthAccount.createMany({
     data: Array.from({ length: DUMMY_COUNT }, (_, index) => {
       const username = `admin${String(index + 1).padStart(2, '0')}`;
@@ -261,7 +272,7 @@ async function insertDummyData() {
       return {
         id: BigInt(index + 1),
         username,
-        passwordHash: createLocalPasswordHash('password123', username),
+        passwordHash: createLocalPasswordHash(localAuthSeedPassword, username),
         userId: BigInt(index + 1),
         isActive: true,
         createdAt: daysFromSeed(index),


### PR DESCRIPTION
## 이슈 번호
close #218 

## Summary

  - 로컬 로그인용 `LocalAuthAccount` 기반 인증 흐름을 확인
  - `admin01`~`admin10` 계정을 로컬 테스트 계정으로 사용할 수 있도록 seed 반영

  ## Test Accounts

 계정:

  admin01 ~10
<img width="848" height="508" alt="스크린샷 2026-07-01 오후 4 58 50" src="https://github.com/user-attachments/assets/7abcaefd-3b0b-49dc-bc03-b5d0e7b6de16" />

  ## Verification

  - npm run prisma:generate
  - npm run typecheck