### PR TITLE
[EUM-52] [Fix] introText 글자수 제한 없애기

### DIFF
--- a/prisma/migrations/20260702000000_change_user_intro_text_to_text/migration.sql
+++ b/prisma/migrations/20260702000000_change_user_intro_text_to_text/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ALTER COLUMN "introText" TYPE TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -143,7 +143,7 @@ model User {
   deletedAt       DateTime?             @db.Timestamp(6)
   idealVoiceUrl   String?               @db.Text
   introVoiceUrl   String                @db.Text
-  introText       String                @db.VarChar(255)
+  introText       String                @db.Text
   profileImageUrl String                @db.Text
   status          ActiveStatus          @default(ACTIVE)
   code            String?               @db.Char(10)


### PR DESCRIPTION
## 이슈 번호
close #224 

## 주요 변경사항
- DB마이그레이션 수정 (introText 글자수 제한 없애기)

## 테스트 결과 (스크린샷)
<img width="1512" height="982" alt="스크린샷 2026-07-02 오후 5 33 12" src="https://github.com/user-attachments/assets/3c439952-93cd-45d4-b5d7-b23778d62147" />

> varying varchar 255자 오류. 20~30초 가량의 음성분석만 되어도 쉽게 255자가 넘어가버리는것 같습니다.

## 참고 및 개선사항
- 
