### PR TITLE
fix: user club에 PENDING 여부추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ tempCodeRunnerFile*
 
 /src/agents.md
 /agents.md
+*.p8

--- a/src/modules/user/dtos/user-clubs-response.dto.ts
+++ b/src/modules/user/dtos/user-clubs-response.dto.ts
@@ -1,4 +1,4 @@
-import { ClubAuthority, ClubCategory } from '@prisma/client';
+import { ClubAuthority, ClubCategory, ClubUserStatus } from '@prisma/client';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class UserClubItemDto {
@@ -28,6 +28,9 @@ export class UserClubItemDto {
 
   @ApiProperty({ enum: ClubAuthority, example: ClubAuthority.GENERAL })
   authority!: ClubAuthority;
+
+  @ApiProperty({ enum: ClubUserStatus, example: ClubUserStatus.PENDING })
+  status!: ClubUserStatus;
 
   @ApiProperty({ example: '2026-05-02T15:40:00.000Z' })
   joinedAt!: string;

--- a/src/modules/user/dtos/user-clubs-response.dto.ts
+++ b/src/modules/user/dtos/user-clubs-response.dto.ts
@@ -32,8 +32,11 @@ export class UserClubItemDto {
   @ApiProperty({ enum: ClubUserStatus, example: ClubUserStatus.PENDING })
   status!: ClubUserStatus;
 
-  @ApiProperty({ example: '2026-05-02T15:40:00.000Z' })
-  joinedAt!: string;
+  @ApiPropertyOptional({
+    example: '2026-05-02T15:40:00.000Z',
+    nullable: true,
+  })
+  joinedAt!: string | null;
 }
 
 export class UserClubsResponseDto {

--- a/src/modules/user/repositories/user.repository.ts
+++ b/src/modules/user/repositories/user.repository.ts
@@ -284,15 +284,16 @@ export class UserRepository {
     });
   }
 
-  findMyActiveClubs(userId: number) {
+  findMyClubs(userId: number) {
     return this.prismaService.clubUser.findMany({
       where: {
         userId: BigInt(userId),
-        status: ClubUserStatus.ACTIVE,
+        status: { in: [ClubUserStatus.ACTIVE, ClubUserStatus.PENDING] },
         club: { deletedAt: null },
       },
       select: {
         authority: true,
+        status: true,
         joinedAt: true,
         club: {
           select: {
@@ -308,7 +309,7 @@ export class UserRepository {
           },
         },
       },
-      orderBy: { joinedAt: 'desc' },
+      orderBy: [{ joinedAt: 'desc' }, { requestedAt: 'desc' }],
     });
   }
 

--- a/src/modules/user/services/user/user.service.spec.ts
+++ b/src/modules/user/services/user/user.service.spec.ts
@@ -106,8 +106,7 @@ describe('UserService', () => {
           memberCount: 1,
           authority: ClubAuthority.GENERAL,
           status: ClubUserStatus.PENDING,
-          joinedAt: '',
-        },
+          joinedAt: null,
       ],
     });
   });

--- a/src/modules/user/services/user/user.service.spec.ts
+++ b/src/modules/user/services/user/user.service.spec.ts
@@ -107,6 +107,7 @@ describe('UserService', () => {
           authority: ClubAuthority.GENERAL,
           status: ClubUserStatus.PENDING,
           joinedAt: null,
+        },
       ],
     });
   });

--- a/src/modules/user/services/user/user.service.spec.ts
+++ b/src/modules/user/services/user/user.service.spec.ts
@@ -1,5 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { ClubAuthority, ClubCategory, Sex } from '@prisma/client';
+import {
+  ClubAuthority,
+  ClubCategory,
+  ClubUserStatus,
+  Sex,
+} from '@prisma/client';
 import { UserService } from './user.service';
 import { UserRepository } from '../../repositories/user.repository';
 
@@ -12,7 +17,7 @@ describe('UserService', () => {
     findPersonalitiesByBodies: jest.fn(),
     findAllPersonalities: jest.fn(),
     findPublicProfileById: jest.fn(),
-    findMyActiveClubs: jest.fn(),
+    findMyClubs: jest.fn(),
     findMyLikedClubs: jest.fn(),
     findMyLatestProfileVisitors: jest.fn(),
     findActiveUserId: jest.fn(),
@@ -45,11 +50,12 @@ describe('UserService', () => {
     expect(service).toBeDefined();
   });
 
-  it('내 ACTIVE 동호회 목록을 반환한다', async () => {
+  it('내 ACTIVE/PENDING 동호회 목록을 반환한다', async () => {
     const joinedAt = new Date('2026-05-02T15:40:00.000Z');
-    repositoryMock.findMyActiveClubs.mockResolvedValue([
+    repositoryMock.findMyClubs.mockResolvedValue([
       {
         authority: ClubAuthority.HOST,
+        status: ClubUserStatus.ACTIVE,
         joinedAt,
         club: {
           id: 12n,
@@ -60,11 +66,24 @@ describe('UserService', () => {
           clubUsers: [{ id: 1n }, { id: 2n }],
         },
       },
+      {
+        authority: ClubAuthority.GENERAL,
+        status: ClubUserStatus.PENDING,
+        joinedAt: null,
+        club: {
+          id: 13n,
+          name: '승인 대기 동호회',
+          thumbnailUrl: null,
+          category: ClubCategory.OTHERS,
+          introText: null,
+          clubUsers: [{ id: 1n }],
+        },
+      },
     ]);
 
     const result = await service.getMyClubs(7);
 
-    expect(repositoryMock.findMyActiveClubs).toHaveBeenCalledWith(7);
+    expect(repositoryMock.findMyClubs).toHaveBeenCalledWith(7);
     expect(result).toEqual({
       items: [
         {
@@ -75,7 +94,19 @@ describe('UserService', () => {
           introText: '테스트용 동호회입니다.',
           memberCount: 2,
           authority: ClubAuthority.HOST,
+          status: ClubUserStatus.ACTIVE,
           joinedAt: joinedAt.toISOString(),
+        },
+        {
+          clubId: 13,
+          name: '승인 대기 동호회',
+          thumbnailUrl: null,
+          category: ClubCategory.OTHERS,
+          introText: null,
+          memberCount: 1,
+          authority: ClubAuthority.GENERAL,
+          status: ClubUserStatus.PENDING,
+          joinedAt: '',
         },
       ],
     });
@@ -85,7 +116,7 @@ describe('UserService', () => {
     await expect(service.getMyClubs(0)).rejects.toMatchObject({
       internalCode: 'AUTH_LOGIN_REQUIRED',
     });
-    expect(repositoryMock.findMyActiveClubs).not.toHaveBeenCalled();
+    expect(repositoryMock.findMyClubs).not.toHaveBeenCalled();
   });
 
   it('내가 찜한 동호회 목록을 반환한다', async () => {

--- a/src/modules/user/services/user/user.service.ts
+++ b/src/modules/user/services/user/user.service.ts
@@ -123,8 +123,7 @@ export class UserService {
         memberCount: membership.club.clubUsers.length,
         authority: membership.authority,
         status: membership.status,
-        joinedAt: membership.joinedAt?.toISOString() ?? '',
-      })),
+        joinedAt: membership.joinedAt?.toISOString() ?? null,
     };
   }
 

--- a/src/modules/user/services/user/user.service.ts
+++ b/src/modules/user/services/user/user.service.ts
@@ -111,7 +111,7 @@ export class UserService {
       throw new AppException('AUTH_LOGIN_REQUIRED');
     }
 
-    const memberships = await this.userRepository.findMyActiveClubs(userId);
+    const memberships = await this.userRepository.findMyClubs(userId);
 
     return {
       items: memberships.map((membership) => ({
@@ -122,6 +122,7 @@ export class UserService {
         introText: membership.club.introText,
         memberCount: membership.club.clubUsers.length,
         authority: membership.authority,
+        status: membership.status,
         joinedAt: membership.joinedAt?.toISOString() ?? '',
       })),
     };

--- a/src/modules/user/services/user/user.service.ts
+++ b/src/modules/user/services/user/user.service.ts
@@ -124,6 +124,7 @@ export class UserService {
         authority: membership.authority,
         status: membership.status,
         joinedAt: membership.joinedAt?.toISOString() ?? null,
+      })),
     };
   }
 


### PR DESCRIPTION
## 주요 변경사항
- 클럽 유저 도메인 ap: GET /v1/users/me/clubs에 PENDING 여부추가
- 기존 가입된 내 동호회 목록 불러오기 -> 활성 상태 여부 상관 없이 가입 신청한 동호회 목록 불러오기로 수정하렸습니다. 

- 애플 private key 파일을 .gitignore에 추가하였습니다. 