### PR TITLE
[EUM-70] [Fix] 마음 조회 api 관련 에러 처리

### DIFF
--- a/src/modules/social/controllers/heart/heart.controller.ts
+++ b/src/modules/social/controllers/heart/heart.controller.ts
@@ -22,14 +22,13 @@ import {
 } from '@nestjs/swagger';
 import { HeartService } from '../../services/heart/heart.service';
 import {
+  CreateHeartRequestDto,
   HeartListPayload,
   HeartReceivedItem,
   HeartSentItem,
 } from '../../dtos/heart.dto';
 import { RequiredUserId } from '../../../auth/decorators';
 import { AccessTokenGuard } from '../../../auth/guards/access-token.guard';
-import { AppException } from '../../../../common/errors/app.exception';
-import { ERROR_DEFINITIONS } from '../../../../common/errors/error-codes';
 import { BlockFilterInterceptor } from '../../../../common/interceptors/block-filter.interceptor';
 
 @ApiTags('Heart')
@@ -42,13 +41,7 @@ export class HeartController {
   @Post()
   @ApiOperation({ summary: '하트 보내기' })
   @ApiBody({
-    schema: {
-      type: 'object',
-      properties: {
-        targetUserId: { type: 'string', example: '24' },
-      },
-      required: ['targetUserId'],
-    },
+    type: CreateHeartRequestDto,
   })
   @ApiOkResponse({
     description: '하트 전송 결과',
@@ -63,17 +56,9 @@ export class HeartController {
   @ApiUnauthorizedResponse({ description: '로그인 필요' })
   public async postHeart(
     @RequiredUserId() userId: number,
-    @Body('targetUserId') targetUserId?: string,
+    @Body() dto: CreateHeartRequestDto,
   ) {
-    if (!targetUserId) {
-      throw new AppException('VALIDATION_INVALID_FORMAT', {
-        message: ERROR_DEFINITIONS.VALIDATION_INVALID_FORMAT.message,
-        details: {
-          field: 'targetUserId',
-        },
-      });
-    }
-    return this.heartService.createHeart(String(userId), targetUserId);
+    return this.heartService.createHeart(String(userId), dto.targetUserId);
   }
 
   @Patch(':heartId')
@@ -110,7 +95,7 @@ export class HeartController {
             type: 'object',
             properties: {
               heartId: { type: 'number', example: 201 },
-              fromUserId: { type: 'number', example: 9 },
+              fromUserId: { type: 'number', nullable: true, example: 9 },
               createdAt: { type: 'string', format: 'date-time' },
               fromUser: {
                 type: 'object',
@@ -123,6 +108,8 @@ export class HeartController {
                   nickname: { type: 'string', example: '사용자123' },
                   age: { type: 'number', example: 25 },
                 },
+                description:
+                  '유저가 삭제되어 Heart.sentById가 null이면 nickname은 "삭제된 사용자", id는 0으로 반환됩니다.',
               },
             },
           },
@@ -164,7 +151,7 @@ export class HeartController {
             type: 'object',
             properties: {
               heartId: { type: 'number', example: 301 },
-              targetUserId: { type: 'number', example: 12 },
+              targetUserId: { type: 'number', nullable: true, example: 12 },
               createdAt: { type: 'string', format: 'date-time' },
               targetUser: {
                 type: 'object',
@@ -177,6 +164,8 @@ export class HeartController {
                   nickname: { type: 'string', example: '사용자456' },
                   age: { type: 'number', example: 27 },
                 },
+                description:
+                  '유저가 삭제되어 Heart.sentToId가 null이면 nickname은 "삭제된 사용자", id는 0으로 반환됩니다.',
               },
             },
           },

--- a/src/modules/social/dtos/heart.dto.ts
+++ b/src/modules/social/dtos/heart.dto.ts
@@ -1,3 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, Matches } from 'class-validator';
+
+export class CreateHeartRequestDto {
+  @ApiProperty({
+    description: '하트를 받을 대상 유저 ID',
+    example: '24',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @Matches(/^[1-9][0-9]*$/)
+  targetUserId: string;
+}
+
 export interface UserProfileInfo {
   id: number;
   nickname: string;
@@ -28,12 +42,12 @@ export interface HeartItemBase {
 }
 
 export interface HeartSentItem extends HeartItemBase {
-  targetUserId: number;
+  targetUserId: number | null;
   targetUser: UserProfileInfo;
 }
 
 export interface HeartReceivedItem extends HeartItemBase {
-  fromUserId: number;
+  fromUserId: number | null;
   fromUser: UserProfileInfo;
 }
 

--- a/src/modules/social/repositories/heart.repository.spec.ts
+++ b/src/modules/social/repositories/heart.repository.spec.ts
@@ -1,0 +1,172 @@
+import { ActiveStatus, type Prisma } from '@prisma/client';
+import { HeartRepository } from './heart.repository';
+
+describe('HeartRepository', () => {
+  let repository: HeartRepository;
+
+  const heartModel = {
+    findMany: jest.fn<Promise<unknown[]>, [Prisma.HeartFindManyArgs]>(),
+    findFirst: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+  };
+  const userModel = {
+    findFirst: jest.fn(),
+  };
+  const prisma = {
+    heart: heartModel,
+    user: userModel,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    repository = new HeartRepository(prisma as never);
+  });
+
+  describe('postHeart', () => {
+    it('로그인 유저가 대상 유저에게 하트를 보내면 sentById, sentToId가 모두 저장된다', async () => {
+      userModel.findFirst.mockResolvedValue({ id: 24n });
+      heartModel.findFirst.mockResolvedValue(null);
+      heartModel.create.mockResolvedValue({
+        id: 101n,
+        createdAt: new Date('2026-07-04T00:00:00.000Z'),
+      });
+
+      const result = await repository.postHeart('7', '24');
+
+      expect(result).toEqual({
+        ok: true,
+        heart: {
+          heartId: 101,
+          createdAt: '2026-07-04T00:00:00.000Z',
+        },
+      });
+      expect(userModel.findFirst).toHaveBeenCalledWith({
+        where: {
+          id: 24n,
+          status: ActiveStatus.ACTIVE,
+          deletedAt: null,
+        },
+        select: { id: true },
+      });
+      expect(heartModel.create).toHaveBeenCalledWith({
+        data: {
+          sentById: 7n,
+          sentToId: 24n,
+          status: ActiveStatus.ACTIVE,
+        },
+      });
+    });
+
+    it('대상 유저 id가 유효하지 않으면 생성하지 않는다', async () => {
+      const result = await repository.postHeart('7', '0');
+
+      expect(result).toEqual({ ok: false, reason: 'INVALID_USER_ID' });
+      expect(heartModel.create).not.toHaveBeenCalled();
+    });
+
+    it('삭제되었거나 비활성인 대상 유저는 존재하지 않는 대상으로 처리한다', async () => {
+      userModel.findFirst.mockResolvedValue(null);
+
+      const result = await repository.postHeart('7', '24');
+
+      expect(result).toEqual({ ok: false, reason: 'TARGET_NOT_FOUND' });
+      expect(heartModel.create).not.toHaveBeenCalled();
+    });
+
+    it('같은 유저에게 ACTIVE Heart를 중복 생성하지 않는다', async () => {
+      userModel.findFirst.mockResolvedValue({ id: 24n });
+      heartModel.findFirst.mockResolvedValueOnce({ id: 1n });
+
+      const result = await repository.postHeart('7', '24');
+
+      expect(result).toEqual({ ok: false, reason: 'ALREADY_EXISTS' });
+      expect(heartModel.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getReceivedHeartsByUserId', () => {
+    it('sentById가 null인 Heart row도 조회 후보에 포함한다', async () => {
+      heartModel.findMany.mockResolvedValue([]);
+
+      await repository.getReceivedHeartsByUserId({ userId: '11', size: 20 });
+
+      expect(heartModel.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            sentToId: 11n,
+            status: ActiveStatus.ACTIVE,
+            deletedAt: null,
+          },
+        }),
+      );
+    });
+
+    it('sentById가 null인 item은 fromUserId null로 매핑한다', async () => {
+      heartModel.findMany.mockResolvedValue([
+        {
+          id: 29n,
+          sentById: null,
+          sentToId: 11n,
+          createdAt: new Date('2026-07-04T02:50:18.949Z'),
+        },
+        {
+          id: 24n,
+          sentById: 174n,
+          sentToId: 11n,
+          createdAt: new Date('2026-07-04T02:08:32.165Z'),
+        },
+      ]);
+
+      const result = await repository.getReceivedHeartsByUserId({
+        userId: '11',
+        size: 20,
+      });
+
+      expect(result).toEqual({
+        nextCursor: null,
+        items: [
+          {
+            heartId: 29,
+            fromUserId: null,
+            createdAt: '2026-07-04T02:50:18.949Z',
+          },
+          {
+            heartId: 24,
+            fromUserId: 174,
+            createdAt: '2026-07-04T02:08:32.165Z',
+          },
+        ],
+      });
+    });
+  });
+
+  describe('getSentHeartsByUserId', () => {
+    it('sentToId가 null인 item은 targetUserId null로 매핑한다', async () => {
+      heartModel.findMany.mockResolvedValue([
+        {
+          id: 30n,
+          sentById: 174n,
+          sentToId: null,
+          createdAt: new Date('2026-07-04T02:52:31.680Z'),
+        },
+      ]);
+
+      const result = await repository.getSentHeartsByUserId({
+        userId: '174',
+        size: 20,
+      });
+
+      expect(result).toEqual({
+        nextCursor: null,
+        items: [
+          {
+            heartId: 30,
+            targetUserId: null,
+            createdAt: '2026-07-04T02:52:31.680Z',
+          },
+        ],
+      });
+    });
+  });
+});

--- a/src/modules/social/repositories/heart.repository.ts
+++ b/src/modules/social/repositories/heart.repository.ts
@@ -9,18 +9,21 @@ import { HeartItemBase, HeartListPayload } from '../dtos/heart.dto';
 type HeartSentItemBase = {
   heartId: number;
   createdAt: string;
-  targetUserId: number;
+  targetUserId: number | null;
 };
 
 type HeartReceivedItemBase = {
   heartId: number;
   createdAt: string;
-  fromUserId: number;
+  fromUserId: number | null;
 };
 
 type PostHeartResult =
   | { ok: true; heart: HeartItemBase }
-  | { ok: false; reason: 'TARGET_NOT_FOUND' | 'ALREADY_EXISTS' };
+  | {
+      ok: false;
+      reason: 'TARGET_NOT_FOUND' | 'ALREADY_EXISTS' | 'INVALID_USER_ID';
+    };
 
 @Injectable()
 export class HeartRepository {
@@ -33,19 +36,39 @@ export class HeartRepository {
     return BigInt(value);
   }
 
+  private toPositiveBigInt(value: string | number | bigint): bigint | null {
+    try {
+      const parsed = this.toBigInt(value);
+      return parsed > 0n ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+
   async postHeart(
     sentById: string | number | bigint,
     sentToId: string | number | bigint,
   ): Promise<PostHeartResult> {
+    const parsedSentById = this.toPositiveBigInt(sentById);
+    const parsedSentToId = this.toPositiveBigInt(sentToId);
+    if (!parsedSentById || !parsedSentToId) {
+      return { ok: false, reason: 'INVALID_USER_ID' };
+    }
+
     const payload = {
-      sentById: this.toBigInt(sentById),
-      sentToId: this.toBigInt(sentToId),
+      sentById: parsedSentById,
+      sentToId: parsedSentToId,
+      status: ActiveStatus.ACTIVE,
     };
     this.logger.debug(
       `postHeart sentById=${payload.sentById} sentToId=${payload.sentToId}`,
     );
-    const targetUser = await this.prisma.user.findUnique({
-      where: { id: payload.sentToId },
+    const targetUser = await this.prisma.user.findFirst({
+      where: {
+        id: payload.sentToId,
+        status: ActiveStatus.ACTIVE,
+        deletedAt: null,
+      },
       select: { id: true },
     });
     if (!targetUser) {
@@ -56,6 +79,7 @@ export class HeartRepository {
         sentById: payload.sentById,
         sentToId: payload.sentToId,
         status: ActiveStatus.ACTIVE,
+        deletedAt: null,
       },
     });
     if (exist != null) {
@@ -159,14 +183,14 @@ export class HeartRepository {
       const mappedItems: HeartSentItemBase[] = items.map((item) => ({
         heartId: Number(item.id),
         createdAt: item.createdAt.toISOString(),
-        targetUserId: Number(item.sentToId),
+        targetUserId: item.sentToId == null ? null : Number(item.sentToId),
       }));
       return { nextCursor, items: mappedItems };
     } else {
       const mappedItems: HeartReceivedItemBase[] = items.map((item) => ({
         heartId: Number(item.id),
         createdAt: item.createdAt.toISOString(),
-        fromUserId: Number(item.sentById),
+        fromUserId: item.sentById == null ? null : Number(item.sentById),
       }));
       return { nextCursor, items: mappedItems };
     }
@@ -182,7 +206,11 @@ export class HeartRepository {
       `getReceivedHeartsByUserId userId=${sentToId} cursor=${params.cursor} size=${params.size}`,
     );
     const result = await this.findHeartsWithCursor({
-      where: { sentToId, status: ActiveStatus.ACTIVE, deletedAt: null },
+      where: {
+        sentToId,
+        status: ActiveStatus.ACTIVE,
+        deletedAt: null,
+      },
       cursor: params.cursor,
       size: params.size,
       isSent: false,
@@ -202,7 +230,11 @@ export class HeartRepository {
       `getSentHeartsByUserId userId=${sentById} cursor=${params.cursor} size=${params.size}`,
     );
     const result = await this.findHeartsWithCursor({
-      where: { sentById, status: ActiveStatus.ACTIVE, deletedAt: null },
+      where: {
+        sentById,
+        status: ActiveStatus.ACTIVE,
+        deletedAt: null,
+      },
       cursor: params.cursor,
       size: params.size,
       isSent: true,

--- a/src/modules/social/services/heart/heart.service.spec.ts
+++ b/src/modules/social/services/heart/heart.service.spec.ts
@@ -3,42 +3,286 @@ import { HeartService } from './heart.service';
 import { HeartRepository } from '../../repositories/heart.repository';
 import { NotificationService } from '../../../notification/services/notification.service';
 import { UserService } from '../../../user/services/user/user.service';
+import { AppException } from '../../../../common/errors/app.exception';
 
 describe('HeartService', () => {
   let service: HeartService;
 
+  const postHeart = jest.fn();
+  const patchHeart = jest.fn();
+  const getReceivedHeartsByUserId = jest.fn();
+  const getSentHeartsByUserId = jest.fn();
+  const createNotification = jest.fn();
+  const getMe = jest.fn();
+  const getDetailedProfile = jest.fn();
+
+  const profile = {
+    id: 174,
+    nickname: 'sender',
+    birthdate: '1970-01-01T00:00:00.000Z',
+    profileImageUrl: null,
+    introText: null,
+    introVoiceUrl: null,
+    address: { fullName: '서울시 강남구' },
+    interests: [],
+    personalities: [],
+  };
+  const deletedUserProfile = {
+    id: 0,
+    nickname: '삭제된 사용자',
+    birthdate: '',
+    profileImageUrl: null,
+    introText: null,
+    introVoiceUrl: null,
+    address: { fullName: '' },
+    interests: [],
+    personalities: [],
+  };
+
   beforeEach(async () => {
+    jest.clearAllMocks();
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         HeartService,
         {
           provide: HeartRepository,
           useValue: {
-            postHeart: jest.fn(),
-            deleteHeart: jest.fn(),
-            getReceivedHearts: jest.fn(),
-            getSentHearts: jest.fn(),
+            postHeart,
+            patchHeart,
+            getReceivedHeartsByUserId,
+            getSentHeartsByUserId,
           },
         },
         {
           provide: NotificationService,
           useValue: {
-            createNotification: jest.fn(),
+            createNotification,
           },
         },
         {
           provide: UserService,
           useValue: {
-            getMe: jest.fn().mockResolvedValue({ nickname: 'TestUser' }),
+            getMe,
+            getDetailedProfile,
           },
         },
       ],
     }).compile();
 
     service = module.get<HeartService>(HeartService);
+    getMe.mockResolvedValue({ nickname: 'TestUser' });
+    createNotification.mockResolvedValue(undefined);
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('createHeart', () => {
+    it('로그인 유저가 대상 유저에게 하트를 보내면 repository와 알림을 호출한다', async () => {
+      postHeart.mockResolvedValue({
+        ok: true,
+        heart: {
+          heartId: 101,
+          createdAt: '2026-07-04T00:00:00.000Z',
+        },
+      });
+
+      await expect(service.createHeart('7', '24')).resolves.toEqual({
+        heartId: 101,
+        createdAt: '2026-07-04T00:00:00.000Z',
+      });
+
+      expect(postHeart).toHaveBeenCalledWith('7', '24');
+      expect(createNotification).toHaveBeenCalledWith(
+        24,
+        'HEART',
+        '마음을 누른 사람이 생겼습니다!',
+        'TestUser님이 회원님에게 마음을 보냈습니다.',
+        7,
+      );
+    });
+
+    it('sentToId가 없거나 유효하지 않으면 validation 에러를 던진다', async () => {
+      await expect(service.createHeart('7', '0')).rejects.toMatchObject({
+        internalCode: 'VALIDATION_INVALID_FORMAT',
+      });
+      expect(postHeart).not.toHaveBeenCalled();
+    });
+
+    it('자기 자신에게 하트를 보낼 수 없다', async () => {
+      await expect(service.createHeart('7', '7')).rejects.toMatchObject({
+        internalCode: 'VALIDATION_INVALID_FORMAT',
+      });
+      expect(postHeart).not.toHaveBeenCalled();
+    });
+
+    it('존재하지 않거나 삭제/비활성인 유저에게 하트를 보낼 수 없다', async () => {
+      postHeart.mockResolvedValue({
+        ok: false,
+        reason: 'TARGET_NOT_FOUND',
+      });
+
+      await expect(service.createHeart('7', '24')).rejects.toMatchObject({
+        internalCode: 'SOCIAL_TARGET_USER_NOT_FOUND',
+      });
+      expect(createNotification).not.toHaveBeenCalled();
+    });
+
+    it('같은 유저에게 ACTIVE Heart를 중복으로 보낼 수 없다', async () => {
+      postHeart.mockResolvedValue({
+        ok: false,
+        reason: 'ALREADY_EXISTS',
+      });
+
+      await expect(service.createHeart('7', '24')).rejects.toMatchObject({
+        internalCode: 'SOCIAL_HEART_ALREADY_EXISTS',
+      });
+      expect(createNotification).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getReceivedHearts', () => {
+    it('정상 Heart row는 기존 응답 포맷대로 내려간다', async () => {
+      getReceivedHeartsByUserId.mockResolvedValue({
+        nextCursor: null,
+        items: [
+          {
+            heartId: 24,
+            createdAt: '2026-07-04T02:08:32.165Z',
+            fromUserId: 174,
+          },
+        ],
+      });
+      getDetailedProfile.mockResolvedValue(profile);
+
+      await expect(
+        service.getReceivedHearts({
+          userId: '11',
+          path: '/api/v1/hearts/received',
+        }),
+      ).resolves.toEqual({
+        nextCursor: null,
+        items: [
+          {
+            heartId: 24,
+            createdAt: '2026-07-04T02:08:32.165Z',
+            fromUserId: 174,
+            fromUser: profile,
+          },
+        ],
+      });
+    });
+
+    it('sentById가 null인 Heart row는 삭제된 사용자 placeholder로 반환한다', async () => {
+      getReceivedHeartsByUserId.mockResolvedValue({
+        nextCursor: null,
+        items: [
+          {
+            heartId: 29,
+            createdAt: '2026-07-04T02:50:18.949Z',
+            fromUserId: null,
+          },
+          {
+            heartId: 24,
+            createdAt: '2026-07-04T02:08:32.165Z',
+            fromUserId: 174,
+          },
+        ],
+      });
+      getDetailedProfile.mockResolvedValue(profile);
+
+      await expect(
+        service.getReceivedHearts({
+          userId: '11',
+          path: '/api/v1/hearts/received',
+        }),
+      ).resolves.toEqual({
+        nextCursor: null,
+        items: [
+          {
+            heartId: 29,
+            createdAt: '2026-07-04T02:50:18.949Z',
+            fromUserId: null,
+            fromUser: deletedUserProfile,
+          },
+          {
+            heartId: 24,
+            createdAt: '2026-07-04T02:08:32.165Z',
+            fromUserId: 174,
+            fromUser: profile,
+          },
+        ],
+      });
+      expect(getDetailedProfile).toHaveBeenCalledTimes(1);
+      expect(getDetailedProfile).toHaveBeenCalledWith(174);
+    });
+
+    it('보낸 유저 프로필 조회가 실패해도 인증 오류로 전체 실패하지 않는다', async () => {
+      getReceivedHeartsByUserId.mockResolvedValue({
+        nextCursor: null,
+        items: [
+          {
+            heartId: 24,
+            createdAt: '2026-07-04T02:08:32.165Z',
+            fromUserId: 174,
+          },
+        ],
+      });
+      getDetailedProfile.mockRejectedValue(
+        new AppException('AUTH_LOGIN_REQUIRED'),
+      );
+
+      await expect(
+        service.getReceivedHearts({
+          userId: '11',
+          path: '/api/v1/hearts/received',
+        }),
+      ).resolves.toEqual({
+        nextCursor: null,
+        items: [
+          {
+            heartId: 24,
+            createdAt: '2026-07-04T02:08:32.165Z',
+            fromUserId: 174,
+            fromUser: deletedUserProfile,
+          },
+        ],
+      });
+    });
+  });
+
+  describe('getSentHearts', () => {
+    it('sentToId가 null인 Heart row는 삭제된 사용자 placeholder로 반환한다', async () => {
+      getSentHeartsByUserId.mockResolvedValue({
+        nextCursor: null,
+        items: [
+          {
+            heartId: 30,
+            createdAt: '2026-07-04T02:52:31.680Z',
+            targetUserId: null,
+          },
+        ],
+      });
+
+      await expect(
+        service.getSentHearts({
+          userId: '174',
+          path: '/api/v1/hearts/sent',
+        }),
+      ).resolves.toEqual({
+        nextCursor: null,
+        items: [
+          {
+            heartId: 30,
+            createdAt: '2026-07-04T02:52:31.680Z',
+            targetUserId: null,
+            targetUser: deletedUserProfile,
+          },
+        ],
+      });
+      expect(getDetailedProfile).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/modules/social/services/heart/heart.service.ts
+++ b/src/modules/social/services/heart/heart.service.ts
@@ -5,6 +5,7 @@ import {
   HeartSentItem,
   HeartListPayload,
   HeartItemBase,
+  UserProfileInfo,
 } from '../../dtos/heart.dto';
 import { AppException } from '../../../../common/errors/app.exception';
 import { ERROR_DEFINITIONS } from '../../../../common/errors/error-codes';
@@ -32,28 +33,49 @@ export class HeartService {
     userId: string,
     targetUserId: string,
   ): Promise<HeartItemBase> {
-    const result = await this.heartRepository.postHeart(userId, targetUserId);
-    const userName = await this.userService
-      .getMe(Number(userId))
-      .then((user) => user.nickname);
-    try {
-      await this.notificationService.createNotification(
-        Number(targetUserId),
-        'HEART',
-        '마음을 누른 사람이 생겼습니다!',
-        `${userName}님이 회원님에게 마음을 보냈습니다.`,
-        Number(userId),
-      );
-    } catch {
-      throw new AppException('SERVER_TEMPORARY_ERROR', {
-        message: ERROR_DEFINITIONS.SERVER_TEMPORARY_ERROR.message,
+    if (!this.isPositiveIntegerString(userId)) {
+      throw new AppException('AUTH_LOGIN_REQUIRED');
+    }
+    if (!this.isPositiveIntegerString(targetUserId)) {
+      throw new AppException('VALIDATION_INVALID_FORMAT', {
+        message: ERROR_DEFINITIONS.VALIDATION_INVALID_FORMAT.message,
         details: { field: 'targetUserId' },
       });
     }
+    if (userId === targetUserId) {
+      throw new AppException('VALIDATION_INVALID_FORMAT', {
+        message: ERROR_DEFINITIONS.VALIDATION_INVALID_FORMAT.message,
+        details: { field: 'targetUserId' },
+      });
+    }
+
+    const result = await this.heartRepository.postHeart(userId, targetUserId);
     if (result.ok) {
+      const userName = await this.userService
+        .getMe(Number(userId))
+        .then((user) => user.nickname);
+      try {
+        await this.notificationService.createNotification(
+          Number(targetUserId),
+          'HEART',
+          '마음을 누른 사람이 생겼습니다!',
+          `${userName}님이 회원님에게 마음을 보냈습니다.`,
+          Number(userId),
+        );
+      } catch {
+        throw new AppException('SERVER_TEMPORARY_ERROR', {
+          message: ERROR_DEFINITIONS.SERVER_TEMPORARY_ERROR.message,
+          details: { field: 'targetUserId' },
+        });
+      }
       return result.heart;
     } else {
-      if (result.reason === 'TARGET_NOT_FOUND') {
+      if (result.reason === 'INVALID_USER_ID') {
+        throw new AppException('VALIDATION_INVALID_FORMAT', {
+          message: ERROR_DEFINITIONS.VALIDATION_INVALID_FORMAT.message,
+          details: { field: 'targetUserId' },
+        });
+      } else if (result.reason === 'TARGET_NOT_FOUND') {
         throw new AppException('SOCIAL_TARGET_USER_NOT_FOUND', {
           message: ERROR_DEFINITIONS.SOCIAL_TARGET_USER_NOT_FOUND.message,
           details: { field: 'targetUserId' },
@@ -100,16 +122,18 @@ export class HeartService {
       });
 
     // 각 하트를 보낸 사용자의 프로필 정보를 가져옴
-    const itemsWithProfile = await Promise.all(
-      result.items.map(async (item) => {
-        const fromUserId = Number(item.fromUserId);
-        const fromUser = await this.userService.getDetailedProfile(fromUserId);
-        return {
-          ...item,
-          fromUser,
-        };
-      }),
-    );
+    const itemsWithProfile: HeartReceivedItem[] = [];
+    for (const item of result.items) {
+      const fromUser = await this.getProfileOrDeletedPlaceholder(
+        item.fromUserId,
+        item.heartId,
+        'received',
+      );
+      itemsWithProfile.push({
+        ...item,
+        fromUser,
+      });
+    }
 
     return {
       nextCursor: result.nextCursor,
@@ -135,21 +159,64 @@ export class HeartService {
       });
 
     // 각 하트를 받은 사용자의 프로필 정보를 가져옴
-    const itemsWithProfile = await Promise.all(
-      result.items.map(async (item) => {
-        const targetUserId = Number(item.targetUserId);
-        const targetUser =
-          await this.userService.getDetailedProfile(targetUserId);
-        return {
-          ...item,
-          targetUser,
-        };
-      }),
-    );
+    const itemsWithProfile: HeartSentItem[] = [];
+    for (const item of result.items) {
+      const targetUser = await this.getProfileOrDeletedPlaceholder(
+        item.targetUserId,
+        item.heartId,
+        'sent',
+      );
+      itemsWithProfile.push({
+        ...item,
+        targetUser,
+      });
+    }
 
     return {
       nextCursor: result.nextCursor,
       items: itemsWithProfile,
+    };
+  }
+
+  private isPositiveIntegerString(value: string): boolean {
+    return /^[1-9][0-9]*$/.test(value);
+  }
+
+  private async getProfileOrDeletedPlaceholder(
+    userId: number | null,
+    heartId: number,
+    context: 'received' | 'sent',
+  ): Promise<UserProfileInfo> {
+    if (userId == null || !Number.isSafeInteger(userId) || userId <= 0) {
+      this.logger.warn(
+        `heart ${context} list uses deleted user placeholder heartId=${heartId} userId=${userId}`,
+      );
+      return this.deletedUserProfile();
+    }
+
+    try {
+      return await this.userService.getDetailedProfile(userId);
+    } catch (error) {
+      this.logger.warn(
+        `heart ${context} list profile unavailable heartId=${heartId} userId=${userId}: ${String(error)}`,
+      );
+      return this.deletedUserProfile();
+    }
+  }
+
+  private deletedUserProfile(): UserProfileInfo {
+    return {
+      id: 0,
+      nickname: '삭제된 사용자',
+      birthdate: '',
+      profileImageUrl: null,
+      introText: null,
+      introVoiceUrl: null,
+      address: {
+        fullName: '',
+      },
+      interests: [],
+      personalities: [],
     };
   }
 


### PR DESCRIPTION
## 이슈 번호
close #232 

## 주요 변경사항
  - Heart 생성 요청 DTO(`CreateHeartRequestDto`)를 추가해 `targetUserId` 필수값 및 양의 정수 문자열 검증을 적용했습니다.
  - Heart 생성 시 로그인 유저 ID, 대상 유저 ID, 자기 자신에게 하트 전송 여부를 검증하도록 보강했습니다.
  - 대상 유저가 존재하지 않거나 삭제/비활성 상태이면 하트가 생성되지 않도록 수정했습니다.
  - 동일한 `sentById`, `sentToId` 조합의 ACTIVE Heart 중복 생성을 방지했습니다.
  - Heart 생성 성공 이후에만 알림이 생성되도록 처리 순서를 정리했습니다.
  - `/hearts/received`, `/hearts/sent` 목록에서 `sentById` 또는 `sentToId`가 null인 경우 row를 숨기지 않고 `"삭제된 사용자"` placeholder를 반환하도록 수정했습니다.
  - `Number(null) === 0`으로 인해 `getDetailedProfile(0)`이 호출되어 인증 오류로 오인되는 문제를 방어했습니다.
  - Heart repository/service 단위 테스트를 추가 및 보강했습니다.

  ## 테스트 결과 (스크린샷)
<img width="1512" height="982" alt="스크린샷 2026-07-04 오후 4 10 41" src="https://github.com/user-attachments/assets/ba908312-3ae2-4e4a-9e1b-81ec04557470" />

> 삭제된 사용자라는 반환 값 확인가능 , 하트를 보낸 대상이 탈퇴할경우 . sentToId - null로 세팅. setnull정책은 유지 

  ## 참고 및 개선사항
  - `Heart.sentById`, `Heart.sentToId`는 기존 정책대로 nullable + `onDelete: SetNull`을 유지했습니다.
  - **유저가 삭제되어 FK가 null이 된 Heart row는 목록에서 유지되며, 사용자 정보는 `"삭제된 사용자"`로 내려갑니다.**

