### PR TITLE
[EUM-77] feat: 동호회 공개 여부에 따른 게시물/댓글/사진 조회 권한 변경

### DIFF
--- a/src/modules/article/controllers/article.controller.spec.ts
+++ b/src/modules/article/controllers/article.controller.spec.ts
@@ -64,8 +64,8 @@ describe('ArticleController', () => {
     };
     serviceMock.findArchivePhotos.mockResolvedValue(expected);
 
-    const res = await controller.findArchive(1, { sort: 'recent' });
-    expect(serviceMock.findArchivePhotos).toHaveBeenCalledWith(1, {
+    const res = await controller.findArchive(10, 1, { sort: 'recent' });
+    expect(serviceMock.findArchivePhotos).toHaveBeenCalledWith(10, 1, {
       sort: 'recent',
     });
     expect(res).toEqual(expected);

--- a/src/modules/article/controllers/article.controller.ts
+++ b/src/modules/article/controllers/article.controller.ts
@@ -69,10 +69,11 @@ export class ArticleController {
   @Get()
   @UseGuards(AccessTokenGuard)
   findArticles(
+    @RequiredUserId() userId: number,
     @Param('clubId', new ParsePositiveIntPipe()) clubId: number,
     @Query() query: ListArticlesQueryDto,
   ) {
-    return this.articleService.findClubArticles(clubId, query);
+    return this.articleService.findClubArticles(userId, clubId, query);
   }
 
   @ApiOperation({ summary: '동호회 사진 모음 조회' })
@@ -98,10 +99,11 @@ export class ArticleController {
   @Get('archive')
   @UseGuards(AccessTokenGuard)
   findArchive(
+    @RequiredUserId() userId: number,
     @Param('clubId', new ParsePositiveIntPipe()) clubId: number,
     @Query() query: ListArticlesQueryDto,
   ) {
-    return this.articleService.findArchivePhotos(clubId, query);
+    return this.articleService.findArchivePhotos(userId, clubId, query);
   }
 
   @ApiOperation({ summary: '동호회 게시글 상세 조회' })

--- a/src/modules/article/repositories/article.repository.ts
+++ b/src/modules/article/repositories/article.repository.ts
@@ -120,6 +120,21 @@ export class ArticleRepository {
     return club !== null;
   }
 
+  async findClubReadSettings(
+    clubId: number,
+  ): Promise<{ id: bigint; boardPublic: boolean } | null> {
+    return this.prisma.club.findFirst({
+      where: {
+        id: BigInt(clubId),
+        deletedAt: null,
+      },
+      select: {
+        id: true,
+        boardPublic: true,
+      },
+    });
+  }
+
   async existsActiveClubUser(userId: number, clubId: number): Promise<boolean> {
     const clubUser = await this.prisma.clubUser.findFirst({
       where: {

--- a/src/modules/article/services/article.service.spec.ts
+++ b/src/modules/article/services/article.service.spec.ts
@@ -20,6 +20,7 @@ describe('ArticleService', () => {
     findArchivePhotos: jest.fn(),
     existsClub: jest.fn(),
     existsActiveClubUser: jest.fn(),
+    findClubReadSettings: jest.fn(),
   };
   const notificationServiceMock = {
     createNotification: jest.fn(),
@@ -68,8 +69,49 @@ describe('ArticleService', () => {
   });
 
   describe('findArticleDetail', () => {
-    it('checks active club membership before reading detail', async () => {
-      repositoryMock.existsClub.mockResolvedValue(true);
+    it('allows authenticated non-members to read detail when club board is public', async () => {
+      repositoryMock.findClubReadSettings.mockResolvedValue({
+        id: 1n,
+        boardPublic: true,
+      });
+      repositoryMock.findArticleDetail.mockResolvedValue({
+        article: {
+          id: 1n,
+          clubId: 1n,
+          title: 'title',
+          contents: 'contents',
+          category: 'FREE',
+          isPinned: false,
+          view: 1,
+          likes: 0,
+          userId: 2n,
+          user: {
+            id: 2n,
+            nickname: 'author',
+            profileImageUrl: 'https://example.com/profile.jpg',
+          },
+          articleLikes: [],
+          articlePhotos: [],
+          comments: [],
+          createdAt: new Date('2026-05-01T17:40:00.000Z'),
+          updatedAt: null,
+        },
+        authorAuthorities: new Map(),
+      });
+
+      const res = await service.findArticleDetail(10, 1, 1);
+
+      expect(repositoryMock.existsActiveClubUser).not.toHaveBeenCalled();
+      expect(repositoryMock.findArticleDetail).toHaveBeenCalledWith(10, 1, 1);
+      expect(res.isMine).toBe(false);
+      expect(res.isLiked).toBe(false);
+    });
+
+    it('checks active club membership before reading private club detail', async () => {
+      repositoryMock.findClubReadSettings.mockResolvedValue({
+        id: 1n,
+        boardPublic: false,
+      });
       repositoryMock.existsActiveClubUser.mockResolvedValue(false);
 
       await expect(service.findArticleDetail(1, 1, 1)).rejects.toMatchObject({
@@ -203,7 +245,10 @@ describe('ArticleService', () => {
 
   describe('findArchivePhotos', () => {
     it('returns archive response with paginated photos', async () => {
-      repositoryMock.existsClub.mockResolvedValue(true);
+      repositoryMock.findClubReadSettings.mockResolvedValue({
+        id: 1n,
+        boardPublic: true,
+      });
       repositoryMock.findArchivePhotos.mockResolvedValue([
         {
           id: BigInt(101),
@@ -213,7 +258,7 @@ describe('ArticleService', () => {
         },
       ]);
 
-      const res = await service.findArchivePhotos(1, { sort: 'recent' });
+      const res = await service.findArchivePhotos(10, 1, { sort: 'recent' });
 
       expect(res.items).toHaveLength(1);
       expect(res.items[0].photoId).toBe(101);
@@ -223,7 +268,10 @@ describe('ArticleService', () => {
     });
 
     it('sets hasMore true when extra photo exists', async () => {
-      repositoryMock.existsClub.mockResolvedValue(true);
+      repositoryMock.findClubReadSettings.mockResolvedValue({
+        id: 1n,
+        boardPublic: true,
+      });
       const mockPhotos = Array(21)
         .fill(0)
         .map((_, i) => ({
@@ -234,7 +282,7 @@ describe('ArticleService', () => {
         }));
       repositoryMock.findArchivePhotos.mockResolvedValue(mockPhotos);
 
-      const res = await service.findArchivePhotos(1, { limit: 20 });
+      const res = await service.findArchivePhotos(10, 1, { limit: 20 });
 
       expect(res.items).toHaveLength(20);
       expect(res.hasMore).toBe(true);
@@ -242,10 +290,10 @@ describe('ArticleService', () => {
     });
 
     it('throws AppException when club not found', async () => {
-      repositoryMock.existsClub.mockResolvedValue(false);
+      repositoryMock.findClubReadSettings.mockResolvedValue(null);
 
       await expect(
-        service.findArchivePhotos(999, { sort: 'recent' }),
+        service.findArchivePhotos(10, 999, { sort: 'recent' }),
       ).rejects.toThrow();
     });
   });

--- a/src/modules/article/services/article.service.ts
+++ b/src/modules/article/services/article.service.ts
@@ -35,10 +35,11 @@ export class ArticleService {
   ) {}
 
   async findClubArticles(
+    userId: number,
     clubId: number,
     query: ListArticlesQueryDto,
   ): Promise<ListArticlesResponseDto> {
-    await this.ensureClubExists(clubId);
+    await this.ensureClubReadable(userId, clubId);
 
     const take = query.limit ?? 20;
     const result = await this.articleRepository.findArticlesByClub(clubId, {
@@ -122,8 +123,7 @@ export class ArticleService {
     clubId: number,
     articleId: number,
   ): Promise<ArticleDetailDto> {
-    await this.ensureClubExists(clubId);
-    await this.ensureClubMember(userId, clubId);
+    await this.ensureClubReadable(userId, clubId);
 
     const result = await this.articleRepository.findArticleDetail(
       userId,
@@ -283,6 +283,23 @@ export class ArticleService {
     if (!exists) {
       throw new AppException('CLUB_NOT_FOUND');
     }
+  }
+
+  private async ensureClubReadable(
+    userId: number,
+    clubId: number,
+  ): Promise<void> {
+    const club = await this.articleRepository.findClubReadSettings(clubId);
+
+    if (!club) {
+      throw new AppException('CLUB_NOT_FOUND');
+    }
+
+    if (club.boardPublic) {
+      return;
+    }
+
+    await this.ensureClubMember(userId, clubId);
   }
 
   private async ensureClubMember(
@@ -471,6 +488,7 @@ export class ArticleService {
   }
 
   async findArchivePhotos(
+    userId: number,
     clubId: number,
     query: ListArticlesQueryDto,
   ): Promise<{
@@ -483,7 +501,7 @@ export class ArticleService {
     nextCursor: string | null;
     hasMore: boolean;
   }> {
-    await this.ensureClubExists(clubId);
+    await this.ensureClubReadable(userId, clubId);
 
     const take = query.limit ?? 20;
     const result = await this.articleRepository.findArchivePhotos(clubId, {

--- a/src/modules/club/repositories/club.repository.ts
+++ b/src/modules/club/repositories/club.repository.ts
@@ -159,6 +159,21 @@ export class ClubRepository {
     });
   }
 
+  async findBoardReadSettings(clubId: bigint): Promise<{
+    id: bigint;
+    deletedAt: Date | null;
+    boardPublic: boolean;
+  } | null> {
+    return this.prisma.club.findUnique({
+      where: { id: clubId },
+      select: {
+        id: true,
+        deletedAt: true,
+        boardPublic: true,
+      },
+    });
+  }
+
   // 채팅방 목록 표시용 배치 조회.
   async findClubBriefsByIds(
     clubIds: bigint[],

--- a/src/modules/comment/services/comment.service.spec.ts
+++ b/src/modules/comment/services/comment.service.spec.ts
@@ -23,6 +23,7 @@ describe('CommentService', () => {
   };
   const clubRepository = {
     findById: jest.fn(),
+    findBoardReadSettings: jest.fn(),
     findActiveClubUser: jest.fn(),
   };
   const notificationService = {
@@ -286,7 +287,11 @@ describe('CommentService', () => {
   });
 
   it('댓글 목록을 조회한다', async () => {
-    clubRepository.findById.mockResolvedValue({ id: 1n, deletedAt: null });
+    clubRepository.findBoardReadSettings.mockResolvedValue({
+      id: 1n,
+      deletedAt: null,
+      boardPublic: false,
+    });
     repository.findArticleByClubId.mockResolvedValue({ id: 1n });
     clubRepository.findActiveClubUser.mockResolvedValue({ id: 10n });
     repository.countComments.mockResolvedValue(2);
@@ -349,8 +354,49 @@ describe('CommentService', () => {
     });
   });
 
+  it('게시판이 공개 상태면 인증된 비회원도 댓글 목록을 조회한다', async () => {
+    clubRepository.findBoardReadSettings.mockResolvedValue({
+      id: 1n,
+      deletedAt: null,
+      boardPublic: true,
+    });
+    repository.findArticleByClubId.mockResolvedValue({ id: 1n });
+    repository.countComments.mockResolvedValue(1);
+    repository.findCommentsWithReplies.mockResolvedValue([
+      {
+        id: 555n,
+        articleId: 1n,
+        parentCommentId: null,
+        depth: 0,
+        contents: '공개 댓글',
+        userId: 2n,
+        createdAt: new Date('2026-05-01T15:20:00.000Z'),
+        user: {
+          id: 2n,
+          nickname: '보이스마스터',
+          profileImageUrl: 'https://cdn.example.com/profile/2.jpg',
+          clubUsers: [{ authority: ClubAuthority.GENERAL }],
+        },
+        replies: [],
+      },
+    ]);
+
+    const result = await service.listComments(userId, clubId, articleId, {});
+
+    expect(clubRepository.findActiveClubUser).not.toHaveBeenCalled();
+    expect(result.comments[0]).toMatchObject({
+      commentId: 555,
+      isMine: false,
+      contents: '공개 댓글',
+    });
+  });
+
   it('limit보다 결과가 많으면 nextCursor와 hasMore를 내려준다', async () => {
-    clubRepository.findById.mockResolvedValue({ id: 1n, deletedAt: null });
+    clubRepository.findBoardReadSettings.mockResolvedValue({
+      id: 1n,
+      deletedAt: null,
+      boardPublic: false,
+    });
     repository.findArticleByClubId.mockResolvedValue({ id: 1n });
     clubRepository.findActiveClubUser.mockResolvedValue({ id: 10n });
     repository.countComments.mockResolvedValue(2);
@@ -399,7 +445,11 @@ describe('CommentService', () => {
   });
 
   it('클럽 멤버가 아니면 댓글 목록 조회가 거부된다', async () => {
-    clubRepository.findById.mockResolvedValue({ id: 1n, deletedAt: null });
+    clubRepository.findBoardReadSettings.mockResolvedValue({
+      id: 1n,
+      deletedAt: null,
+      boardPublic: false,
+    });
     repository.findArticleByClubId.mockResolvedValue({ id: 1n });
     clubRepository.findActiveClubUser.mockResolvedValue(null);
 

--- a/src/modules/comment/services/comment.service.ts
+++ b/src/modules/comment/services/comment.service.ts
@@ -224,7 +224,26 @@ export class CommentService {
     clubId: number,
     articleId: number,
   ) {
-    await this.validateArticleExists(clubId, articleId);
+    const club = await this.clubRepository.findBoardReadSettings(
+      BigInt(clubId),
+    );
+
+    if (!club || club.deletedAt) {
+      throw new AppException('CLUB_NOT_FOUND');
+    }
+
+    const article = await this.commentRepository.findArticleByClubId(
+      BigInt(clubId),
+      BigInt(articleId),
+    );
+
+    if (!article) {
+      throw new AppException('ARTICLE_NOT_FOUND');
+    }
+
+    if (club.boardPublic) {
+      return;
+    }
 
     const clubUser = await this.clubRepository.findActiveClubUser(
       BigInt(userId),


### PR DESCRIPTION
## 이슈 번호
close #241 

## 주요 변경사항
- boardPublic이 true로 설정된 동호회의 경우, 비회원도 게시물/댓글/사진을 조회 가능하도록 변경했습니다.
- GET을 제외한 다른 변경/삭제/생성 요청에 대해서는 boardPublic과 무관하게 회원이 아닌 경우 제한됩니다.

## 테스트 결과 (스크린샷)
1. boardPublic==true인 경우, 가입되지 않은 동호회의 게시물 목록 조회(성공)
<img width="1536" height="481" alt="image" src="https://github.com/user-attachments/assets/3348e7d9-0a2f-4a37-bcb6-3204e4a63f49" />

3. boardPublic==true인 경우, 가입되지 않은 동호회의 게시물 좋아요 시도(거절)
<img width="1616" height="548" alt="image" src="https://github.com/user-attachments/assets/3911d907-12a2-4f4f-a7fa-aa18b0f21ad3" />

4. boardPublic==true인 경우, 가입되지 않은 동호회의 댓글 작성 시도(거절)
<img width="1564" height="451" alt="image" src="https://github.com/user-attachments/assets/b4d798e6-fd36-4418-8cff-8aeafa63c13d" />

5. boardPublic==false인 경우, 가입되지 않은 동호회의 게시물 목록 조회(거절)
<img width="1555" height="405" alt="image" src="https://github.com/user-attachments/assets/a853f192-844e-4904-9dfc-3477e0398c69" />

6. boardPublic==false인 경우, 가입되지 않은 동호회의 댓글 조회(거절)
<img width="1566" height="508" alt="image" src="https://github.com/user-attachments/assets/050e24f3-918e-40ca-a293-2542ebd36bcf" />


## 참고 및 개선사항
- 
