### PR TITLE
[EUM-79] [Fix] s3 presigned url 저장방식 변경. DB에는 영속한 값은 s3 Key 값 저장해두기

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -44,6 +44,18 @@ const REPORT_COUNT = DUMMY_COUNT * 2;
 const ADDRESS_CHUNK_SIZE = 5_000;
 const now = new Date('2026-01-10T09:00:00.000Z');
 
+const S3_SEED_BUCKET =
+  process.env.S3_SEED_BUCKET?.trim() || 'eum-voice-staging';
+
+function s3Uri(...parts: Array<string | number | bigint>) {
+  const key = parts
+    .map((part) => String(part).replace(/^\/+|\/+$/g, ''))
+    .filter(Boolean)
+    .join('/');
+
+  return `s3://${S3_SEED_BUCKET}/${key}`;
+}
+
 function requiredEnv(name: string) {
   const value = process.env[name]?.trim();
   if (!value) {
@@ -202,9 +214,9 @@ async function insertUsers() {
       ${daysFromSeed(index)},
       ${`seed-user-${index + 1}`},
       ${daysFromSeed(index)},
-      ${`https://cdn.example.com/voice/intro/seed-user-${index + 1}.m4a`},
+      ${s3Uri('voice', 'intro', `seed-user-${index + 1}.m4a`)},
       ${`seed intro text ${index + 1}`},
-      ${`https://cdn.example.com/images/profile/seed-user-${index + 1}.jpg`},
+      ${s3Uri('images', id, 'profile', `seed-user-${index + 1}.jpg`)},
       ${'ACTIVE'}::"ActiveStatus",
       ${index < 5 ? '1111010100' : '1111010200'},
       ${'KAKAO'}::"AuthProvider",
@@ -234,14 +246,16 @@ async function insertClubs() {
     'STUDY',
     'OTHERS',
   ];
+
   const rows = Array.from({ length: DUMMY_COUNT }, (_, index) => {
     const id = BigInt(index + 1);
+    const hostId = BigInt(index + 1);
 
     return Prisma.sql`(
       ${id},
-      ${BigInt(index + 1)},
+      ${hostId},
       ${`Seed Club ${index + 1}`},
-      ${`https://cdn.example.com/voice/club/seed-club-${index + 1}.m4a`},
+      ${s3Uri('voice', 'club', id, `seed-club-${index + 1}.m4a`)},
       ${`seed club intro ${index + 1}`},
       ${categories[index % categories.length]}::"ClubCategory",
       ${20 + index},
@@ -250,7 +264,7 @@ async function insertClubs() {
       ${index < 5 ? '1111010100' : '1111010200'},
       ${index * 2},
       ${vectorLiteral(index + 20)}::vector,
-      ${`https://cdn.example.com/images/club/seed-club-${index + 1}.jpg`}
+      ${s3Uri('images', id, 'club', `seed-club-${index + 1}.jpg`)}
     )`;
   });
 
@@ -302,7 +316,12 @@ async function insertDummyData() {
     data: Array.from({ length: DUMMY_COUNT }, (_, index) => ({
       id: BigInt(index + 1),
       userId: BigInt(index + 1),
-      url: `https://cdn.example.com/images/user-photo/seed-${index + 1}.jpg`,
+      url: s3Uri(
+        'images',
+        BigInt(index + 1),
+        'user-photo',
+        `seed-${index + 1}.jpg`,
+      ),
       createdAt: daysFromSeed(index),
     })),
     skipDuplicates: true,
@@ -505,6 +524,7 @@ async function insertDummyData() {
   await prisma.meeting.createMany({
     data: Array.from({ length: DUMMY_COUNT }, (_, index) => {
       const type = RECURRENCE_TYPES[index % RECURRENCE_TYPES.length];
+
       return {
         id: BigInt(index + 1),
         name: `Seed Meeting ${index + 1}`,
@@ -580,7 +600,12 @@ async function insertDummyData() {
   await prisma.articlePhoto.createMany({
     data: Array.from({ length: DUMMY_COUNT }, (_, index) => ({
       id: BigInt(index + 1),
-      photoUrl: `https://cdn.example.com/images/article/seed-${index + 1}.jpg`,
+      photoUrl: s3Uri(
+        'images',
+        BigInt(index + 1),
+        'article',
+        `seed-${index + 1}.jpg`,
+      ),
       createdAt: daysFromSeed(index),
       articleId: BigInt(index + 1),
       clubUserId: BigInt(index + 1),

--- a/src/common/interceptors/response.interceptor.ts
+++ b/src/common/interceptors/response.interceptor.ts
@@ -4,14 +4,17 @@ import {
   Injectable,
   NestInterceptor,
 } from '@nestjs/common';
-import { map, type Observable } from 'rxjs';
+import { mergeMap, type Observable } from 'rxjs';
 import type { ApiSuccessResponse } from '../dto/api-response.dto';
+import { S3ObjectUrlService } from '../s3/s3-object-url.service';
 
 @Injectable()
 export class ResponseInterceptor<T> implements NestInterceptor<
   T,
   ApiSuccessResponse<T>
 > {
+  constructor(private readonly s3ObjectUrlService: S3ObjectUrlService) {}
+
   intercept(
     context: ExecutionContext,
     next: CallHandler<T>,
@@ -21,12 +24,14 @@ export class ResponseInterceptor<T> implements NestInterceptor<
       .getRequest<{ originalUrl?: string; url?: string }>();
 
     return next.handle().pipe(
-      map((data) => {
+      mergeMap(async (data) => {
         const payload = data === undefined ? ({} as unknown as T) : data;
+        const transformedPayload =
+          await this.s3ObjectUrlService.transformClientUrlFields(payload);
 
         return {
-          resultType: 'SUCCESS',
-          success: { data: payload },
+          resultType: 'SUCCESS' as const,
+          success: { data: transformedPayload },
           error: null,
           meta: {
             timestamp: new Date().toISOString(),

--- a/src/common/s3/s3-object-url.module.ts
+++ b/src/common/s3/s3-object-url.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { S3ObjectUrlService } from './s3-object-url.service';
+
+@Global()
+@Module({
+  providers: [S3ObjectUrlService],
+  exports: [S3ObjectUrlService],
+})
+export class S3ObjectUrlModule {}

--- a/src/common/s3/s3-object-url.service.spec.ts
+++ b/src/common/s3/s3-object-url.service.spec.ts
@@ -1,0 +1,23 @@
+import { normalizeS3ObjectRef } from './s3-object-url.service';
+
+describe('normalizeS3ObjectRef', () => {
+  it('keeps s3 refs unchanged', () => {
+    expect(normalizeS3ObjectRef('s3://bucket/images/1.jpg')).toBe(
+      's3://bucket/images/1.jpg',
+    );
+  });
+
+  it('normalizes virtual-hosted S3 URLs to s3 refs', () => {
+    expect(
+      normalizeS3ObjectRef(
+        'https://bucket.s3.ap-northeast-2.amazonaws.com/images/1.jpg?X-Amz-Signature=abc',
+      ),
+    ).toBe('s3://bucket/images/1.jpg');
+  });
+
+  it('keeps non-S3 URLs unchanged', () => {
+    expect(normalizeS3ObjectRef('https://cdn.example.com/images/1.jpg')).toBe(
+      'https://cdn.example.com/images/1.jpg',
+    );
+  });
+});

--- a/src/common/s3/s3-object-url.service.ts
+++ b/src/common/s3/s3-object-url.service.ts
@@ -1,0 +1,167 @@
+import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { AppException } from '../errors/app.exception';
+
+type ParsedS3Ref = {
+  bucket: string;
+  key: string;
+};
+
+const S3_REF_PREFIX = 's3://';
+const DEFAULT_GET_EXPIRES_SEC = 60 * 60;
+const CLIENT_URL_FIELDS = new Set([
+  'profileImageUrl',
+  'thumbnailUrl',
+  'photoUrl',
+  'imageUrl',
+  'introVoiceUrl',
+  'introAudioUrl',
+  'mediaUrl',
+]);
+
+function parseS3Ref(input: string): ParsedS3Ref | null {
+  if (!input.startsWith(S3_REF_PREFIX)) return null;
+
+  const rest = input.slice(S3_REF_PREFIX.length);
+  const separatorIndex = rest.indexOf('/');
+  if (separatorIndex <= 0 || separatorIndex === rest.length - 1) {
+    throw new AppException('VALIDATION_INVALID_FORMAT', {
+      message: 'S3 파일 참조 형식이 올바르지 않습니다.',
+    });
+  }
+
+  return {
+    bucket: rest.slice(0, separatorIndex),
+    key: rest.slice(separatorIndex + 1),
+  };
+}
+
+function parseS3HttpsUrl(input: string): ParsedS3Ref | null {
+  let url: URL;
+  try {
+    url = new URL(input);
+  } catch {
+    return null;
+  }
+
+  if (url.protocol !== 'https:') return null;
+
+  const hostParts = url.hostname.split('.');
+  const rawPath = url.pathname.replace(/^\/+/, '');
+  if (!rawPath) return null;
+
+  if (hostParts.length >= 3 && hostParts[1] === 's3') {
+    return {
+      bucket: hostParts[0],
+      key: decodeURIComponent(rawPath),
+    };
+  }
+
+  if (hostParts.length >= 3 && hostParts[0] === 's3') {
+    const separatorIndex = rawPath.indexOf('/');
+    if (separatorIndex <= 0 || separatorIndex === rawPath.length - 1) {
+      return null;
+    }
+
+    return {
+      bucket: rawPath.slice(0, separatorIndex),
+      key: decodeURIComponent(rawPath.slice(separatorIndex + 1)),
+    };
+  }
+
+  return null;
+}
+
+export function buildS3StoredRef(bucket: string, key: string): string {
+  return `${S3_REF_PREFIX}${bucket}/${key}`;
+}
+
+export function normalizeS3ObjectRef(input: string): string {
+  const trimmed = input.trim();
+  const parsed = parseS3Ref(trimmed) ?? parseS3HttpsUrl(trimmed);
+  if (!parsed) return trimmed;
+
+  return buildS3StoredRef(parsed.bucket, parsed.key);
+}
+
+@Injectable()
+export class S3ObjectUrlService {
+  private readonly s3: S3Client;
+  private readonly defaultBucket: string;
+  private readonly getExpiresSec: number;
+
+  constructor(private readonly configService: ConfigService) {
+    const accessKeyId = this.configService.get<string>('AWS_ACCESS_KEY_ID');
+    const secretAccessKey = this.configService.get<string>(
+      'AWS_SECRET_ACCESS_KEY',
+    );
+
+    this.s3 = new S3Client({
+      region: this.configService.get<string>('AWS_REGION'),
+      ...(accessKeyId && secretAccessKey
+        ? { credentials: { accessKeyId, secretAccessKey } }
+        : {}),
+    });
+    this.defaultBucket = this.configService.getOrThrow<string>('AWS_S3_BUCKET');
+    this.getExpiresSec = this.configService.get<number>(
+      'S3_GET_PRESIGN_EXPIRES_SEC',
+      DEFAULT_GET_EXPIRES_SEC,
+    );
+  }
+
+  buildStoredRef(key: string, bucket = this.defaultBucket): string {
+    return buildS3StoredRef(bucket, key);
+  }
+
+  normalizeToStoredRef(input: string): string {
+    return normalizeS3ObjectRef(input);
+  }
+
+  async toClientUrl(input: string | null): Promise<string | null> {
+    if (!input) return null;
+
+    const parsed = parseS3Ref(input) ?? parseS3HttpsUrl(input);
+    if (!parsed) return input;
+
+    const command = new GetObjectCommand({
+      Bucket: parsed.bucket,
+      Key: parsed.key,
+    });
+
+    return getSignedUrl(this.s3, command, { expiresIn: this.getExpiresSec });
+  }
+
+  async transformClientUrlFields<T>(value: T): Promise<T> {
+    return this.transform(value, null) as Promise<T>;
+  }
+
+  private async transform(
+    value: unknown,
+    key: string | null,
+  ): Promise<unknown> {
+    if (typeof value === 'string') {
+      return key && CLIENT_URL_FIELDS.has(key)
+        ? this.toClientUrl(value)
+        : value;
+    }
+
+    if (value === null || typeof value !== 'object' || value instanceof Date) {
+      return value;
+    }
+
+    if (Array.isArray(value)) {
+      return Promise.all(value.map((item) => this.transform(item, null)));
+    }
+
+    const entries = await Promise.all(
+      Object.entries(value).map(async ([entryKey, entryValue]) => [
+        entryKey,
+        await this.transform(entryValue, entryKey),
+      ]),
+    );
+
+    return Object.fromEntries(entries);
+  }
+}

--- a/src/config/env.schema.ts
+++ b/src/config/env.schema.ts
@@ -14,6 +14,7 @@ export const envSchema = z.object({
   AWS_ACCESS_KEY_ID: z.string().min(1).optional(),
   AWS_SECRET_ACCESS_KEY: z.string().min(1).optional(),
   AWS_S3_BUCKET: z.string().min(1),
+  S3_GET_PRESIGN_EXPIRES_SEC: z.coerce.number().int().positive().optional(),
   FASTAPI_BASE_URL: z.string().url().default('http://fastapi.eum.local:8000'),
   FASTAPI_TIMEOUT_MS: z.coerce.number().int().positive().default(10000),
   FASTAPI_PROFILE_ANALYSIS_PATH: z

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import { GlobalExceptionFilter } from './common/filters/global-exception.filter'
 import { ResponseInterceptor } from './common/interceptors/response.interceptor';
 import { AppException } from './common/errors/app.exception';
 import { setupSwagger } from './swagger';
+import { S3ObjectUrlService } from './common/s3/s3-object-url.service';
 
 import { SocketIoAdapter } from './infra/websocket/socket-io.adapter';
 
@@ -83,7 +84,9 @@ async function bootstrap() {
     }),
   );
 
-  app.useGlobalInterceptors(new ResponseInterceptor());
+  app.useGlobalInterceptors(
+    new ResponseInterceptor(app.get(S3ObjectUrlService)),
+  );
   app.useGlobalFilters(new GlobalExceptionFilter(logger));
   app.useWebSocketAdapter(new SocketIoAdapter(app, configService));
 

--- a/src/modules/app/app.module.ts
+++ b/src/modules/app/app.module.ts
@@ -16,6 +16,7 @@ import { ClubModule } from '../club/club.module';
 import { WebsocketCommonModule } from 'src/infra/websocket/websocket-common.module';
 import { ArticleModule } from '../article/article.module';
 import { CommentModule } from '../comment/comment.module';
+import { S3ObjectUrlModule } from 'src/common/s3/s3-object-url.module';
 
 @Module({
   imports: [
@@ -33,6 +34,7 @@ import { CommentModule } from '../comment/comment.module';
         return parsed.data;
       },
     }),
+    S3ObjectUrlModule,
     HealthModule,
     PrismaModule,
     WebsocketCommonModule,

--- a/src/modules/article/dtos/create-article.dto.ts
+++ b/src/modules/article/dtos/create-article.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { ArticleCategory } from '@prisma/client';
-import { IsString, IsEnum, IsArray, IsOptional, IsUrl } from 'class-validator';
+import { IsString, IsEnum, IsArray, IsOptional } from 'class-validator';
 
 export class CreateArticleDto {
   @ApiProperty({ example: '이번 주 정모 후기 공유합니다!' })
@@ -17,13 +17,13 @@ export class CreateArticleDto {
 
   @ApiPropertyOptional({
     example: [
-      'https://cdn.example.com/articles/abc123.jpg',
-      'https://cdn.example.com/articles/def456.jpg',
+      's3://eum-voice-staging/images/42/article/abc123.jpg',
+      's3://eum-voice-staging/images/42/article/def456.jpg',
     ],
     type: [String],
   })
   @IsOptional()
   @IsArray()
-  @IsUrl({}, { each: true })
+  @IsString({ each: true })
   photoUrls?: string[];
 }

--- a/src/modules/article/dtos/update-article.dto.ts
+++ b/src/modules/article/dtos/update-article.dto.ts
@@ -1,6 +1,6 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { ArticleCategory } from '@prisma/client';
-import { IsArray, IsEnum, IsOptional, IsString, IsUrl } from 'class-validator';
+import { IsArray, IsEnum, IsOptional, IsString } from 'class-validator';
 
 export class UpdateArticleDto {
   @ApiPropertyOptional({ example: '수정된 제목' })
@@ -19,11 +19,11 @@ export class UpdateArticleDto {
   category?: ArticleCategory;
 
   @ApiPropertyOptional({
-    example: ['https://cdn.example.com/articles/new.jpg'],
+    example: ['s3://eum-voice-staging/images/42/article/new.jpg'],
     type: [String],
   })
   @IsOptional()
   @IsArray()
-  @IsUrl({}, { each: true })
+  @IsString({ each: true })
   photoUrls?: string[];
 }

--- a/src/modules/article/services/article.service.ts
+++ b/src/modules/article/services/article.service.ts
@@ -23,6 +23,7 @@ import { ListArticlesQueryDto } from '../dtos/list-articles-query.dto';
 import { AppException } from '../../../common/errors/app.exception';
 import { UpdateArticleDto } from '../dtos/update-article.dto';
 import { NotificationService } from '../../notification/services/notification.service';
+import { normalizeS3ObjectRef } from '../../../common/s3/s3-object-url.service';
 
 type ArticleEntity = Awaited<ReturnType<ArticleRepository['createArticle']>>;
 
@@ -108,7 +109,9 @@ export class ArticleService {
       createArticleDto.title,
       createArticleDto.contents,
       createArticleDto.category,
-      createArticleDto.photoUrls,
+      createArticleDto.photoUrls?.map((photoUrl) =>
+        normalizeS3ObjectRef(photoUrl),
+      ),
     );
 
     return this.toArticleDto(result);
@@ -141,11 +144,18 @@ export class ArticleService {
     articleId: number,
     updateArticleDto: UpdateArticleDto,
   ): Promise<UpdateArticleResponseDto> {
+    const normalizedDto: UpdateArticleDto = {
+      ...updateArticleDto,
+      photoUrls: updateArticleDto.photoUrls?.map((photoUrl) =>
+        normalizeS3ObjectRef(photoUrl),
+      ),
+    };
+
     const result = await this.articleRepository.updateArticle(
       userId,
       clubId,
       articleId,
-      updateArticleDto,
+      normalizedDto,
     );
 
     if (result.status === 'not_found') {

--- a/src/modules/club/dtos/club.dto.ts
+++ b/src/modules/club/dtos/club.dto.ts
@@ -9,7 +9,6 @@ import {
   IsNotEmpty,
   IsOptional,
   IsString,
-  IsUrl,
   Max,
   Min,
 } from 'class-validator';
@@ -77,19 +76,19 @@ export class CreateClubRequestDto {
   boardPublic: boolean;
 
   @ApiProperty({
-    description: '클럽 대표 썸네일 이미지 URL',
-    example: 'https://cdn.example.com/clubs/12/thumbnail.jpg',
+    description: '클럽 대표 썸네일 이미지 S3 참조',
+    example: 's3://eum-voice-staging/images/42/club/thumbnail.jpg',
   })
   @IsString()
   @IsNotEmpty()
-  @IsUrl()
   thumbnailUrl: string;
 
   @ApiPropertyOptional({
-    description: '클럽 추가 이미지 URL 목록. 최대 4장까지 입력할 수 있습니다.',
+    description:
+      '클럽 추가 이미지 S3 참조 목록. 최대 4장까지 입력할 수 있습니다.',
     example: [
-      'https://cdn.example.com/clubs/12/images/1.jpg',
-      'https://cdn.example.com/clubs/12/images/2.jpg',
+      's3://eum-voice-staging/images/42/club/1.jpg',
+      's3://eum-voice-staging/images/42/club/2.jpg',
     ],
     isArray: true,
     maxItems: 4,
@@ -98,7 +97,6 @@ export class CreateClubRequestDto {
   @IsArray()
   @ArrayMaxSize(4)
   @IsString({ each: true })
-  @IsUrl(undefined, { each: true })
   imageUrls?: string[];
 }
 

--- a/src/modules/club/services/club/club.service.ts
+++ b/src/modules/club/services/club/club.service.ts
@@ -24,6 +24,7 @@ import { toClubDetailDto, toClubListItemDto } from '../../utils/club.mapper';
 import { AppException } from '../../../../common/errors/app.exception';
 import { UserRepository } from '../../../user/repositories/user.repository';
 import { OnboardingAiService } from '../../../onboarding/services/onboarding-ai.service';
+import { normalizeS3ObjectRef } from '../../../../common/s3/s3-object-url.service';
 
 @Injectable()
 export class ClubService {
@@ -51,8 +52,10 @@ export class ClubService {
       addressCode: dto.areaCode,
       approvalRequired: dto.approvalRequired,
       boardPublic: dto.boardPublic,
-      thumbnailUrl: dto.thumbnailUrl,
-      imageUrls: dto.imageUrls,
+      thumbnailUrl: normalizeS3ObjectRef(dto.thumbnailUrl),
+      imageUrls: dto.imageUrls?.map((imageUrl) =>
+        normalizeS3ObjectRef(imageUrl),
+      ),
     });
 
     try {
@@ -324,7 +327,10 @@ export class ClubService {
 
     if (dto.name !== undefined) data.name = dto.name;
     if (dto.introText !== undefined) data.introText = dto.introText;
-    if (dto.introVoice !== undefined) data.introVoiceUrl = dto.introVoice;
+    if (dto.introVoice !== undefined) {
+      data.introVoiceUrl =
+        dto.introVoice === null ? null : normalizeS3ObjectRef(dto.introVoice);
+    }
     if (dto.capacity !== undefined) data.capacity = dto.capacity;
     if (dto.category !== undefined) data.category = dto.category;
 

--- a/src/modules/onboarding/controllers/files.controller.ts
+++ b/src/modules/onboarding/controllers/files.controller.ts
@@ -1,20 +1,23 @@
 import { Body, Controller, Post, UseGuards } from '@nestjs/common';
 import { FileUploadService } from '../services/files.service';
-import { PresignFileDto } from '../dtos/files.dto';
+import { PresignFileDto, PresignFileResponseDto } from '../dtos/files.dto';
 import { AppException } from '../../../common/errors/app.exception';
 import { RequiredUserId } from 'src/modules/auth/decorators';
 import {
   ApiBearerAuth,
   ApiBody,
+  ApiExtraModels,
   ApiOkResponse,
   ApiOperation,
   ApiTags,
   ApiUnauthorizedResponse,
+  getSchemaPath,
 } from '@nestjs/swagger';
 import { AccessTokenGuard } from 'src/modules/auth/guards/access-token.guard';
 
 @ApiTags('Files')
 @ApiBearerAuth('access-token')
+@ApiExtraModels(PresignFileResponseDto)
 @Controller('files')
 export class FilesController {
   constructor(private readonly fileUploadService: FileUploadService) {}
@@ -24,7 +27,7 @@ export class FilesController {
   @ApiOperation({
     summary: '파일 업로드용 presigned URL 발급',
     description:
-      "프로필 소개 음성, 프로필 이미지, 클럽 이미지 업로드용 S3 presigned URL을 발급합니다. purpose가 'CLUB'이면 파일은 images/{userId}/club 경로에 저장됩니다.",
+      "프로필 소개 음성, 프로필 이미지, 클럽 이미지 업로드용 S3 presigned URL을 발급합니다. uploadUrl은 PUT 업로드에만 사용하고, 저장 API에는 fileRef를 전달해야 합니다. purpose가 'CLUB'이면 파일은 images/{userId}/club 경로에 저장됩니다.",
   })
   @ApiBody({
     type: PresignFileDto,
@@ -58,6 +61,25 @@ export class FilesController {
   @ApiOkResponse({
     description: 'presigned URL 발급 성공',
     schema: {
+      properties: {
+        resultType: { example: 'SUCCESS' },
+        success: {
+          properties: {
+            data: {
+              properties: {
+                data: { $ref: getSchemaPath(PresignFileResponseDto) },
+              },
+            },
+          },
+        },
+        error: { example: null },
+        meta: {
+          properties: {
+            timestamp: { example: '2026-07-04T00:00:00.000Z' },
+            path: { example: '/api/v1/files/presign' },
+          },
+        },
+      },
       example: {
         resultType: 'SUCCESS',
         success: {
@@ -65,9 +87,10 @@ export class FilesController {
             data: {
               uploadUrl:
                 'https://bucket.s3.ap-northeast-2.amazonaws.com/images/42/club/1783139000000_club-cover.jpg?...',
-              fileUrl:
-                'https://bucket.s3.ap-northeast-2.amazonaws.com/images/42/club/1783139000000_club-cover.jpg?...',
-              expiresAt: '2026-07-11T00:00:00.000Z',
+              fileRef:
+                's3://bucket/images/42/club/1783139000000_club-cover.jpg',
+              key: 'images/42/club/1783139000000_club-cover.jpg',
+              expiresAt: '2026-07-04T00:05:00.000Z',
             },
           },
         },
@@ -83,7 +106,7 @@ export class FilesController {
   async getPresignedUrl(
     @RequiredUserId() userId: number,
     @Body() dto: PresignFileDto,
-  ) {
+  ): Promise<{ data: PresignFileResponseDto }> {
     try {
       const result = await this.fileUploadService.generatePresignedUrl(
         userId,

--- a/src/modules/onboarding/dtos/files.dto.ts
+++ b/src/modules/onboarding/dtos/files.dto.ts
@@ -32,3 +32,32 @@ export class PresignFileDto {
   @IsIn(FILE_PURPOSES)
   purpose: FilePurpose;
 }
+
+export class PresignFileResponseDto {
+  @ApiProperty({
+    example:
+      'https://bucket.s3.ap-northeast-2.amazonaws.com/images/42/club/1783139000000_club-cover.jpg?...',
+    description:
+      'S3 PUT 업로드에만 사용하는 presigned URL입니다. 저장 API에 전달하지 않습니다.',
+  })
+  uploadUrl: string;
+
+  @ApiProperty({
+    example: 's3://bucket/images/42/club/1783139000000_club-cover.jpg',
+    description:
+      'DB 저장용 S3 객체 참조입니다. 프로필/클럽/게시글 저장 API에는 이 값을 전달합니다.',
+  })
+  fileRef: string;
+
+  @ApiProperty({
+    example: 'images/42/club/1783139000000_club-cover.jpg',
+    description: 'S3 object key입니다.',
+  })
+  key: string;
+
+  @ApiProperty({
+    example: '2026-07-04T00:05:00.000Z',
+    description: 'uploadUrl 만료 시각입니다.',
+  })
+  expiresAt: string;
+}

--- a/src/modules/onboarding/services/files.service.ts
+++ b/src/modules/onboarding/services/files.service.ts
@@ -1,29 +1,32 @@
 import { Injectable } from '@nestjs/common';
-import {
-  S3Client,
-  PutObjectCommand,
-  GetObjectCommand,
-} from '@aws-sdk/client-s3';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { PresignFileDto } from '../dtos/files.dto';
-import * as process from 'process';
+import { ConfigService } from '@nestjs/config';
+import { S3ObjectUrlService } from '../../../common/s3/s3-object-url.service';
 
 @Injectable()
 export class FileUploadService {
-  private s3: S3Client;
-  private bucket: string;
+  private readonly s3: S3Client;
+  private readonly bucket: string;
+  private readonly putExpiresSec = 300;
 
-  constructor() {
-    const accessKeyId = process.env.AWS_ACCESS_KEY_ID;
-    const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly s3ObjectUrlService: S3ObjectUrlService,
+  ) {
+    const accessKeyId = this.configService.get<string>('AWS_ACCESS_KEY_ID');
+    const secretAccessKey = this.configService.get<string>(
+      'AWS_SECRET_ACCESS_KEY',
+    );
 
     this.s3 = new S3Client({
-      region: process.env.AWS_REGION,
+      region: this.configService.get<string>('AWS_REGION'),
       ...(accessKeyId && secretAccessKey
         ? { credentials: { accessKeyId, secretAccessKey } }
         : {}),
     });
-    this.bucket = process.env.AWS_S3_BUCKET!;
+    this.bucket = this.configService.getOrThrow<string>('AWS_S3_BUCKET');
   }
 
   async generatePresignedUrl(userId: number, dto: PresignFileDto) {
@@ -46,23 +49,14 @@ export class FileUploadService {
     });
 
     const uploadUrl = await getSignedUrl(this.s3, putCommand, {
-      expiresIn: 300,
-    });
-
-    // 다운로드용 Presigned URL (GET)
-    const getCommand = new GetObjectCommand({
-      Bucket: this.bucket,
-      Key: key,
-    });
-
-    const downloadUrl = await getSignedUrl(this.s3, getCommand, {
-      expiresIn: 3600 * 24 * 7,
+      expiresIn: this.putExpiresSec,
     });
 
     return {
       uploadUrl,
-      fileUrl: downloadUrl,
-      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+      fileRef: this.s3ObjectUrlService.buildStoredRef(key, this.bucket),
+      key,
+      expiresAt: new Date(Date.now() + this.putExpiresSec * 1000).toISOString(),
     };
   }
 }

--- a/src/modules/onboarding/services/onboarding.service.ts
+++ b/src/modules/onboarding/services/onboarding.service.ts
@@ -10,6 +10,7 @@ import {
 import { OnboardingAiService } from './onboarding-ai.service';
 import { AppException } from '../../../common/errors/app.exception';
 import { ClubRepository } from '../../club/repositories/club.repository';
+import { normalizeS3ObjectRef } from '../../../common/s3/s3-object-url.service';
 
 @Injectable()
 export class OnboardingService {
@@ -26,6 +27,7 @@ export class OnboardingService {
     const analysis = await this.onboardingAiService.analyzeProfile(userId, dto);
     const profileDto: CreateProfileDto = {
       ...dto,
+      introAudioUrl: normalizeS3ObjectRef(dto.introAudioUrl),
       introText: analysis.transcript,
       selectedKeywords: analysis.selectedKeywords,
       vibeVector: analysis.vibeVector,

--- a/src/modules/user/dtos/user-profile-update-request.dto.ts
+++ b/src/modules/user/dtos/user-profile-update-request.dto.ts
@@ -6,7 +6,6 @@ import {
   IsEnum,
   IsOptional,
   IsString,
-  IsUrl,
   IsInt,
   Min,
   Max,
@@ -69,11 +68,13 @@ export class UserProfileUpdateRequestDto {
 
   @ApiPropertyOptional({ example: 'https://cdn.example.com/files/intro.m4a' })
   @IsOptional()
-  @IsUrl()
+  @IsString()
   introAudioUrl?: string;
 
-  @ApiPropertyOptional({ example: 'https://cdn.example.com/files/profile.jpg' })
+  @ApiPropertyOptional({
+    example: 's3://eum-voice-staging/images/42/profile.jpg',
+  })
   @IsOptional()
-  @IsUrl()
+  @IsString()
   profileImageUrl?: string;
 }

--- a/src/modules/user/services/user/user.service.ts
+++ b/src/modules/user/services/user/user.service.ts
@@ -12,6 +12,7 @@ import {
 import { UserVisitorsResponseDto } from '../../dtos/user-visitors-response.dto';
 import { UserPublicProfileResponseDto } from '../../dtos/user-public-profile-response.dto';
 import { UserRepository } from '../../repositories/user.repository';
+import { normalizeS3ObjectRef } from '../../../../common/s3/s3-object-url.service';
 
 type ProfileVisitorsCursor = {
   visitedAt: string;
@@ -333,11 +334,13 @@ export class UserService {
     }
 
     if (payload.introAudioUrl !== undefined) {
-      updateData.introVoiceUrl = payload.introAudioUrl;
+      updateData.introVoiceUrl = normalizeS3ObjectRef(payload.introAudioUrl);
     }
 
     if (payload.profileImageUrl !== undefined) {
-      updateData.profileImageUrl = payload.profileImageUrl;
+      updateData.profileImageUrl = normalizeS3ObjectRef(
+        payload.profileImageUrl,
+      );
     }
 
     if (Object.keys(updateData).length > 0) {


### PR DESCRIPTION
## 이슈 번호
close #243 


### 주요 변경사항

  - S3 presigned GET URL을 DB에 저장하지 않도록 구조를 변경했습니다.
  - /files/presign 응답에서 기존 fileUrl 대신 저장용 fileRef와 key를 반환하도록 변경했습니다.
      - uploadUrl: S3 PUT 업로드 전용
      - fileRef: DB 저장/API 요청용 s3://bucket/key
      - key: S3 object key

  - profileImageUrl, thumbnailUrl, photoUrl, imageUrl, introVoiceUrl, introAudioUrl, mediaUrl 응답 필드가 s3://...이면 **전역 응답 인터셉터**에서 매번 presigned GET URL로 변환하도록 추가했습니다.

  - 프로필/클럽/게시글/온보딩 저장 입력 DTO에서 s3://... 값을 받을 수 있도록 URL 검증을 문자열 검증으로 조정했습니다.
  
  - Swagger 문서에 /files/presign 응답 DTO를 추가하고, 프론트가 저장 API에 fileRef를 전달해야 한다는 내용을 명시했습니다.
  
  - prisma/seed.ts는 seed 이미지/음성 값을 s3://bucket/key 형태로 저장하도록 구성되어 있습니다.

### 테스트화면
<img width="1920" height="1080" alt="스크린샷 2026-07-05 오후 8 26 34" src="https://github.com/user-attachments/assets/920df65f-fa87-49f3-9c14-eaebdf6d58d1" />

> 이제 db에 url 형태가 아니라 위의 그림처럼 s3 key형태로만 저장된다.
<img width="1920" height="1080" alt="스크린샷 2026-07-05 오후 8 38 06" src="https://github.com/user-attachments/assets/01516705-0592-4388-b691-dea70fa45bd8" />

> presigned url 발급 api의 응답값이 위의 그림과 같이 변경되었다. fileRef 가 db에 저장될 s3key 값이다.



### 참고사항 및 개선사항

  - DB에는 더 이상 X-Amz-*가 붙은 presigned URL을 저장하면 안 됩니다.
  - **Seed 파일도 새롭게 생성했습니다 ! 내일 QA 를 위해 모든 데이터 밀고, 해당 시드 파일로 데이터 재삽입해야합니다!!**

