### PR TITLE
fix: 유저 조회시 보낸 하트id 정보 조회 기능 추가

### DIFF
--- a/src/modules/user/dtos/user-public-profile-response.dto.ts
+++ b/src/modules/user/dtos/user-public-profile-response.dto.ts
@@ -67,6 +67,14 @@ export class UserPublicProfileResponseDto {
   })
   hasSentHeart!: boolean;
 
+  @ApiPropertyOptional({
+    example: 101,
+    nullable: true,
+    description:
+      '현재 로그인 사용자가 이 사용자에게 보낸 활성 하트 ID. 없으면 null',
+  })
+  sentHeartId!: number | null;
+
   @ApiProperty({ example: 'https://example.com/assets/profile.png' })
   profileImageUrl!: string;
 }

--- a/src/modules/user/services/user/user.service.spec.ts
+++ b/src/modules/user/services/user/user.service.spec.ts
@@ -407,6 +407,7 @@ describe('UserService', () => {
         },
       ],
       hasSentHeart: true,
+      sentHeartId: 101,
       profileImageUrl: 'https://example.com/profile.png',
     });
   });
@@ -431,6 +432,7 @@ describe('UserService', () => {
 
     expect(result.userId).toBe(7);
     expect(result.hasSentHeart).toBe(false);
+    expect(result.sentHeartId).toBeNull();
     expect(repositoryMock.createProfileVisitLog).not.toHaveBeenCalled();
   });
 

--- a/src/modules/user/services/user/user.service.ts
+++ b/src/modules/user/services/user/user.service.ts
@@ -258,6 +258,7 @@ export class UserService {
       participatingClubs,
       hostingClubs: Array.from(hostingClubsById.values()),
       hasSentHeart: Boolean(sentHeart),
+      sentHeartId: sentHeart ? Number(sentHeart.id) : null,
       profileImageUrl: user.profileImageUrl,
     };
   }


### PR DESCRIPTION
## 이슈 번호
close #248 

## 주요 변경사항
- GET /v1/users/{userId}/profile 응답에 hasSentHeart 및 likedHeartId도 같이

## 테스트 결과 (스크린샷)
<img width="680" height="96" alt="스크린샷 2026-07-06 오후 3 38 17" src="https://github.com/user-attachments/assets/04388efb-bc78-46f1-a64a-0031cfed7ab4" />

