### PR TITLE
fix : fastapi 던져주는 값 url로 변경 s3key가 아닌

### DIFF
--- a/src/modules/onboarding/services/onboarding.service.ts
+++ b/src/modules/onboarding/services/onboarding.service.ts
@@ -10,7 +10,10 @@ import {
 import { OnboardingAiService } from './onboarding-ai.service';
 import { AppException } from '../../../common/errors/app.exception';
 import { ClubRepository } from '../../club/repositories/club.repository';
-import { normalizeS3ObjectRef } from '../../../common/s3/s3-object-url.service';
+import {
+  normalizeS3ObjectRef,
+  S3ObjectUrlService,
+} from '../../../common/s3/s3-object-url.service';
 
 @Injectable()
 export class OnboardingService {
@@ -18,16 +21,23 @@ export class OnboardingService {
     private readonly onboardingRepository: OnboardingRepository,
     private readonly onboardingAiService: OnboardingAiService,
     private readonly clubRepository: ClubRepository,
+    private readonly s3ObjectUrlService: S3ObjectUrlService,
   ) {}
 
   async createUserProfile(
     userId: number,
     dto: CreateProfileRequestDto,
   ): Promise<CreateProfileResponseDto> {
-    const analysis = await this.onboardingAiService.analyzeProfile(userId, dto);
+    const storedIntroAudioUrl = normalizeS3ObjectRef(dto.introAudioUrl);
+    const analysisIntroAudioUrl =
+      await this.s3ObjectUrlService.toClientUrl(storedIntroAudioUrl);
+    const analysis = await this.onboardingAiService.analyzeProfile(userId, {
+      ...dto,
+      introAudioUrl: analysisIntroAudioUrl ?? storedIntroAudioUrl,
+    });
     const profileDto: CreateProfileDto = {
       ...dto,
-      introAudioUrl: normalizeS3ObjectRef(dto.introAudioUrl),
+      introAudioUrl: storedIntroAudioUrl,
       introText: analysis.transcript,
       selectedKeywords: analysis.selectedKeywords,
       vibeVector: analysis.vibeVector,


### PR DESCRIPTION
## 이슈 번호
close #252 

## 주요 변경사항
- fastapi 던져주는 값이 s3key가 아닌 Url로 던져주는것으로 변경

## 테스트 결과 (스크린샷)
<img width="1512" height="982" alt="스크린샷 2026-07-06 오후 4 15 58" src="https://github.com/user-attachments/assets/b2fc7403-ca1e-408b-abac-025d51347f20" />


## 참고 및 개선사항
- 
