### PR TITLE
[EUM-93] fix: 클럽 조회 api에서 hostid 반환 값 추가

### DIFF
--- a/src/modules/club/controllers/club/club.controller.ts
+++ b/src/modules/club/controllers/club/club.controller.ts
@@ -186,7 +186,7 @@ export class ClubController {
             items: [
               {
                 clubId: '1',
-                hostId: '7',
+                hostNickname: '보이스마스터',
                 name: '새벽 등산 모임',
                 introText: '함께 새벽 산행할 분들 모집해요.',
                 category: 'HOBBY',

--- a/src/modules/club/controllers/club/club.controller.ts
+++ b/src/modules/club/controllers/club/club.controller.ts
@@ -176,6 +176,7 @@ export class ClubController {
   })
   @ApiOkResponse({
     description: '조회 성공',
+    type: ListClubsResponseDto,
     schema: {
       example: {
         resultType: 'SUCCESS',
@@ -185,6 +186,7 @@ export class ClubController {
             items: [
               {
                 clubId: '1',
+                hostId: '7',
                 name: '새벽 등산 모임',
                 introText: '함께 새벽 산행할 분들 모집해요.',
                 category: 'HOBBY',

--- a/src/modules/club/dtos/club.dto.ts
+++ b/src/modules/club/dtos/club.dto.ts
@@ -365,6 +365,13 @@ export class ClubListItemDto {
   @ApiProperty({ description: '클럽 ID', example: '1' })
   clubId: string;
 
+  @ApiProperty({
+    description: '호스트 사용자 ID',
+    example: '7',
+    nullable: true,
+  })
+  hostId: string | null;
+
   @ApiProperty({ description: '클럽 이름', example: '새벽 등산 모임' })
   name: string;
 

--- a/src/modules/club/dtos/club.dto.ts
+++ b/src/modules/club/dtos/club.dto.ts
@@ -366,11 +366,11 @@ export class ClubListItemDto {
   clubId: string;
 
   @ApiProperty({
-    description: '호스트 사용자 ID',
-    example: '7',
+    description: '호스트 닉네임',
+    example: '보이스마스터',
     nullable: true,
   })
-  hostId: string | null;
+  hostNickname: string | null;
 
   @ApiProperty({ description: '클럽 이름', example: '새벽 등산 모임' })
   name: string;

--- a/src/modules/club/repositories/club.repository.types.ts
+++ b/src/modules/club/repositories/club.repository.types.ts
@@ -19,6 +19,7 @@ export interface ListClubsRepositoryParams {
 
 export const CLUB_LIST_SELECT = {
   id: true,
+  hostId: true,
   name: true,
   introText: true,
   category: true,

--- a/src/modules/club/repositories/club.repository.types.ts
+++ b/src/modules/club/repositories/club.repository.types.ts
@@ -19,13 +19,19 @@ export interface ListClubsRepositoryParams {
 
 export const CLUB_LIST_SELECT = {
   id: true,
-  hostId: true,
   name: true,
   introText: true,
   category: true,
   thumbnailUrl: true,
   likes: true,
   createdAt: true,
+  user: {
+    select: {
+      nickname: true,
+      deletedAt: true,
+      status: true,
+    },
+  },
   _count: {
     select: {
       clubUsers: {

--- a/src/modules/club/services/club/club.service.spec.ts
+++ b/src/modules/club/services/club/club.service.spec.ts
@@ -137,6 +137,7 @@ describe('ClubService', () => {
     findManyForList.mockResolvedValue([
       {
         id: 12n,
+        hostId: 7n,
         name: '등산 러버즈',
         introText: '등산으로 친해져요',
         category: ClubCategory.HOBBY,
@@ -147,6 +148,7 @@ describe('ClubService', () => {
       },
       {
         id: 11n,
+        hostId: 8n,
         name: '러닝 클럽',
         introText: null,
         category: ClubCategory.SPORTS,
@@ -174,6 +176,7 @@ describe('ClubService', () => {
     expect(result.items).toEqual([
       {
         clubId: '12',
+        hostId: '7',
         name: '등산 러버즈',
         introText: '등산으로 친해져요',
         category: ClubCategory.HOBBY,

--- a/src/modules/club/services/club/club.service.spec.ts
+++ b/src/modules/club/services/club/club.service.spec.ts
@@ -137,24 +137,32 @@ describe('ClubService', () => {
     findManyForList.mockResolvedValue([
       {
         id: 12n,
-        hostId: 7n,
         name: '등산 러버즈',
         introText: '등산으로 친해져요',
         category: ClubCategory.HOBBY,
         thumbnailUrl: 'https://cdn.example.com/clubs/12.jpg',
         likes: 142,
         createdAt: new Date('2026-03-01T00:00:00.000Z'),
+        user: {
+          nickname: '보이스마스터',
+          deletedAt: null,
+          status: ActiveStatus.ACTIVE,
+        },
         _count: { clubUsers: 18 },
       },
       {
         id: 11n,
-        hostId: 8n,
         name: '러닝 클럽',
         introText: null,
         category: ClubCategory.SPORTS,
         thumbnailUrl: null,
         likes: 100,
         createdAt: new Date('2026-02-01T00:00:00.000Z'),
+        user: {
+          nickname: '러너',
+          deletedAt: null,
+          status: ActiveStatus.ACTIVE,
+        },
         _count: { clubUsers: 9 },
       },
     ]);
@@ -176,7 +184,7 @@ describe('ClubService', () => {
     expect(result.items).toEqual([
       {
         clubId: '12',
-        hostId: '7',
+        hostNickname: '보이스마스터',
         name: '등산 러버즈',
         introText: '등산으로 친해져요',
         category: ClubCategory.HOBBY,

--- a/src/modules/club/utils/club.mapper.ts
+++ b/src/modules/club/utils/club.mapper.ts
@@ -12,7 +12,12 @@ import { ActiveStatus, ClubAuthority, DayOfWeek } from '@prisma/client';
 export function toClubListItemDto(row: ClubListRow): ClubListItemDto {
   return {
     clubId: row.id.toString(),
-    hostId: row.hostId?.toString() ?? null,
+    hostNickname:
+      row.user &&
+      row.user.deletedAt === null &&
+      row.user.status === ActiveStatus.ACTIVE
+        ? row.user.nickname
+        : null,
     name: row.name,
     introText: row.introText,
     category: row.category,

--- a/src/modules/club/utils/club.mapper.ts
+++ b/src/modules/club/utils/club.mapper.ts
@@ -12,6 +12,7 @@ import { ActiveStatus, ClubAuthority, DayOfWeek } from '@prisma/client';
 export function toClubListItemDto(row: ClubListRow): ClubListItemDto {
   return {
     clubId: row.id.toString(),
+    hostId: row.hostId?.toString() ?? null,
     name: row.name,
     introText: row.introText,
     category: row.category,


### PR DESCRIPTION
## 이슈 번호
close #255 

## 주요 변경사항
- 동호회 조회 api 호스트 id 반환값 추가. DTO 추가
- 가 아니라 hostNickname 으로 변경

## 테스트 결과 (스크린샷)
<img width="1209" height="266" alt="스크린샷 2026-07-06 오후 10 04 02" src="https://github.com/user-attachments/assets/35070f2e-532b-44cf-8c4f-dbf6177e2946" />




## 참고 및 개선사항
- 
