### PR TITLE
[EUM-94] feat: 모든 동호회 알림 읽음 처리 api 구현

### DIFF
--- a/src/modules/notification/controllers/notification.controller.spec.ts
+++ b/src/modules/notification/controllers/notification.controller.spec.ts
@@ -10,6 +10,7 @@ describe('NotificationController', () => {
     markAsRead: jest.fn(),
     findAll: jest.fn(),
     update: jest.fn(),
+    readAllClubNotifications: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -31,5 +32,11 @@ describe('NotificationController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  it('marks all club notifications as read', async () => {
+    await controller.readAllClubNotifications(1);
+
+    expect(serviceMock.readAllClubNotifications).toHaveBeenCalledWith(1);
   });
 });

--- a/src/modules/notification/controllers/notification.controller.ts
+++ b/src/modules/notification/controllers/notification.controller.ts
@@ -31,8 +31,15 @@ export class NotificationController {
   @Patch('/hearts/read')
   @UseGuards(AccessTokenGuard)
   async readAllHeartNotifications(@RequiredUserId() userId: number) {
-    console.log('readAllHeartNotifications 진입');
     await this.notificationService.readAllHeartNotifications(userId);
+  }
+
+  @ApiOperation({ summary: '동호회 알림 전체 읽기' })
+  @ApiOkResponse()
+  @Patch('/clubs/read')
+  @UseGuards(AccessTokenGuard)
+  async readAllClubNotifications(@RequiredUserId() userId: number) {
+    await this.notificationService.readAllClubNotifications(userId);
   }
 
   @ApiOperation({ summary: '알림 읽음 처리' })

--- a/src/modules/notification/repositories/notification.repository.ts
+++ b/src/modules/notification/repositories/notification.repository.ts
@@ -231,4 +231,19 @@ export class NotificationRepository {
       },
     });
   }
+
+  // 동호회 알림 전체 읽음
+  readAllClubNotifications(userId: number) {
+    return this.prisma.notification.updateMany({
+      data: {
+        isRead: true,
+      },
+      where: {
+        userId: BigInt(userId),
+        isRead: false,
+        deletedAt: null,
+        type: { in: [NotificationType.ARTICLE, NotificationType.COMMENT] },
+      },
+    });
+  }
 }

--- a/src/modules/notification/services/notification.service.spec.ts
+++ b/src/modules/notification/services/notification.service.spec.ts
@@ -9,6 +9,7 @@ describe('NotificationService', () => {
     createNotification: jest.fn(),
     markAsRead: jest.fn(),
     findAll: jest.fn(),
+    readAllClubNotifications: jest.fn(),
   };
   const fcmPushServiceMock = {
     sendNotificationToUser: jest.fn(),
@@ -28,5 +29,11 @@ describe('NotificationService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('marks all club notifications as read', async () => {
+    await service.readAllClubNotifications(1);
+
+    expect(repositoryMock.readAllClubNotifications).toHaveBeenCalledWith(1);
   });
 });

--- a/src/modules/notification/services/notification.service.ts
+++ b/src/modules/notification/services/notification.service.ts
@@ -158,6 +158,10 @@ export class NotificationService {
     await this.notificationRepository.readAllHeartNotifications(userId);
   }
 
+  async readAllClubNotifications(userId: number) {
+    await this.notificationRepository.readAllClubNotifications(userId);
+  }
+
   private decodeNotificationCursor(cursor: string): bigint {
     const parsed = decodeCursorRaw(cursor);
     const id = parsed.id;


### PR DESCRIPTION
## 이슈 번호
close #257 

## 주요 변경사항
- 모든 동호회 알림(type: COMMENT, ARTICLE) 읽음 처리 api를 구현하였습니다.

## 테스트 결과 (스크린샷)
1. 모든 동호회 알림 조회(isRead=false)
<img width="1436" height="472" alt="image" src="https://github.com/user-attachments/assets/41b8eacf-acd7-46b3-ae8d-57d1cdb67cdc" />

2. 모든 동호회 알림 읽기
<img width="1470" height="323" alt="image" src="https://github.com/user-attachments/assets/da744488-27e7-41df-8588-dfe2e7259f43" />

3. 모든 동호회 알림 조회(isRead=true)
<img width="1526" height="488" alt="image" src="https://github.com/user-attachments/assets/b2acb61e-26a3-40f4-80f8-79307c888855" />


## 참고 및 개선사항
- 추후 동호회 가입 신청 알림이나, 동호회 좋아요 알림 등 생성 로직이 추가된다면 해당 타입의 알림도 반영하겠습니다.