### PR TITLE
fix: FCM 진단 로그 추가

### DIFF
--- a/src/modules/push/services/fcm-push.service.spec.ts
+++ b/src/modules/push/services/fcm-push.service.spec.ts
@@ -1,4 +1,5 @@
 import { ConfigService } from '@nestjs/config';
+import { Logger } from '@nestjs/common';
 import { NotificationType } from '@prisma/client';
 import { BatchResponse, MulticastMessage } from 'firebase-admin/messaging';
 import { FcmPushService } from './fcm-push.service';
@@ -105,9 +106,26 @@ describe('FcmPushService', () => {
     expect(sendEachForMulticastMock).toHaveBeenCalledTimes(2);
     expect(firstMessage.tokens).toHaveLength(500);
     expect(secondMessage.tokens).toHaveLength(1);
+    expect(firstMessage.apns).toEqual({
+      headers: {
+        'apns-push-type': 'alert',
+        'apns-priority': '10',
+      },
+      payload: {
+        aps: {
+          alert: {
+            title: '제목',
+            body: '본문',
+          },
+          sound: 'default',
+        },
+      },
+    });
   });
 
   it('revokes invalid FCM tokens without logging token values', async () => {
+    const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+    const logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
     repository.findActiveTokensByUserId.mockResolvedValue([
       { token: ' valid-token ' },
       { token: 'invalid-token' },
@@ -147,6 +165,14 @@ describe('FcmPushService', () => {
       }),
     );
     expect(repository.revokeTokens).toHaveBeenCalledWith(['invalid-token']);
+    expect(
+      warnSpy.mock.calls.some((call) =>
+        String(call[0]).includes('invalid-token'),
+      ),
+    ).toBe(false);
+
+    warnSpy.mockRestore();
+    logSpy.mockRestore();
   });
 
   it('does not send when Firebase credentials are absent', async () => {

--- a/src/modules/push/services/fcm-push.service.ts
+++ b/src/modules/push/services/fcm-push.service.ts
@@ -32,6 +32,9 @@ export class FcmPushService {
     notification: Notification,
   ): Promise<void> {
     if (!this.messaging) {
+      this.logger.warn(
+        `FCM send skipped because messaging client is disabled userId=${userId} notificationId=${notification.id.toString()}`,
+      );
       return;
     }
 
@@ -42,6 +45,9 @@ export class FcmPushService {
       .filter((token) => token.length > 0);
 
     if (tokens.length === 0) {
+      this.logger.warn(
+        `FCM send skipped because active token is empty userId=${userId} notificationId=${notification.id.toString()}`,
+      );
       return;
     }
 
@@ -66,8 +72,16 @@ export class FcmPushService {
           type: String(notification.type),
         },
         apns: {
+          headers: {
+            'apns-push-type': 'alert',
+            'apns-priority': '10',
+          },
           payload: {
             aps: {
+              alert: {
+                title: notification.title,
+                body: notification.body,
+              },
               sound: 'default',
             },
           },
@@ -84,11 +98,22 @@ export class FcmPushService {
         const response = await this.messaging.sendEachForMulticast(message);
         failureCount += response.failureCount;
 
+        this.logger.log(
+          `FCM chunk send result userId=${userId} notificationId=${notification.id.toString()} chunk=${chunkNumber} tokenCount=${tokenChunk.length} successCount=${response.successCount} failureCount=${response.failureCount}`,
+        );
+
         response.responses.forEach((sendResponse, responseIndex) => {
           const errorCode = sendResponse.error?.code;
+          const errorMessage = sendResponse.error?.message;
 
           if (errorCode && INVALID_TOKEN_ERROR_CODES.has(errorCode)) {
             invalidTokens.push(tokenChunk[responseIndex]);
+          }
+
+          if (errorCode) {
+            this.logger.warn(
+              `FCM token send failed userId=${userId} notificationId=${notification.id.toString()} chunk=${chunkNumber} tokenIndex=${responseIndex} tokenPrefix=${this.maskToken(tokenChunk[responseIndex])} errorCode=${errorCode} errorMessage=${errorMessage ?? ''}`,
+            );
           }
         });
       } catch (e) {
@@ -101,6 +126,9 @@ export class FcmPushService {
 
     if (invalidTokens.length > 0) {
       await this.pushDeviceTokenRepository.revokeTokens(invalidTokens);
+      this.logger.warn(
+        `FCM revoked invalid tokens userId=${userId} notificationId=${notification.id.toString()} count=${invalidTokens.length}`,
+      );
     }
 
     if (failureCount > invalidTokens.length) {
@@ -140,5 +168,11 @@ export class FcmPushService {
       this.logger.error(`FCM is disabled: ${String(e)}`);
       return null;
     }
+  }
+
+  private maskToken(token: string): string {
+    return token.length <= 12
+      ? `${token.slice(0, 4)}...`
+      : `${token.slice(0, 8)}...${token.slice(-4)}`;
   }
 }


### PR DESCRIPTION
## 이슈 번호
close #262 

## 주요 변경사항
- FCM 푸시 알림이 백엔드쪽에서 제대로 작동하지 않는데 원인을 파악하고자 진단 로그를 추가했습니다.

## 테스트 결과 (스크린샷)
- 

## 참고 및 개선사항
- 
