### PR TITLE
fix: Apple 로그인에서 authorizationCode 검증 삭제

### DIFF
--- a/src/modules/auth/services/apple-auth.service.spec.ts
+++ b/src/modules/auth/services/apple-auth.service.spec.ts
@@ -7,21 +7,29 @@ describe('AppleAuthService', () => {
   const { privateKey, publicKey } = generateKeyPairSync('rsa', {
     modulusLength: 2048,
   });
+  const { privateKey: appleClientPrivateKey } = generateKeyPairSync('ec', {
+    namedCurve: 'prime256v1',
+  });
+  const appleClientPrivateKeyPem = appleClientPrivateKey
+    .export({ type: 'pkcs8', format: 'pem' })
+    .toString();
   const publicJwk = publicKey.export({ format: 'jwk' });
   const kid = 'apple-test-key';
   const clientId = 'com.eum.app';
+  const configValues: Record<string, string> = {
+    APPLE_CLIENT_ID: clientId,
+    APPLE_TEAM_ID: 'TEAMID1234',
+    APPLE_KEY_ID: 'KEYID1234',
+    APPLE_PRIVATE_KEY: appleClientPrivateKeyPem,
+    JWT_ACCESS_SECRET: 'access-secret',
+    JWT_REFRESH_SECRET: 'refresh-secret',
+    JWT_ACCESS_EXPIRES_IN: '1h',
+    JWT_REFRESH_EXPIRES_IN: '14d',
+  };
 
   const configServiceMock = {
     get: jest.fn((key: string, defaultValue?: string) => {
-      const values: Record<string, string> = {
-        APPLE_CLIENT_ID: clientId,
-        JWT_ACCESS_SECRET: 'access-secret',
-        JWT_REFRESH_SECRET: 'refresh-secret',
-        JWT_ACCESS_EXPIRES_IN: '1h',
-        JWT_REFRESH_EXPIRES_IN: '14d',
-      };
-
-      return values[key] ?? defaultValue;
+      return configValues[key] ?? defaultValue;
     }),
   };
   const jwtTokenServiceMock = {
@@ -44,6 +52,7 @@ describe('AppleAuthService', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    configValues.APPLE_PRIVATE_KEY = appleClientPrivateKeyPem;
 
     fetchMock = jest.fn().mockResolvedValue({
       ok: true,
@@ -139,5 +148,20 @@ describe('AppleAuthService', () => {
     });
 
     expect(userRepositoryMock.upsertAppleUser).not.toHaveBeenCalled();
+  });
+
+  it('authorization code가 전달되어도 Apple token endpoint를 호출하지 않는다', async () => {
+    const escapedPrivateKey = appleClientPrivateKeyPem.replaceAll('\n', '\\n');
+    configValues.APPLE_PRIVATE_KEY = `"${Buffer.from(escapedPrivateKey).toString('base64')}"`;
+
+    await service.loginWithApple({
+      identityToken: signIdentityToken(),
+      authorizationCode: 'apple-auth-code',
+    });
+
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      'https://appleid.apple.com/auth/token',
+      expect.anything(),
+    );
   });
 });

--- a/src/modules/auth/services/apple-auth.service.ts
+++ b/src/modules/auth/services/apple-auth.service.ts
@@ -81,14 +81,6 @@ export class AppleAuthService {
         clientId,
       );
 
-      phase = 'exchange_authorization_code';
-      if (request.authorizationCode) {
-        await this.exchangeAuthorizationCode(
-          request.authorizationCode,
-          clientId,
-        );
-      }
-
       providerUserId = identity.sub;
       const nickname =
         request.name?.trim() || `apple_${providerUserId.slice(0, 8)}`;
@@ -275,20 +267,28 @@ export class AppleAuthService {
       });
     }
 
-    const clientSecret = jwt.sign(
-      {
-        iss: teamId,
-        iat: Math.floor(Date.now() / 1000),
-        exp: Math.floor(Date.now() / 1000) + 60 * 60,
-        aud: AppleAuthService.APPLE_ISSUER,
-        sub: clientId,
-      },
-      createPrivateKey(privateKey),
-      {
-        algorithm: 'ES256',
-        keyid: keyId,
-      },
-    );
+    let clientSecret: string;
+    try {
+      clientSecret = jwt.sign(
+        {
+          iss: teamId,
+          iat: Math.floor(Date.now() / 1000),
+          exp: Math.floor(Date.now() / 1000) + 60 * 60,
+          aud: AppleAuthService.APPLE_ISSUER,
+          sub: clientId,
+        },
+        createPrivateKey(privateKey),
+        {
+          algorithm: 'ES256',
+          keyid: keyId,
+        },
+      );
+    } catch (error) {
+      throw new AppException('SERVER_TEMPORARY_ERROR', {
+        message: 'Apple private key is invalid.',
+        details: error,
+      });
+    }
 
     const params = new URLSearchParams({
       grant_type: 'authorization_code',
@@ -326,7 +326,16 @@ export class AppleAuthService {
       return null;
     }
 
-    return privateKey.replaceAll('\\n', '\n');
+    const unquoted = privateKey.trim().replace(/^['"]|['"]$/g, '');
+    const maybePem = unquoted.includes('BEGIN')
+      ? unquoted
+      : Buffer.from(unquoted, 'base64').toString('utf8');
+
+    return maybePem
+      .trim()
+      .replaceAll('\\\\n', '\n')
+      .replaceAll('\\n', '\n')
+      .replaceAll('\r\n', '\n');
   }
 
   private async rotateRefreshTokens(refreshToken: string, userId: number) {


### PR DESCRIPTION
## 이슈 번호
close #264 

 1. 백엔드에서 authorizationCode exchange 제거
  2. 프런트에는 authorizationCode 안 보내도 됨
  3. 프런트 수정 전까지 authorizationCode가 와도 백엔드는 무시
