### PR TITLE
[EUM-96] [Fix]: 백엔드 프로세스 인메모리 캐시 사용한 url 발급 로직 추가

### DIFF
--- a/src/common/s3/s3-object-url.service.spec.ts
+++ b/src/common/s3/s3-object-url.service.spec.ts
@@ -1,4 +1,12 @@
-import { normalizeS3ObjectRef } from './s3-object-url.service';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import {
+  S3ObjectUrlService,
+  normalizeS3ObjectRef,
+} from './s3-object-url.service';
+
+jest.mock('@aws-sdk/s3-request-presigner', () => ({
+  getSignedUrl: jest.fn(),
+}));
 
 describe('normalizeS3ObjectRef', () => {
   it('keeps s3 refs unchanged', () => {
@@ -19,5 +27,66 @@ describe('normalizeS3ObjectRef', () => {
     expect(normalizeS3ObjectRef('https://cdn.example.com/images/1.jpg')).toBe(
       'https://cdn.example.com/images/1.jpg',
     );
+  });
+});
+
+describe('S3ObjectUrlService', () => {
+  const getSignedUrlMock = getSignedUrl as jest.MockedFunction<
+    typeof getSignedUrl
+  >;
+  const configService = {
+    get: jest.fn((key: string, defaultValue?: unknown) => {
+      if (key === 'AWS_REGION') return 'ap-northeast-2';
+      if (key === 'S3_GET_PRESIGN_EXPIRES_SEC') return 3600;
+      return defaultValue;
+    }),
+    getOrThrow: jest.fn((key: string) => {
+      if (key === 'AWS_S3_BUCKET') return 'bucket';
+      throw new Error(`Unexpected config key: ${key}`);
+    }),
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-07-07T00:00:00.000Z'));
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('reuses a presigned GET URL until it expires', async () => {
+    getSignedUrlMock.mockResolvedValueOnce('https://signed-url-1');
+    const service = new S3ObjectUrlService(configService as never);
+
+    await expect(service.toClientUrl('s3://bucket/images/1.jpg')).resolves.toBe(
+      'https://signed-url-1',
+    );
+
+    jest.setSystemTime(new Date('2026-07-07T00:59:59.000Z'));
+
+    await expect(service.toClientUrl('s3://bucket/images/1.jpg')).resolves.toBe(
+      'https://signed-url-1',
+    );
+    expect(getSignedUrlMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('issues a new presigned GET URL after the cached URL expires', async () => {
+    getSignedUrlMock
+      .mockResolvedValueOnce('https://signed-url-1')
+      .mockResolvedValueOnce('https://signed-url-2');
+    const service = new S3ObjectUrlService(configService as never);
+
+    await expect(service.toClientUrl('s3://bucket/images/1.jpg')).resolves.toBe(
+      'https://signed-url-1',
+    );
+
+    jest.setSystemTime(new Date('2026-07-07T01:00:00.000Z'));
+
+    await expect(service.toClientUrl('s3://bucket/images/1.jpg')).resolves.toBe(
+      'https://signed-url-2',
+    );
+    expect(getSignedUrlMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/common/s3/s3-object-url.service.ts
+++ b/src/common/s3/s3-object-url.service.ts
@@ -9,6 +9,11 @@ type ParsedS3Ref = {
   key: string;
 };
 
+type CachedClientUrl = {
+  url: string;
+  expiresAtMs: number;
+};
+
 const S3_REF_PREFIX = 's3://';
 const DEFAULT_GET_EXPIRES_SEC = 60 * 60;
 const CLIENT_URL_FIELDS = new Set([
@@ -91,6 +96,7 @@ export class S3ObjectUrlService {
   private readonly s3: S3Client;
   private readonly defaultBucket: string;
   private readonly getExpiresSec: number;
+  private readonly clientUrlCache = new Map<string, CachedClientUrl>();
 
   constructor(private readonly configService: ConfigService) {
     const accessKeyId = this.configService.get<string>('AWS_ACCESS_KEY_ID');
@@ -125,12 +131,27 @@ export class S3ObjectUrlService {
     const parsed = parseS3Ref(input) ?? parseS3HttpsUrl(input);
     if (!parsed) return input;
 
+    const cacheKey = `${parsed.bucket}/${parsed.key}`;
+    const now = Date.now();
+    const cached = this.clientUrlCache.get(cacheKey);
+    if (cached && cached.expiresAtMs > now) {
+      return cached.url;
+    }
+
     const command = new GetObjectCommand({
       Bucket: parsed.bucket,
       Key: parsed.key,
     });
 
-    return getSignedUrl(this.s3, command, { expiresIn: this.getExpiresSec });
+    const url = await getSignedUrl(this.s3, command, {
+      expiresIn: this.getExpiresSec,
+    });
+    this.clientUrlCache.set(cacheKey, {
+      url,
+      expiresAtMs: now + this.getExpiresSec * 1000,
+    });
+
+    return url;
   }
 
   async transformClientUrlFields<T>(value: T): Promise<T> {


### PR DESCRIPTION
## 이슈 번호
close #260 

## 주요 변경사항
- URL 발급을 프론트엔드 캐시사용 효율을 높이기 위해서 백엔드의 인메모리 캐시를 이용해 한시간내에서는 동일하 URL을 던져주는 로직으로 수정.

## 테스트 결과 (스크린샷)
<img width="691" height="530" alt="스크린샷 2026-07-08 오후 12 34 38" src="https://github.com/user-attachments/assets/83ce316d-f63b-46aa-94af-e0c9d5959dcd" />

> ExpiredAt , 즉 만료시간이 기준 시간보다 클때, 새로운 URL을 발급한다는것 확인가능.

## 참고 및 개선사항
- 
