### PR TITLE
feat: FCM알림 누르면 이동할 수 있도록 data payload에 실어 보냄. swagger 리스폰스 타입 수정.

### DIFF
--- a/src/modules/article/repositories/article.repository.ts
+++ b/src/modules/article/repositories/article.repository.ts
@@ -81,6 +81,7 @@ export type LikeArticleResult =
       status: 'success';
       article: {
         id: bigint;
+        clubId: bigint;
         likes: number;
         userId: bigint | null;
         user: { nickname: string } | null;
@@ -575,6 +576,7 @@ export class ArticleRepository {
         },
         select: {
           id: true,
+          clubId: true,
           likes: true,
           userId: true,
           user: {
@@ -636,6 +638,7 @@ export class ArticleRepository {
         data: { likes: { increment: 1 } },
         select: {
           id: true,
+          clubId: true,
           likes: true,
           userId: true,
           user: {

--- a/src/modules/article/services/article.service.spec.ts
+++ b/src/modules/article/services/article.service.spec.ts
@@ -177,6 +177,7 @@ describe('ArticleService', () => {
         created: true,
         article: {
           id: BigInt(10),
+          clubId: BigInt(1),
           likes: 3,
           userId: BigInt(20),
           user: { nickname: '받는사람' },
@@ -194,6 +195,11 @@ describe('ArticleService', () => {
         '회원님의 게시물에 좋아요가 눌렸어요.',
         '[한강 라이딩 동호회]보낸사람님이 회원님의 게시물에 좋아요를 눌렀어요.',
         11,
+        {
+          clubId: '1',
+          articleId: '10',
+          senderUserId: '11',
+        },
       );
     });
 
@@ -205,6 +211,7 @@ describe('ArticleService', () => {
         created: false,
         article: {
           id: BigInt(10),
+          clubId: BigInt(1),
           likes: 3,
           userId: BigInt(20),
           user: { nickname: '받는사람' },
@@ -220,6 +227,7 @@ describe('ArticleService', () => {
         created: true,
         article: {
           id: BigInt(10),
+          clubId: BigInt(1),
           likes: 4,
           userId: BigInt(11),
           user: { nickname: '보낸사람' },

--- a/src/modules/article/services/article.service.ts
+++ b/src/modules/article/services/article.service.ts
@@ -367,6 +367,11 @@ export class ArticleService {
       '회원님의 게시물에 좋아요가 눌렸어요.',
       `[${clubName}]${senderNickname}님이 회원님의 게시물에 좋아요를 눌렀어요.`,
       senderId,
+      {
+        clubId: result.article.clubId.toString(),
+        articleId: result.article.id.toString(),
+        senderUserId: String(senderId),
+      },
     );
   }
 

--- a/src/modules/chat/services/socket/chat-socket.service.ts
+++ b/src/modules/chat/services/socket/chat-socket.service.ts
@@ -265,6 +265,12 @@ export class ChatSocketService {
           NotificationType.CHAT,
           title,
           preview.textPreview,
+          params.senderUserId,
+          {
+            chatRoomId: String(params.chatRoomId),
+            messageId: String(params.messageId),
+            senderUserId: String(params.senderUserId),
+          },
         );
 
         server.to(toUserRoom(receiverUserId)).emit('notification.new', {

--- a/src/modules/comment/services/comment.service.spec.ts
+++ b/src/modules/comment/services/comment.service.spec.ts
@@ -144,6 +144,12 @@ describe('CommentService', () => {
       '회원님의 게시물에 댓글이 달렸어요.',
       '[동작구 뜨개질 모임]댓글작성자님이 회원님의 게시물에 댓글을 남겼어요.',
       1,
+      {
+        clubId: String(clubId),
+        articleId: String(articleId),
+        commentId: '555',
+        senderUserId: '1',
+      },
     );
   });
 
@@ -230,6 +236,12 @@ describe('CommentService', () => {
       '회원님의 댓글에 답글이 달렸어요.',
       '[동작구 뜨개질 모임]자식작성자님이 회원님의 댓글에 답글을 남겼어요.',
       1,
+      {
+        clubId: String(clubId),
+        articleId: String(articleId),
+        commentId: '556',
+        senderUserId: '1',
+      },
     );
   });
 

--- a/src/modules/comment/services/comment.service.ts
+++ b/src/modules/comment/services/comment.service.ts
@@ -94,6 +94,9 @@ export class CommentService {
         title: '회원님의 댓글에 답글이 달렸어요.',
         body: `[${club.name}]${comment.user.nickname}님이 회원님의 댓글에 답글을 남겼어요.`,
         senderId: userId,
+        clubId,
+        articleId,
+        commentId: Number(comment.id),
         context: 'reply',
       });
     }
@@ -104,6 +107,9 @@ export class CommentService {
         title: '회원님의 게시물에 댓글이 달렸어요.',
         body: `[${club.name}]${comment.user.nickname}님이 회원님의 게시물에 댓글을 남겼어요.`,
         senderId: userId,
+        clubId,
+        articleId,
+        commentId: Number(comment.id),
         context: 'article',
       });
     }
@@ -116,6 +122,9 @@ export class CommentService {
     title: string;
     body: string;
     senderId: number;
+    clubId: number;
+    articleId: number;
+    commentId: number;
     context: 'article' | 'reply';
   }): Promise<void> {
     try {
@@ -125,6 +134,12 @@ export class CommentService {
         params.title,
         params.body,
         params.senderId,
+        {
+          clubId: String(params.clubId),
+          articleId: String(params.articleId),
+          commentId: String(params.commentId),
+          senderUserId: String(params.senderId),
+        },
       );
     } catch (e) {
       this.logger.warn(

--- a/src/modules/notification/dtos/notification.dto.ts
+++ b/src/modules/notification/dtos/notification.dto.ts
@@ -60,13 +60,7 @@ export class NotificationResponseDto {
   @IsString()
   body!: string;
 
-  @ApiPropertyOptional({ type: NotificationTargetDto })
-  target?: NotificationTargetDto;
-
-  static from(
-    entity: Notification,
-    target?: NotificationTargetDto,
-  ): NotificationResponseDto {
+  static from(entity: Notification): NotificationResponseDto {
     return {
       notificationId: entity.id.toString(),
       type: entity.type,
@@ -74,7 +68,6 @@ export class NotificationResponseDto {
       body: entity.body,
       isRead: entity.isRead,
       createdAt: entity.createdAt.toISOString(),
-      ...(target && { target }),
     };
   }
 }

--- a/src/modules/notification/services/notification.service.ts
+++ b/src/modules/notification/services/notification.service.ts
@@ -11,7 +11,10 @@ import {
   decodeCursorRaw,
   encodeCursor,
 } from '../../../common/utils/cursor.util';
-import { FcmPushService } from '../../push/services/fcm-push.service';
+import {
+  FcmNotificationData,
+  FcmPushService,
+} from '../../push/services/fcm-push.service';
 
 @Injectable()
 export class NotificationService {
@@ -55,6 +58,7 @@ export class NotificationService {
     title: string,
     body: string,
     sentById?: number,
+    pushData?: FcmNotificationData,
   ) {
     const result = await this.notificationRepository.createNotification(
       userId,
@@ -65,7 +69,11 @@ export class NotificationService {
     );
 
     try {
-      await this.fcmPushService.sendNotificationToUser(userId, result);
+      await this.fcmPushService.sendNotificationToUser(
+        userId,
+        result,
+        pushData,
+      );
     } catch (e) {
       this.logger.warn(
         `FCM push failed notificationId=${result.id.toString()} userId=${userId}: ${String(e)}`,

--- a/src/modules/push/services/fcm-push.service.spec.ts
+++ b/src/modules/push/services/fcm-push.service.spec.ts
@@ -123,6 +123,52 @@ describe('FcmPushService', () => {
     });
   });
 
+  it('includes extra click navigation data in FCM payload', async () => {
+    repository.findActiveTokensByUserId.mockResolvedValue([
+      { token: 'valid-token' },
+    ]);
+    sendEachForMulticastMock.mockResolvedValue(
+      batchResponse({ successCount: 1, failureCount: 0 }),
+    );
+
+    const service = new FcmPushService(
+      configService as unknown as ConfigService,
+      repository as unknown as PushDeviceTokenRepository,
+    );
+
+    await service.sendNotificationToUser(
+      10,
+      {
+        id: BigInt(1),
+        userId: BigInt(10),
+        type: NotificationType.CHAT,
+        isRead: false,
+        createdAt: new Date('2026-06-28T12:00:00.000Z'),
+        deletedAt: null,
+        title: '제목',
+        body: '본문',
+        sentById: null,
+      },
+      {
+        chatRoomId: '123',
+        messageId: '456',
+        senderUserId: '789',
+      },
+    );
+
+    expect(sendEachForMulticastMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: {
+          notificationId: '1',
+          type: 'CHAT',
+          chatRoomId: '123',
+          messageId: '456',
+          senderUserId: '789',
+        },
+      }),
+    );
+  });
+
   it('revokes invalid FCM tokens without logging token values', async () => {
     const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
     const logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();

--- a/src/modules/push/services/fcm-push.service.ts
+++ b/src/modules/push/services/fcm-push.service.ts
@@ -15,6 +15,8 @@ const INVALID_TOKEN_ERROR_CODES = new Set([
 ]);
 const FCM_MULTICAST_TOKEN_LIMIT = 500;
 
+export type FcmNotificationData = Record<string, string>;
+
 @Injectable()
 export class FcmPushService {
   private readonly logger = new Logger(FcmPushService.name);
@@ -30,6 +32,7 @@ export class FcmPushService {
   async sendNotificationToUser(
     userId: number,
     notification: Notification,
+    data: FcmNotificationData = {},
   ): Promise<void> {
     if (!this.messaging) {
       this.logger.warn(
@@ -70,6 +73,7 @@ export class FcmPushService {
         data: {
           notificationId: notification.id.toString(),
           type: String(notification.type),
+          ...data,
         },
         apns: {
           headers: {

--- a/src/modules/social/services/heart/heart.service.spec.ts
+++ b/src/modules/social/services/heart/heart.service.spec.ts
@@ -101,6 +101,10 @@ describe('HeartService', () => {
         '마음을 누른 사람이 생겼습니다!',
         'TestUser님이 회원님에게 마음을 보냈습니다.',
         7,
+        {
+          senderUserId: '7',
+          heartId: '101',
+        },
       );
     });
 

--- a/src/modules/social/services/heart/heart.service.ts
+++ b/src/modules/social/services/heart/heart.service.ts
@@ -61,6 +61,10 @@ export class HeartService {
           '마음을 누른 사람이 생겼습니다!',
           `${userName}님이 회원님에게 마음을 보냈습니다.`,
           Number(userId),
+          {
+            senderUserId: String(userId),
+            heartId: String(result.heart.heartId),
+          },
         );
       } catch {
         throw new AppException('SERVER_TEMPORARY_ERROR', {


### PR DESCRIPTION
## 이슈 번호
close #268 

## 주요 변경사항
- 채팅 알림뿐 아니라 게시물, 댓글 관련 알림도 페이로드에 관련 정보를 실어 보내 push알림 클릭 시 이동이 가능하게 했습니다.
- Notification 타입별 페이로드를 다르게 전달합니다.

// 채팅 알림
CHAT: {
  chatRoomId: string
  messageId: string
  senderUserId: string
}

// 게시글 좋아요 알림
ARTICLE: {
  clubId: string
  articleId: string
  senderUserId: string
}

// 댓글/답글 알림
COMMENT: {
  clubId: string
  articleId: string
  commentId: string
  senderUserId: string
}

// 마음 알림
HEART: {
  senderUserId: string
  heartId: string
}

## 테스트 결과 (스크린샷)
- 

## 참고 및 개선사항
- 
