### PR TITLE
[EUM-105] [Fix] 동호회 가입신청 시 , 가입 승인 시 FCM 푸시 알람 추가

### DIFF
--- a/prisma/dbml/schema.dbml
+++ b/prisma/dbml/schema.dbml
@@ -592,6 +592,7 @@ Enum NotificationType {
   PROFILE
   REMIND
   UPDATE
+  CLUB
 }
 
 Enum PushPlatform {

--- a/prisma/migrations/20260708000000_add_club_notification_type/migration.sql
+++ b/prisma/migrations/20260708000000_add_club_notification_type/migration.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "NotificationType" ADD VALUE IF NOT EXISTS 'CLUB';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -66,6 +66,7 @@ enum NotificationType {
   PROFILE
   REMIND
   UPDATE
+  CLUB
 }
 
 enum PushPlatform {
@@ -397,16 +398,16 @@ model Notification {
 }
 
 model PushDeviceToken {
-  id          BigInt       @id @default(autoincrement()) @db.BigInt
-  userId      BigInt       @db.BigInt
-  token       String       @unique @db.VarChar(512)
-  platform    PushPlatform
-  deviceId    String?      @db.VarChar(128)
-  appVersion  String?      @db.VarChar(32)
-  lastSeenAt  DateTime     @default(now()) @db.Timestamp(6)
-  revokedAt   DateTime?    @db.Timestamp(6)
-  createdAt   DateTime     @default(now()) @db.Timestamp(6)
-  updatedAt   DateTime     @updatedAt @db.Timestamp(6)
+  id         BigInt       @id @default(autoincrement()) @db.BigInt
+  userId     BigInt       @db.BigInt
+  token      String       @unique @db.VarChar(512)
+  platform   PushPlatform
+  deviceId   String?      @db.VarChar(128)
+  appVersion String?      @db.VarChar(32)
+  lastSeenAt DateTime     @default(now()) @db.Timestamp(6)
+  revokedAt  DateTime?    @db.Timestamp(6)
+  createdAt  DateTime     @default(now()) @db.Timestamp(6)
+  updatedAt  DateTime     @updatedAt @db.Timestamp(6)
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 

--- a/src/modules/club/club.module.ts
+++ b/src/modules/club/club.module.ts
@@ -14,9 +14,16 @@ import { MeetingRepository } from './repositories/meeting.repository';
 import { ClubMemberRepository } from './repositories/club-member.repository';
 import { UserModule } from '../user/user.module';
 import { OnboardingModule } from '../onboarding/onboarding.module';
+import { NotificationModule } from '../notification/notification.module';
 
 @Module({
-  imports: [AuthModule, PrismaModule, UserModule, OnboardingModule],
+  imports: [
+    AuthModule,
+    PrismaModule,
+    UserModule,
+    OnboardingModule,
+    NotificationModule,
+  ],
   controllers: [
     ClubController,
     ClubSearchController,

--- a/src/modules/club/services/member/club-member.service.spec.ts
+++ b/src/modules/club/services/member/club-member.service.spec.ts
@@ -1,8 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { ClubAuthority, ClubUserStatus } from '@prisma/client';
+import {
+  ClubAuthority,
+  ClubUserStatus,
+  NotificationType,
+} from '@prisma/client';
 import { ClubMemberService } from './club-member.service';
 import { ClubRepository } from '../../repositories/club.repository';
 import { ClubMemberRepository } from '../../repositories/club-member.repository';
+import { NotificationService } from '../../../notification/services/notification.service';
 
 describe('ClubMemberService', () => {
   let service: ClubMemberService;
@@ -17,6 +22,7 @@ describe('ClubMemberService', () => {
   const leave = jest.fn();
   const kick = jest.fn();
   const delegateHost = jest.fn();
+  const createNotification = jest.fn();
 
   const clubId = 12n;
   const userId = 42n;
@@ -47,6 +53,7 @@ describe('ClubMemberService', () => {
     leave.mockReset();
     kick.mockReset();
     delegateHost.mockReset();
+    createNotification.mockReset();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -66,6 +73,12 @@ describe('ClubMemberService', () => {
             delegateHost,
           },
         },
+        {
+          provide: NotificationService,
+          useValue: {
+            createNotification,
+          },
+        },
       ],
     }).compile();
 
@@ -76,6 +89,7 @@ describe('ClubMemberService', () => {
     findClubById.mockResolvedValue({
       id: clubId,
       hostId: hostUserId,
+      name: '테스트 동호회',
       capacity: 10,
       deletedAt: null,
     });
@@ -91,6 +105,17 @@ describe('ClubMemberService', () => {
       userId,
       message: member.joinMessage,
     });
+    expect(createNotification).toHaveBeenCalledWith(
+      Number(hostUserId),
+      NotificationType.CLUB,
+      '새 동호회 가입 신청이 있어요.',
+      '[테스트 동호회] 새 가입 신청이 도착했어요.',
+      Number(userId),
+      {
+        clubId: clubId.toString(),
+        senderUserId: userId.toString(),
+      },
+    );
     expect(result).toEqual({
       clubUserId: 333,
       clubId: 12,
@@ -107,6 +132,7 @@ describe('ClubMemberService', () => {
     findClubById.mockResolvedValue({
       id: clubId,
       hostId: hostUserId,
+      name: '테스트 동호회',
       capacity: 10,
       deletedAt: null,
     });
@@ -124,6 +150,7 @@ describe('ClubMemberService', () => {
     findClubById.mockResolvedValue({
       id: clubId,
       hostId: hostUserId,
+      name: '테스트 동호회',
       capacity: 10,
       deletedAt: null,
     });
@@ -142,6 +169,17 @@ describe('ClubMemberService', () => {
       userId,
       message: member.joinMessage,
     });
+    expect(createNotification).toHaveBeenCalledWith(
+      Number(hostUserId),
+      NotificationType.CLUB,
+      '새 동호회 가입 신청이 있어요.',
+      '[테스트 동호회] 새 가입 신청이 도착했어요.',
+      Number(userId),
+      {
+        clubId: clubId.toString(),
+        senderUserId: userId.toString(),
+      },
+    );
     expect(result.status).toBe(ClubUserStatus.PENDING);
   });
 
@@ -149,6 +187,7 @@ describe('ClubMemberService', () => {
     findClubById.mockResolvedValue({
       id: clubId,
       hostId: hostUserId,
+      name: '테스트 동호회',
       capacity: 10,
       deletedAt: null,
     });
@@ -174,6 +213,18 @@ describe('ClubMemberService', () => {
       status: ClubUserStatus.ACTIVE,
       capacity: 10,
     });
+    expect(createNotification).toHaveBeenCalledWith(
+      Number(userId),
+      NotificationType.CLUB,
+      '동호회 가입이 승인됐어요.',
+      '[테스트 동호회] 동호회 가입이 승인됐어요.',
+      Number(hostUserId),
+      {
+        clubId: clubId.toString(),
+        senderUserId: hostUserId.toString(),
+        status: ClubUserStatus.ACTIVE,
+      },
+    );
     expect(result.status).toBe(ClubUserStatus.ACTIVE);
     expect(result.joinedAt).toBe(joinedAt.toISOString());
   });

--- a/src/modules/club/services/member/club-member.service.ts
+++ b/src/modules/club/services/member/club-member.service.ts
@@ -1,8 +1,14 @@
 import { Injectable } from '@nestjs/common';
-import { ClubAuthority, ClubUser, ClubUserStatus } from '@prisma/client';
+import {
+  ClubAuthority,
+  ClubUser,
+  ClubUserStatus,
+  NotificationType,
+} from '@prisma/client';
 import { AppException } from '../../../../common/errors/app.exception';
 import { ClubRepository } from '../../repositories/club.repository';
 import { ClubMemberRepository } from '../../repositories/club-member.repository';
+import { NotificationService } from '../../../notification/services/notification.service';
 import {
   ClubMemberListItemDto,
   ClubMemberListResponseDto,
@@ -20,6 +26,7 @@ export class ClubMemberService {
   constructor(
     private readonly clubRepository: ClubRepository,
     private readonly clubMemberRepository: ClubMemberRepository,
+    private readonly notificationService: NotificationService,
   ) {}
 
   async requestJoin(
@@ -43,6 +50,7 @@ export class ClubMemberService {
         userId,
         message: dto.message,
       });
+      await this.createJoinRequestNotification(club, userId);
       return this.toResponse(created);
     }
 
@@ -55,6 +63,7 @@ export class ClubMemberService {
         userId,
         message: dto.message,
       });
+      await this.createJoinRequestNotification(club, userId);
       return this.toResponse(updated);
     }
 
@@ -96,6 +105,13 @@ export class ClubMemberService {
     if (result.result === 'capacity_exceeded') {
       throw new AppException('CLUB_CAPACITY_EXCEEDED');
     }
+
+    await this.createJoinRequestStatusNotification(
+      club,
+      hostUserId,
+      targetUserId,
+      dto.status,
+    );
 
     return this.toResponse(result.member);
   }
@@ -266,6 +282,51 @@ export class ClubMemberService {
       requestedAt: member.requestedAt.toISOString(),
       joinedAt: member.joinedAt?.toISOString() ?? null,
     };
+  }
+
+  private async createJoinRequestNotification(
+    club: { id: bigint; hostId: bigint | null; name: string },
+    requesterUserId: bigint,
+  ): Promise<void> {
+    if (!club.hostId || club.hostId === requesterUserId) {
+      return;
+    }
+
+    await this.notificationService.createNotification(
+      Number(club.hostId),
+      NotificationType.CLUB,
+      '새 동호회 가입 신청이 있어요.',
+      `[${club.name}] 새 가입 신청이 도착했어요.`,
+      Number(requesterUserId),
+      {
+        clubId: club.id.toString(),
+        senderUserId: requesterUserId.toString(),
+      },
+    );
+  }
+
+  private async createJoinRequestStatusNotification(
+    club: { id: bigint; name: string },
+    hostUserId: bigint,
+    targetUserId: bigint,
+    status: ClubUserStatus,
+  ): Promise<void> {
+    const approved = status === ClubUserStatus.ACTIVE;
+
+    await this.notificationService.createNotification(
+      Number(targetUserId),
+      NotificationType.CLUB,
+      approved ? '동호회 가입이 승인됐어요.' : '동호회 가입 신청이 거절됐어요.',
+      approved
+        ? `[${club.name}] 동호회 가입이 승인됐어요.`
+        : `[${club.name}] 동호회 가입 신청이 거절됐어요.`,
+      Number(hostUserId),
+      {
+        clubId: club.id.toString(),
+        senderUserId: hostUserId.toString(),
+        status,
+      },
+    );
   }
 
   private toRequestItem(

--- a/src/modules/notification/repositories/notification.repository.ts
+++ b/src/modules/notification/repositories/notification.repository.ts
@@ -91,7 +91,13 @@ export class NotificationRepository {
     return this.prisma.notification.findMany({
       where: {
         userId: BigInt(userId),
-        type: { in: [NotificationType.ARTICLE, NotificationType.COMMENT] },
+        type: {
+          in: [
+            NotificationType.ARTICLE,
+            NotificationType.COMMENT,
+            NotificationType.CLUB,
+          ],
+        },
         deletedAt: null,
       },
       take: limit,
@@ -245,7 +251,13 @@ export class NotificationRepository {
         userId: BigInt(userId),
         isRead: false,
         deletedAt: null,
-        type: { in: [NotificationType.ARTICLE, NotificationType.COMMENT] },
+        type: {
+          in: [
+            NotificationType.ARTICLE,
+            NotificationType.COMMENT,
+            NotificationType.CLUB,
+          ],
+        },
       },
     });
   }


### PR DESCRIPTION
## 이슈 번호
close #270 

## 주요 변경사항
  - 동호회 가입 신청 생성/재신청 성공 시 호스트에게 FCM 푸시 알림이 가도록 NotificationService.createNotification() 호출 추가
  - 동호회 가입 승인/거절 성공 시 신청자에게 FCM 푸시 알림이 가도록 추가
  - 알림 타입은 NotificationType.CLUB 사용
  - ClubModule에서 NotificationModule을 import 하도록 DI 연결
  - 동호회 알림 목록/전체 읽음 대상에 ARTICLE, COMMENT뿐 아니라 CLUB 타입도 포함
  - Prisma NotificationType enum에 CLUB 추가 마이그레이션 생성
      - prisma/migrations/20260708000000_add_club_notification_type/migration.sql

## 테스트 결과 (스크린샷)
- 

## 참고 및 개선사항
