### PR TITLE
[EUM-108] [Feat] 동호회 신고 및 게시글 신고 기능 추가

### DIFF
--- a/prisma/dbml/schema.dbml
+++ b/prisma/dbml/schema.dbml
@@ -197,6 +197,8 @@ Table Block {
 Table Report {
   id BigInt [pk, increment]
   reportedById BigInt
+  targetType ReportTargetType
+  targetId BigInt
   reportedAt DateTime [not null]
   reason String [not null]
   category ReportCategory [not null, default: 'OTHERS']
@@ -648,6 +650,12 @@ Enum ReportCategory {
   ABUSE
   SPAM
   OTHERS
+}
+
+Enum ReportTargetType {
+  USER
+  CLUB
+  ARTICLE
 }
 
 Enum ChatRoomType {

--- a/prisma/dbml/schema.dbml
+++ b/prisma/dbml/schema.dbml
@@ -199,6 +199,7 @@ Table Report {
   reportedById BigInt
   targetType ReportTargetType
   targetId BigInt
+  chatRoomId BigInt
   reportedAt DateTime [not null]
   reason String [not null]
   category ReportCategory [not null, default: 'OTHERS']

--- a/prisma/migrations/20260708001000_add_report_target_fields/migration.sql
+++ b/prisma/migrations/20260708001000_add_report_target_fields/migration.sql
@@ -2,6 +2,30 @@ CREATE TYPE "ReportTargetType" AS ENUM ('USER', 'CLUB', 'ARTICLE');
 
 ALTER TABLE "Report"
   ADD COLUMN "targetType" "ReportTargetType",
-  ADD COLUMN "targetId" BIGINT;
+  ADD COLUMN "targetId" BIGINT,
+  ADD COLUMN "chatRoomId" BIGINT;
+
+UPDATE "Report"
+SET
+  "targetType" = 'USER',
+  "targetId" = "UserReport"."reportedUserId"
+FROM "UserReport"
+WHERE "UserReport"."reportId" = "Report"."id"
+  AND "UserReport"."reportedUserId" IS NOT NULL;
+
+UPDATE "Report"
+SET
+  "targetType" = 'CLUB',
+  "targetId" = "ClubReport"."reportedClubId"
+FROM "ClubReport"
+WHERE "ClubReport"."reportId" = "Report"."id"
+  AND "ClubReport"."reportedClubId" IS NOT NULL;
 
 CREATE INDEX "Report_targetType_targetId_idx" ON "Report"("targetType", "targetId");
+CREATE INDEX "Report_chatRoomId_idx" ON "Report"("chatRoomId");
+CREATE UNIQUE INDEX "Report_reportedById_targetType_targetId_active_key"
+  ON "Report"("reportedById", "targetType", "targetId")
+  WHERE "reportedById" IS NOT NULL
+    AND "targetType" IS NOT NULL
+    AND "targetId" IS NOT NULL
+    AND "deletedAt" IS NULL;

--- a/prisma/migrations/20260708001000_add_report_target_fields/migration.sql
+++ b/prisma/migrations/20260708001000_add_report_target_fields/migration.sql
@@ -1,0 +1,7 @@
+CREATE TYPE "ReportTargetType" AS ENUM ('USER', 'CLUB', 'ARTICLE');
+
+ALTER TABLE "Report"
+  ADD COLUMN "targetType" "ReportTargetType",
+  ADD COLUMN "targetId" BIGINT;
+
+CREATE INDEX "Report_targetType_targetId_idx" ON "Report"("targetType", "targetId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -124,6 +124,12 @@ enum ReportCategory {
   OTHERS
 }
 
+enum ReportTargetType {
+  USER
+  CLUB
+  ARTICLE
+}
+
 enum ChatRoomType {
   DIRECT
   CLUB
@@ -365,6 +371,8 @@ model Block {
 model Report {
   id           BigInt         @id @default(autoincrement()) @db.BigInt
   reportedById BigInt?        @db.BigInt
+  targetType   ReportTargetType?
+  targetId     BigInt?        @db.BigInt
   reportedAt   DateTime       @db.Timestamp(6)
   reason       String         @db.VarChar(100)
   category     ReportCategory @default(OTHERS)
@@ -375,6 +383,7 @@ model Report {
   clubReport ClubReport?
 
   @@index([reportedById])
+  @@index([targetType, targetId])
   @@index([reportedAt])
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -373,6 +373,7 @@ model Report {
   reportedById BigInt?        @db.BigInt
   targetType   ReportTargetType?
   targetId     BigInt?        @db.BigInt
+  chatRoomId   BigInt?        @db.BigInt
   reportedAt   DateTime       @db.Timestamp(6)
   reason       String         @db.VarChar(100)
   category     ReportCategory @default(OTHERS)
@@ -384,6 +385,7 @@ model Report {
 
   @@index([reportedById])
   @@index([targetType, targetId])
+  @@index([chatRoomId])
   @@index([reportedAt])
 }
 

--- a/src/modules/social/controllers/report/report.controller.spec.ts
+++ b/src/modules/social/controllers/report/report.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
+import { ReportCategory } from '@prisma/client';
 import { JwtTokenService } from '../../../auth/services/jwt-token.service';
 import { PrismaService } from '../../../../infra/prisma/prisma.service';
 import { AccessTokenGuard } from '../../../auth/guards/access-token.guard';
@@ -8,8 +9,15 @@ import { ReportController } from './report.controller';
 
 describe('ReportController', () => {
   let controller: ReportController;
+  const reportService = {
+    createReport: jest.fn(),
+    createClubReport: jest.fn(),
+    createArticleReport: jest.fn(),
+  };
 
   beforeEach(async () => {
+    Object.values(reportService).forEach((mock) => mock.mockReset());
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ReportController],
       providers: [
@@ -35,9 +43,7 @@ describe('ReportController', () => {
         },
         {
           provide: ReportService,
-          useValue: {
-            createReport: jest.fn(),
-          },
+          useValue: reportService,
         },
         AccessTokenGuard,
       ],
@@ -48,5 +54,49 @@ describe('ReportController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  it('동호회 신고 요청을 서비스로 위임한다', async () => {
+    reportService.createClubReport.mockResolvedValue({
+      reportId: 1,
+      category: ReportCategory.SPAM,
+      reason: '스팸입니다.',
+      clubId: 12,
+    });
+
+    await controller.createClubReport(7, 12, {
+      category: ReportCategory.SPAM,
+      reason: '스팸입니다.',
+    });
+
+    expect(reportService.createClubReport).toHaveBeenCalledWith('7', '12', {
+      category: ReportCategory.SPAM,
+      reason: '스팸입니다.',
+    });
+  });
+
+  it('동호회 게시글 신고 요청을 서비스로 위임한다', async () => {
+    reportService.createArticleReport.mockResolvedValue({
+      reportId: 1,
+      category: ReportCategory.ABUSE,
+      reason: '욕설입니다.',
+      clubId: 12,
+      articleId: 345,
+    });
+
+    await controller.createArticleReport(7, 12, 345, {
+      category: ReportCategory.ABUSE,
+      reason: '욕설입니다.',
+    });
+
+    expect(reportService.createArticleReport).toHaveBeenCalledWith(
+      '7',
+      '12',
+      '345',
+      {
+        category: ReportCategory.ABUSE,
+        reason: '욕설입니다.',
+      },
+    );
   });
 });

--- a/src/modules/social/controllers/report/report.controller.ts
+++ b/src/modules/social/controllers/report/report.controller.ts
@@ -1,15 +1,24 @@
-import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Param, Post, UseGuards } from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiBody,
+  ApiConflictResponse,
   ApiCreatedResponse,
+  ApiNotFoundResponse,
   ApiOperation,
+  ApiParam,
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { ReportService } from '../../services/report/report.service';
 import { RequiredUserId } from '../../../auth/decorators';
 import { AccessTokenGuard } from '../../../auth/guards/access-token.guard';
+import {
+  CreateReportRequestDto,
+  CreateUserReportRequestDto,
+  ReportCreatedResponseDto,
+} from '../../dtos/report.dto';
+import { ParsePositiveIntPipe } from '../../../../common/pipes/parse-positive-int.pipe';
 
 @ApiTags('Report')
 @ApiBearerAuth('access-token')
@@ -20,44 +29,68 @@ export class ReportController {
 
   @Post()
   @ApiOperation({ summary: '사용자 신고 생성' })
-  @ApiBody({
-    schema: {
-      type: 'object',
-      properties: {
-        targetUserId: { type: 'string', example: '40' },
-        reason: {
-          type: 'string',
-          example: '불쾌한 메시지를 반복 전송',
-        },
-        category: {
-          type: 'string',
-          example: 'HARASSMENT',
-          description: '신고 유형 코드',
-        },
-        chatRoomId: {
-          type: 'string',
-          example: '123',
-          description: '관련된 채팅방 ID',
-        },
-      },
-      required: ['targetUserId', 'reason'],
-    },
-  })
+  @ApiBody({ type: CreateUserReportRequestDto })
   @ApiCreatedResponse({ description: '신고 접수 완료' })
   @ApiUnauthorizedResponse({ description: '로그인 필요' })
   async createReport(
     @RequiredUserId() userId: number,
-    @Body('targetUserId') targetUserId: string,
-    @Body('reason') reason: string,
-    @Body('category') category: string,
-    @Body('chatRoomId') chatRoomId: string,
+    @Body() dto: CreateUserReportRequestDto,
   ) {
     return this.reportService.createReport(
       String(userId),
-      targetUserId,
-      reason,
-      category,
-      chatRoomId,
+      dto.targetUserId,
+      dto.reason,
+      dto.category,
+      dto.chatRoomId,
+    );
+  }
+
+  @Post('clubs/:clubId')
+  @ApiOperation({ summary: '동호회 신고 생성' })
+  @ApiParam({ name: 'clubId', example: 12 })
+  @ApiBody({ type: CreateReportRequestDto })
+  @ApiCreatedResponse({
+    description: '동호회 신고 접수 완료',
+    type: ReportCreatedResponseDto,
+  })
+  @ApiUnauthorizedResponse({ description: '로그인 필요' })
+  @ApiNotFoundResponse({ description: '동호회를 찾을 수 없음' })
+  @ApiConflictResponse({ description: '이미 신고한 동호회' })
+  async createClubReport(
+    @RequiredUserId() userId: number,
+    @Param('clubId', new ParsePositiveIntPipe()) clubId: number,
+    @Body() dto: CreateReportRequestDto,
+  ): Promise<ReportCreatedResponseDto> {
+    return this.reportService.createClubReport(
+      String(userId),
+      String(clubId),
+      dto,
+    );
+  }
+
+  @Post('clubs/:clubId/articles/:articleId')
+  @ApiOperation({ summary: '동호회 게시글 신고 생성' })
+  @ApiParam({ name: 'clubId', example: 12 })
+  @ApiParam({ name: 'articleId', example: 345 })
+  @ApiBody({ type: CreateReportRequestDto })
+  @ApiCreatedResponse({
+    description: '동호회 게시글 신고 접수 완료',
+    type: ReportCreatedResponseDto,
+  })
+  @ApiUnauthorizedResponse({ description: '로그인 필요' })
+  @ApiNotFoundResponse({ description: '게시글을 찾을 수 없음' })
+  @ApiConflictResponse({ description: '이미 신고한 게시글' })
+  async createArticleReport(
+    @RequiredUserId() userId: number,
+    @Param('clubId', new ParsePositiveIntPipe()) clubId: number,
+    @Param('articleId', new ParsePositiveIntPipe()) articleId: number,
+    @Body() dto: CreateReportRequestDto,
+  ): Promise<ReportCreatedResponseDto> {
+    return this.reportService.createArticleReport(
+      String(userId),
+      String(clubId),
+      String(articleId),
+      dto,
     );
   }
 }

--- a/src/modules/social/dtos/report.dto.ts
+++ b/src/modules/social/dtos/report.dto.ts
@@ -1,7 +1,73 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ReportCategory } from '@prisma/client';
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MaxLength,
+} from 'class-validator';
+
 export interface ReportDto {
   targetUserId: number;
   reason: string;
 }
+
+export class CreateReportRequestDto {
+  @ApiProperty({
+    enum: ReportCategory,
+    example: ReportCategory.SPAM,
+    description: '신고 유형 코드',
+  })
+  @IsEnum(ReportCategory)
+  category!: ReportCategory;
+
+  @ApiProperty({
+    example: '스팸성 홍보 내용이 반복적으로 게시됩니다.',
+    description: '신고 상세 사유',
+    maxLength: 100,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  reason!: string;
+}
+
+export class CreateUserReportRequestDto extends CreateReportRequestDto {
+  @ApiProperty({
+    example: '40',
+    description: '신고 대상 사용자 ID',
+  })
+  @IsString()
+  @IsNotEmpty()
+  targetUserId!: string;
+
+  @ApiPropertyOptional({
+    example: '123',
+    description: '관련된 채팅방 ID',
+  })
+  @IsOptional()
+  @IsString()
+  chatRoomId?: string;
+}
+
+export class ReportCreatedResponseDto {
+  @ApiProperty({ example: 123 })
+  reportId!: number;
+
+  @ApiProperty({ enum: ReportCategory, example: ReportCategory.SPAM })
+  category!: ReportCategory;
+
+  @ApiProperty({ example: '스팸성 홍보 내용이 반복적으로 게시됩니다.' })
+  reason!: string;
+
+  @ApiPropertyOptional({ example: 12 })
+  clubId?: number;
+
+  @ApiPropertyOptional({ example: 345 })
+  articleId?: number;
+}
+
 export interface ReportResponseDto {
   reportId: number;
   category: string;

--- a/src/modules/social/repositories/report.repository.ts
+++ b/src/modules/social/repositories/report.repository.ts
@@ -42,6 +42,18 @@ export class ReportRepository {
     });
   }
 
+  deactivateClub(clubId: string) {
+    return this.prisma.club.updateMany({
+      where: {
+        id: BigInt(clubId),
+        deletedAt: null,
+      },
+      data: {
+        deletedAt: new Date(),
+      },
+    });
+  }
+
   countActiveUserReports(userId: string) {
     return this.prisma.userReport.count({
       where: {

--- a/src/modules/social/repositories/report.repository.ts
+++ b/src/modules/social/repositories/report.repository.ts
@@ -1,81 +1,296 @@
 import { Injectable } from '@nestjs/common';
+import {
+  Prisma,
+  Report,
+  ReportCategory,
+  ReportTargetType,
+} from '@prisma/client';
 import { PrismaService } from '../../../infra/prisma/prisma.service';
-import { ReportResponseDto } from '../dtos/report.dto';
-import { ReportCategory } from '@prisma/client';
+import {
+  ReportCreatedResponseDto,
+  ReportResponseDto,
+} from '../dtos/report.dto';
 
 @Injectable()
 export class ReportRepository {
   constructor(private readonly prisma: PrismaService) {}
 
-  // TODO(schema): Report 모델이 재구조됨.
-  //   - 옛: Report{reportedById, reportedId, reason, category(String), chatRoomId, ...} (단일 테이블)
-  //   - 신: Report{reportedById, reason, category(ReportCategory enum), ...} + UserReport{reportId, reportedUserId} 분리
-  // 변경 영향:
-  //   1) "내가 X를 신고한 적 있는지" 체크가 Report unique 인덱스 → UserReport + report join으로 변경
-  //   2) category가 String → ReportCategory enum이라 invalid한 값은 런타임에 에러. boundary(컨트롤러)에서 validate 필요.
-  //   3) chatRoomId 필드가 새 Report에서 사라짐 → 신고 컨텍스트(어느 채팅방)가 DB에 보존되지 않음. UserReport에도 없음.
-  //      DTO 응답에는 echo만 함. 필요 시 ClubReport 패턴 같은 새 join table 추가 검토.
+  findActiveClubById(clubId: string) {
+    return this.prisma.club.findFirst({
+      where: { id: BigInt(clubId), deletedAt: null },
+      select: { id: true, hostId: true },
+    });
+  }
+
+  findActiveArticleByClubId(clubId: string, articleId: string) {
+    return this.prisma.article.findFirst({
+      where: {
+        id: BigInt(articleId),
+        clubId: BigInt(clubId),
+        deletedAt: null,
+      },
+      select: { id: true, clubId: true, userId: true },
+    });
+  }
+
+  countActiveClubReports(clubId: string) {
+    return this.prisma.clubReport.count({
+      where: {
+        reportedClubId: BigInt(clubId),
+        report: { deletedAt: null },
+      },
+    });
+  }
+
+  countActiveUserReports(userId: string) {
+    return this.prisma.userReport.count({
+      where: {
+        reportedUserId: BigInt(userId),
+        report: { deletedAt: null },
+      },
+    });
+  }
+
   async createReport(
     userId: string,
     targetUserId: string,
     reason: string,
-    category: string,
-    chatRoomId: string,
+    category: ReportCategory,
+    chatRoomId?: string,
   ): Promise<ReportResponseDto> {
-    // TODO(business): category 문자열 validation을 컨트롤러/DTO 레벨로 옮기는 게 정석. 일단 캐스팅 + 잘못된 값이면 throw.
-    if (!(category in ReportCategory)) {
-      throw new Error(`Invalid report category: ${category}`);
-    }
-    const cat = category as ReportCategory;
-
-    // TODO(concurrency, Codex P2): 옛 schema의 (reportedById, reportedId) unique 인덱스가 race 방어 역할을 했는데,
-    // 새 schema엔 (reportedById, reportedUserId) unique 제약이 없음. 아래 findFirst → create 사이의 race window에서
-    // 동일 reporter가 동일 target에 거의 동시에 요청을 보내면 둘 다 existence check 통과 → 중복 Report+UserReport 생성 가능
-    // (API 계약상 두번째 요청은 "Already reported."가 반환되어야 하는데 실제로는 신규 ID로 생성됨).
-    // 해결 옵션:
-    //   (a) #172 schema에 unique 인덱스 추가 (Report.reportedById + UserReport.reportedUserId 결합 또는 별도 join 모델)
-    //   (b) $transaction with SELECT ... FOR UPDATE on UserReport
-    //   (c) (a) + unique constraint violation catch → "Already reported." 응답으로 변환
-    // AI/서버팀 협의 후 follow-up.
-    const exist = await this.prisma.userReport.findFirst({
-      where: {
-        reportedUserId: BigInt(targetUserId),
-        report: { reportedById: BigInt(userId), deletedAt: null },
-      },
-      select: { report: { select: { id: true } } },
-    });
+    const exist = await this.findExistingTargetReport(
+      userId,
+      ReportTargetType.USER,
+      targetUserId,
+    );
     if (exist != null) {
       return {
-        reportId: Number(exist.report.id),
+        reportId: Number(exist.id),
         category,
         reason: 'Already reported.',
-        chatRoomId: Number(chatRoomId),
+        chatRoomId: Number(chatRoomId ?? 0),
       };
     }
 
-    const created = await this.prisma.$transaction(async (tx) => {
-      const r = await tx.report.create({
-        data: {
-          reportedById: BigInt(userId),
-          reason,
-          category: cat,
-          reportedAt: new Date(),
-        },
-      });
-      await tx.userReport.create({
-        data: {
-          reportId: r.id,
-          reportedUserId: BigInt(targetUserId),
-        },
-      });
-      return r;
+    const result = await this.createTargetReport({
+      userId,
+      targetType: ReportTargetType.USER,
+      targetId: targetUserId,
+      reason,
+      category,
+      chatRoomId,
+      createLegacyTarget: async (tx, reportId) => {
+        await tx.userReport.create({
+          data: {
+            reportId,
+            reportedUserId: BigInt(targetUserId),
+          },
+        });
+      },
     });
+    if (!result.created) {
+      return {
+        reportId: Number(result.report.id),
+        category,
+        reason: 'Already reported.',
+        chatRoomId: Number(chatRoomId ?? 0),
+      };
+    }
 
     return {
-      reportId: Number(created.id),
+      reportId: Number(result.report.id),
       category,
       reason,
-      chatRoomId: Number(chatRoomId),
+      chatRoomId: Number(chatRoomId ?? 0),
+    };
+  }
+
+  private findExistingTargetReport(
+    userId: string,
+    targetType: ReportTargetType,
+    targetId: string,
+  ) {
+    return this.prisma.report.findFirst({
+      where: {
+        reportedById: BigInt(userId),
+        targetType,
+        targetId: BigInt(targetId),
+        deletedAt: null,
+      },
+      select: { id: true },
+    });
+  }
+
+  private async createTargetReport(params: {
+    userId: string;
+    targetType: ReportTargetType;
+    targetId: string;
+    reason: string;
+    category: ReportCategory;
+    chatRoomId?: string;
+    createLegacyTarget?: (
+      tx: Prisma.TransactionClient,
+      reportId: bigint,
+    ) => Promise<void>;
+  }): Promise<{ report: Report; created: boolean }> {
+    try {
+      const report = await this.prisma.$transaction(async (tx) => {
+        const report = await tx.report.create({
+          data: {
+            reportedById: BigInt(params.userId),
+            targetType: params.targetType,
+            targetId: BigInt(params.targetId),
+            chatRoomId: params.chatRoomId ? BigInt(params.chatRoomId) : null,
+            reason: params.reason,
+            category: params.category,
+            reportedAt: new Date(),
+          },
+        });
+        await params.createLegacyTarget?.(tx, report.id);
+        return report;
+      });
+      return { report, created: true };
+    } catch (error) {
+      if (!this.isUniqueReportTargetError(error)) {
+        throw error;
+      }
+
+      const existing = await this.findExistingTargetReport(
+        params.userId,
+        params.targetType,
+        params.targetId,
+      );
+      if (!existing) {
+        throw error;
+      }
+
+      const report = await this.prisma.report.findUniqueOrThrow({
+        where: { id: existing.id },
+      });
+      return { report, created: false };
+    }
+  }
+
+  private isUniqueReportTargetError(error: unknown): boolean {
+    return (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === 'P2002'
+    );
+  }
+
+  async createClubReport(
+    userId: string,
+    clubId: string,
+    reason: string,
+    category: ReportCategory,
+  ): Promise<ReportCreatedResponseDto> {
+    const exist = await this.findExistingTargetReport(
+      userId,
+      ReportTargetType.CLUB,
+      clubId,
+    );
+    if (exist != null) {
+      return {
+        reportId: Number(exist.id),
+        category,
+        reason: 'Already reported.',
+        clubId: Number(clubId),
+      };
+    }
+
+    const result = await this.createTargetReport({
+      userId,
+      targetType: ReportTargetType.CLUB,
+      targetId: clubId,
+      reason,
+      category,
+      createLegacyTarget: async (tx, reportId) => {
+        await tx.clubReport.create({
+          data: {
+            reportId,
+            reportedClubId: BigInt(clubId),
+          },
+        });
+      },
+    });
+    if (!result.created) {
+      return {
+        reportId: Number(result.report.id),
+        category,
+        reason: 'Already reported.',
+        clubId: Number(clubId),
+      };
+    }
+
+    return {
+      reportId: Number(result.report.id),
+      category,
+      reason,
+      clubId: Number(clubId),
+    };
+  }
+
+  async createArticleReport(
+    userId: string,
+    clubId: string,
+    articleId: string,
+    reason: string,
+    category: ReportCategory,
+  ): Promise<ReportCreatedResponseDto> {
+    const exist = await this.findExistingTargetReport(
+      userId,
+      ReportTargetType.ARTICLE,
+      articleId,
+    );
+    if (exist != null) {
+      return {
+        reportId: Number(exist.id),
+        category,
+        reason: 'Already reported.',
+        clubId: Number(clubId),
+        articleId: Number(articleId),
+      };
+    }
+
+    const result = await this.createTargetReport({
+      userId,
+      targetType: ReportTargetType.ARTICLE,
+      targetId: articleId,
+      reason,
+      category,
+      createLegacyTarget: async (tx, reportId) => {
+        const article = await tx.article.findUnique({
+          where: { id: BigInt(articleId) },
+          select: { userId: true },
+        });
+        if (!article?.userId) {
+          return;
+        }
+
+        await tx.userReport.create({
+          data: {
+            reportId,
+            reportedUserId: article.userId,
+          },
+        });
+      },
+    });
+    if (!result.created) {
+      return {
+        reportId: Number(result.report.id),
+        category,
+        reason: 'Already reported.',
+        clubId: Number(clubId),
+        articleId: Number(articleId),
+      };
+    }
+
+    return {
+      reportId: Number(result.report.id),
+      category,
+      reason,
+      clubId: Number(clubId),
+      articleId: Number(articleId),
     };
   }
 }

--- a/src/modules/social/services/report/report.service.spec.ts
+++ b/src/modules/social/services/report/report.service.spec.ts
@@ -12,6 +12,7 @@ describe('ReportService', () => {
     findActiveArticleByClubId: jest.fn(),
     countActiveClubReports: jest.fn(),
     countActiveUserReports: jest.fn(),
+    deactivateClub: jest.fn(),
     createClubReport: jest.fn(),
     createArticleReport: jest.fn(),
   };
@@ -81,7 +82,40 @@ describe('ReportService', () => {
         reportCount: '3',
       },
     );
+    expect(reportRepository.deactivateClub).not.toHaveBeenCalled();
     expect(result.clubId).toBe(12);
+  });
+
+  it('동호회 신고가 5번 이상이면 동호회를 비활성화한다', async () => {
+    reportRepository.findActiveClubById.mockResolvedValue({
+      id: 12n,
+      hostId: 99n,
+    });
+    reportRepository.createClubReport.mockResolvedValue({
+      reportId: 1,
+      category: ReportCategory.SPAM,
+      reason: '스팸입니다.',
+      clubId: 12,
+    });
+    reportRepository.countActiveClubReports.mockResolvedValue(5);
+
+    await service.createClubReport('7', '12', {
+      category: ReportCategory.SPAM,
+      reason: '스팸입니다.',
+    });
+
+    expect(reportRepository.deactivateClub).toHaveBeenCalledWith('12');
+    expect(notificationService.createNotification).toHaveBeenCalledWith(
+      99,
+      'CLUB',
+      '동호회 신고 알림',
+      '5번 이상의 동호회 신고시에, 동호회가 비활성화됩니다. 현재 5번 신고되었습니다.',
+      7,
+      {
+        clubId: '12',
+        reportCount: '5',
+      },
+    );
   });
 
   it('동호회가 없으면 CLUB_NOT_FOUND', async () => {

--- a/src/modules/social/services/report/report.service.spec.ts
+++ b/src/modules/social/services/report/report.service.spec.ts
@@ -1,19 +1,38 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ReportCategory } from '@prisma/client';
 import { ReportService } from './report.service';
 import { ReportRepository } from '../../repositories/report.repository';
+import { NotificationService } from '../../../notification/services/notification.service';
 
 describe('ReportService', () => {
   let service: ReportService;
+  const reportRepository = {
+    createReport: jest.fn(),
+    findActiveClubById: jest.fn(),
+    findActiveArticleByClubId: jest.fn(),
+    countActiveClubReports: jest.fn(),
+    countActiveUserReports: jest.fn(),
+    createClubReport: jest.fn(),
+    createArticleReport: jest.fn(),
+  };
+  const notificationService = {
+    createNotification: jest.fn(),
+  };
 
   beforeEach(async () => {
+    Object.values(reportRepository).forEach((mock) => mock.mockReset());
+    notificationService.createNotification.mockReset();
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ReportService,
         {
           provide: ReportRepository,
-          useValue: {
-            createReport: jest.fn(),
-          },
+          useValue: reportRepository,
+        },
+        {
+          provide: NotificationService,
+          useValue: notificationService,
         },
       ],
     }).compile();
@@ -23,5 +42,136 @@ describe('ReportService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('동호회 신고를 생성한다', async () => {
+    reportRepository.findActiveClubById.mockResolvedValue({
+      id: 12n,
+      hostId: 99n,
+    });
+    reportRepository.createClubReport.mockResolvedValue({
+      reportId: 1,
+      category: ReportCategory.SPAM,
+      reason: '스팸입니다.',
+      clubId: 12,
+    });
+    reportRepository.countActiveClubReports.mockResolvedValue(3);
+
+    const result = await service.createClubReport('7', '12', {
+      category: ReportCategory.SPAM,
+      reason: '스팸입니다.',
+    });
+
+    expect(reportRepository.findActiveClubById).toHaveBeenCalledWith('12');
+    expect(reportRepository.createClubReport).toHaveBeenCalledWith(
+      '7',
+      '12',
+      '스팸입니다.',
+      ReportCategory.SPAM,
+    );
+    expect(reportRepository.countActiveClubReports).toHaveBeenCalledWith('12');
+    expect(notificationService.createNotification).toHaveBeenCalledWith(
+      99,
+      'CLUB',
+      '동호회 신고 알림',
+      '5번 이상의 동호회 신고시에, 동호회가 비활성화됩니다. 현재 3번 신고되었습니다.',
+      7,
+      {
+        clubId: '12',
+        reportCount: '3',
+      },
+    );
+    expect(result.clubId).toBe(12);
+  });
+
+  it('동호회가 없으면 CLUB_NOT_FOUND', async () => {
+    reportRepository.findActiveClubById.mockResolvedValue(null);
+
+    await expect(
+      service.createClubReport('7', '12', {
+        category: ReportCategory.SPAM,
+        reason: '스팸입니다.',
+      }),
+    ).rejects.toMatchObject({ internalCode: 'CLUB_NOT_FOUND' });
+    expect(reportRepository.createClubReport).not.toHaveBeenCalled();
+  });
+
+  it('이미 신고한 동호회면 SOCIAL_REPORT_EXISTS', async () => {
+    reportRepository.findActiveClubById.mockResolvedValue({
+      id: 12n,
+      hostId: 99n,
+    });
+    reportRepository.createClubReport.mockResolvedValue({
+      reportId: 1,
+      category: ReportCategory.SPAM,
+      reason: 'Already reported.',
+      clubId: 12,
+    });
+
+    await expect(
+      service.createClubReport('7', '12', {
+        category: ReportCategory.SPAM,
+        reason: '스팸입니다.',
+      }),
+    ).rejects.toMatchObject({ internalCode: 'SOCIAL_REPORT_EXISTS' });
+    expect(notificationService.createNotification).not.toHaveBeenCalled();
+  });
+
+  it('동호회 게시글 신고를 생성한다', async () => {
+    reportRepository.findActiveArticleByClubId.mockResolvedValue({
+      id: 345n,
+      clubId: 12n,
+      userId: 88n,
+    });
+    reportRepository.createArticleReport.mockResolvedValue({
+      reportId: 1,
+      category: ReportCategory.ABUSE,
+      reason: '욕설입니다.',
+      clubId: 12,
+      articleId: 345,
+    });
+    reportRepository.countActiveUserReports.mockResolvedValue(4);
+
+    const result = await service.createArticleReport('7', '12', '345', {
+      category: ReportCategory.ABUSE,
+      reason: '욕설입니다.',
+    });
+
+    expect(reportRepository.findActiveArticleByClubId).toHaveBeenCalledWith(
+      '12',
+      '345',
+    );
+    expect(reportRepository.createArticleReport).toHaveBeenCalledWith(
+      '7',
+      '12',
+      '345',
+      '욕설입니다.',
+      ReportCategory.ABUSE,
+    );
+    expect(reportRepository.countActiveUserReports).toHaveBeenCalledWith('88');
+    expect(notificationService.createNotification).toHaveBeenCalledWith(
+      88,
+      'CLUB',
+      '게시글 신고 알림',
+      '신고 5번 이상 받았을 경우, 로그인이 제한됩니다. 현재 4번 신고되었습니다.',
+      7,
+      {
+        articleId: '345',
+        reportCount: '4',
+      },
+    );
+    expect(result.articleId).toBe(345);
+  });
+
+  it('게시글이 없으면 ARTICLE_NOT_FOUND', async () => {
+    reportRepository.findActiveArticleByClubId.mockResolvedValue(null);
+
+    await expect(
+      service.createArticleReport('7', '12', '345', {
+        category: ReportCategory.ABUSE,
+        reason: '욕설입니다.',
+      }),
+    ).rejects.toMatchObject({ internalCode: 'ARTICLE_NOT_FOUND' });
+    expect(reportRepository.createArticleReport).not.toHaveBeenCalled();
   });
 });

--- a/src/modules/social/services/report/report.service.ts
+++ b/src/modules/social/services/report/report.service.ts
@@ -8,6 +8,8 @@ import { NotificationService } from '../../../notification/services/notification
 
 @Injectable()
 export class ReportService {
+  private static readonly CLUB_REPORT_DEACTIVATION_THRESHOLD = 5;
+
   constructor(
     readonly reportRepository: ReportRepository,
     private readonly notificationService: NotificationService,
@@ -58,11 +60,7 @@ export class ReportService {
       });
     }
 
-    await this.createClubReportNotification(
-      String(userId),
-      clubId,
-      club.hostId,
-    );
+    await this.handleClubReportThreshold(String(userId), clubId, club.hostId);
     return result;
   }
 
@@ -102,29 +100,31 @@ export class ReportService {
     return result;
   }
 
-  private async createClubReportNotification(
+  private async handleClubReportThreshold(
     reporterUserId: string,
     clubId: string,
     hostId: bigint | null,
   ): Promise<void> {
-    if (!hostId) {
-      return;
-    }
-
     const reportCount =
       await this.reportRepository.countActiveClubReports(clubId);
 
-    await this.notificationService.createNotification(
-      Number(hostId),
-      NotificationType.CLUB,
-      '동호회 신고 알림',
-      `5번 이상의 동호회 신고시에, 동호회가 비활성화됩니다. 현재 ${reportCount}번 신고되었습니다.`,
-      Number(reporterUserId),
-      {
-        clubId,
-        reportCount: reportCount.toString(),
-      },
-    );
+    if (hostId) {
+      await this.notificationService.createNotification(
+        Number(hostId),
+        NotificationType.CLUB,
+        '동호회 신고 알림',
+        `5번 이상의 동호회 신고시에, 동호회가 비활성화됩니다. 현재 ${reportCount}번 신고되었습니다.`,
+        Number(reporterUserId),
+        {
+          clubId,
+          reportCount: reportCount.toString(),
+        },
+      );
+    }
+
+    if (reportCount >= ReportService.CLUB_REPORT_DEACTIVATION_THRESHOLD) {
+      await this.reportRepository.deactivateClub(clubId);
+    }
   }
 
   private async createArticleReportNotification(

--- a/src/modules/social/services/report/report.service.ts
+++ b/src/modules/social/services/report/report.service.ts
@@ -1,18 +1,24 @@
 import { Injectable } from '@nestjs/common';
+import { NotificationType, ReportCategory } from '@prisma/client';
 import { ReportRepository } from '../../repositories/report.repository';
 import { AppException } from '../../../../common/errors/app.exception';
 import { ERROR_DEFINITIONS } from '../../../../common/errors/error-codes';
+import { CreateReportRequestDto } from '../../dtos/report.dto';
+import { NotificationService } from '../../../notification/services/notification.service';
 
 @Injectable()
 export class ReportService {
-  constructor(readonly reportRepository: ReportRepository) {}
+  constructor(
+    readonly reportRepository: ReportRepository,
+    private readonly notificationService: NotificationService,
+  ) {}
 
   async createReport(
     userId: string,
     targetUserId: string,
     reason: string,
-    category: string,
-    chatRoomId: string,
+    category: ReportCategory,
+    chatRoomId?: string,
   ) {
     const result = await this.reportRepository.createReport(
       userId,
@@ -27,5 +33,123 @@ export class ReportService {
         details: { field: 'targetUserId' },
       });
     } else return result;
+  }
+
+  async createClubReport(
+    userId: string,
+    clubId: string,
+    dto: CreateReportRequestDto,
+  ) {
+    const club = await this.reportRepository.findActiveClubById(clubId);
+    if (!club) {
+      throw new AppException('CLUB_NOT_FOUND');
+    }
+
+    const result = await this.reportRepository.createClubReport(
+      userId,
+      clubId,
+      dto.reason,
+      dto.category,
+    );
+    if (result.reason === 'Already reported.') {
+      throw new AppException('SOCIAL_REPORT_EXISTS', {
+        message: ERROR_DEFINITIONS.SOCIAL_REPORT_EXISTS.message,
+        details: { field: 'clubId' },
+      });
+    }
+
+    await this.createClubReportNotification(
+      String(userId),
+      clubId,
+      club.hostId,
+    );
+    return result;
+  }
+
+  async createArticleReport(
+    userId: string,
+    clubId: string,
+    articleId: string,
+    dto: CreateReportRequestDto,
+  ) {
+    const article = await this.reportRepository.findActiveArticleByClubId(
+      clubId,
+      articleId,
+    );
+    if (!article) {
+      throw new AppException('ARTICLE_NOT_FOUND');
+    }
+
+    const result = await this.reportRepository.createArticleReport(
+      userId,
+      clubId,
+      articleId,
+      dto.reason,
+      dto.category,
+    );
+    if (result.reason === 'Already reported.') {
+      throw new AppException('SOCIAL_REPORT_EXISTS', {
+        message: ERROR_DEFINITIONS.SOCIAL_REPORT_EXISTS.message,
+        details: { field: 'articleId' },
+      });
+    }
+
+    await this.createArticleReportNotification(
+      String(userId),
+      articleId,
+      article.userId,
+    );
+    return result;
+  }
+
+  private async createClubReportNotification(
+    reporterUserId: string,
+    clubId: string,
+    hostId: bigint | null,
+  ): Promise<void> {
+    if (!hostId) {
+      return;
+    }
+
+    const reportCount =
+      await this.reportRepository.countActiveClubReports(clubId);
+
+    await this.notificationService.createNotification(
+      Number(hostId),
+      NotificationType.CLUB,
+      '동호회 신고 알림',
+      `5번 이상의 동호회 신고시에, 동호회가 비활성화됩니다. 현재 ${reportCount}번 신고되었습니다.`,
+      Number(reporterUserId),
+      {
+        clubId,
+        reportCount: reportCount.toString(),
+      },
+    );
+  }
+
+  private async createArticleReportNotification(
+    reporterUserId: string,
+    articleId: string,
+    authorId: bigint | null,
+  ): Promise<void> {
+    if (!authorId) {
+      return;
+    }
+
+    const reportCount = await this.reportRepository.countActiveUserReports(
+      authorId.toString(),
+    );
+
+    await this.notificationService.createNotification(
+      Number(authorId),
+      NotificationType.CLUB,
+      '게시글 신고 알림',
+      `신고 5번 이상 받았을 경우, 로그인이 제한됩니다. 현재 ${reportCount}번 신고되었습니다.`,
+      Number(reporterUserId),
+      {
+        articleId,
+        reportCount: reportCount.toString(),
+      },
+    );
   }
 }


### PR DESCRIPTION
## 이슈 번호
close #273 

## 주요 변경사항
  - 동호회 신고 5회 이상 시 자동 비활성화 로직 추가
  - 동호회 비활성화는 기존 구조에 맞춰 Club.deletedAt = now 방식으로 처리
  - 동호회 신고 생성 시 ClubReport 기준 active 신고 수 조회
  - 신고 수가 5 이상이면 reportRepository.deactivateClub(clubId) 호출
  - host FCM 알림은 그대로 발송
  - 중복 신고(SOCIAL_REPORT_EXISTS)인 경우 알림/카운트/비활성화 처리 안 함


## 테스트 결과 (스크린샷)
<img width="1512" height="982" alt="스크린샷 2026-07-08 오후 6 07 53" src="https://github.com/user-attachments/assets/0a4af993-1fa7-42ce-a582-1bd6f0b542b5" />
<img width="1512" height="982" alt="스크린샷 2026-07-08 오후 6 13 41" src="https://github.com/user-attachments/assets/8a7e4148-8130-4fa0-a9ed-c036275557c2" />


## 참고 및 개선사항
- 
