### PR TITLE
[EUM-115] fix: 정모 승인 참석 기능 개선 (AUTO 승격/취소 범위/joinMessage 제거)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ NestJS 기반으로 구성되어 있으며, 초기 프로젝트 세팅과 공통
 ```bash
 # 최초 세팅
 npm install                    # 의존성 설치 (postinstall로 prisma generate 자동 실행)
-npm run prisma:migrate:dev     # 로컬 DB 마이그레이션 적용
+npm run prisma:migrate:deploy     # 로컬 DB 마이그레이션 적용
 
 # 실행
 npm run start:dev              # 개발 모드 (watch) — 기본 포트 3000

--- a/prisma/dbml/schema.dbml
+++ b/prisma/dbml/schema.dbml
@@ -495,7 +495,6 @@ Table MeetingMember {
   status MeetingMemberStatus [not null, default: 'ACTIVE']
   requestedAt DateTime [default: `now()`, not null]
   joinedAt DateTime
-  joinMessage String [not null, default: '']
   deletedAt DateTime
   meeting Meeting [not null]
   clubUser ClubUser [not null]

--- a/prisma/migrations/20260709000000_remove_meeting_member_join_message/migration.sql
+++ b/prisma/migrations/20260709000000_remove_meeting_member_join_message/migration.sql
@@ -1,0 +1,2 @@
+-- MeetingMember.joinMessage 제거 (정모 참석 신청은 신청 메시지를 받지 않음)
+ALTER TABLE "MeetingMember" DROP COLUMN "joinMessage";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -730,7 +730,6 @@ model MeetingMember {
   status      MeetingMemberStatus @default(ACTIVE) // 참석 상태 (승인정모: PENDING→ACTIVE/REJECTED)
   requestedAt DateTime            @default(now()) @db.Timestamp(6) // 참석 신청 시각
   joinedAt    DateTime?           @db.Timestamp(6) // 승인/참석 확정 시각 (PENDING이면 null)
-  joinMessage String              @default("") @db.VarChar(300) // 승인정모 신청 메시지 (선택)
   deletedAt   DateTime?           @db.Timestamp(6)
 
   meeting  Meeting  @relation(fields: [meetingId], references: [id], onDelete: Cascade) // 미팅 삭제 시 함께 삭제

--- a/src/common/errors/error-codes.ts
+++ b/src/common/errors/error-codes.ts
@@ -347,7 +347,7 @@ export const ERROR_DEFINITIONS = {
   MEETING_NOT_JOINED: {
     status: HttpStatus.NOT_FOUND,
     code: 'MEETING-006',
-    message: '참석 중인 정모가 아니에요.',
+    message: '참석/신청 중인 정모가 아니에요.',
   },
   MEETING_HOST_CANNOT_LEAVE: {
     status: HttpStatus.FORBIDDEN,

--- a/src/modules/meeting/controllers/meeting.controller.ts
+++ b/src/modules/meeting/controllers/meeting.controller.ts
@@ -161,13 +161,17 @@ export class MeetingController {
   }
 
   @Delete(':meetingId/attendees/me')
-  @ApiOperation({ summary: '정모 참석 취소 (본인, 호스트 불가)' })
+  @ApiOperation({
+    summary: '정모 참석/신청 취소 (본인, 호스트 불가)',
+    description:
+      '참석(ACTIVE) 또는 승인 대기(PENDING) 상태를 취소합니다. 승인정모 신청 철회에도 사용됩니다.',
+  })
   @ApiOkResponse({
-    description: '정모 참석 취소 완료',
+    description: '정모 참석/신청 취소 완료',
     type: LeaveMeetingResponseDto,
   })
   @ApiNotFoundResponse({
-    description: '클럽/정모 없음 또는 참석 중인 정모가 아님',
+    description: '클럽/정모 없음 또는 참석·신청 중인 정모가 아님',
   })
   async leaveMeeting(
     @RequiredUserId() userId: number,

--- a/src/modules/meeting/dtos/meeting.dto.ts
+++ b/src/modules/meeting/dtos/meeting.dto.ts
@@ -455,9 +455,6 @@ export class MeetingRequestItemDto {
   @ApiProperty({ type: AttendeeUserDto })
   user!: AttendeeUserDto;
 
-  @ApiProperty({ example: '참석하고 싶습니다!' })
-  joinMessage!: string;
-
   @ApiProperty({ example: '2026-05-01T20:05:00+09:00' })
   requestedAt!: string;
 }

--- a/src/modules/meeting/repositories/meeting.repository.ts
+++ b/src/modules/meeting/repositories/meeting.repository.ts
@@ -48,7 +48,6 @@ export type PendingRequestRow = {
   meetingMemberId: bigint;
   clubUserId: bigint;
   requestedAt: Date;
-  joinMessage: string;
   userId: bigint;
   nickname: string;
   profileImageUrl: string;
@@ -339,7 +338,9 @@ export class MeetingRepository {
         where: { meetingId_clubUserId: { meetingId, clubUserId } },
         select: { id: true, status: true, deletedAt: true },
       });
-      // 이미 참석중이거나 승인 대기중이면 중복 처리 (REJECTED/취소 이력은 재신청 허용)
+      // 이미 참석중이면 중복 차단. 승인 대기중(PENDING)은 정책이 여전히 APPROVAL_REQUIRED일 때만
+      // 중복 신청으로 막고, AUTO로 바뀌었으면 아래 AUTO 경로로 흘려보내 정원 체크 후 ACTIVE로 승격한다.
+      // (REJECTED/취소 이력도 아래 경로에서 재신청/재참석 허용)
       if (existing && existing.deletedAt === null) {
         if (existing.status === MeetingMemberStatus.ACTIVE) {
           return {
@@ -350,7 +351,7 @@ export class MeetingRepository {
             alreadyRequested: false,
           };
         }
-        if (existing.status === MeetingMemberStatus.PENDING) {
+        if (existing.status === MeetingMemberStatus.PENDING && isApproval) {
           return {
             member: null,
             capacityExceeded: false,
@@ -445,6 +446,10 @@ export class MeetingRepository {
         meetingId,
         clubUserId,
         deletedAt: null,
+        // 참석(ACTIVE) 또는 승인 대기(PENDING)만 취소 대상. REJECTED 이력은 제외.
+        status: {
+          in: [MeetingMemberStatus.ACTIVE, MeetingMemberStatus.PENDING],
+        },
         meeting: { clubId },
       },
       data: { deletedAt },
@@ -520,7 +525,6 @@ export class MeetingRepository {
         id: true,
         clubUserId: true,
         requestedAt: true,
-        joinMessage: true,
         clubUser: {
           select: {
             authority: true,
@@ -535,7 +539,6 @@ export class MeetingRepository {
       meetingMemberId: r.id,
       clubUserId: r.clubUserId,
       requestedAt: r.requestedAt,
-      joinMessage: r.joinMessage,
       userId: r.clubUser.user.id,
       nickname: r.clubUser.user.nickname,
       profileImageUrl: r.clubUser.user.profileImageUrl,

--- a/src/modules/meeting/services/meeting.service.spec.ts
+++ b/src/modules/meeting/services/meeting.service.spec.ts
@@ -744,7 +744,6 @@ describe('MeetingService', () => {
           meetingMemberId: 9001n,
           clubUserId: 777n,
           requestedAt: new Date('2026-05-01T11:05:00.000Z'),
-          joinMessage: '참석하고 싶어요',
           userId: 200n,
           nickname: '지원자',
           profileImageUrl: 'u-200',
@@ -764,7 +763,6 @@ describe('MeetingService', () => {
       expect(result.requests[0]).toMatchObject({
         meetingMemberId: 9001,
         clubUserId: 777,
-        joinMessage: '참석하고 싶어요',
         user: {
           userId: 200,
           nickname: '지원자',

--- a/src/modules/meeting/services/meeting.service.ts
+++ b/src/modules/meeting/services/meeting.service.ts
@@ -463,7 +463,6 @@ export class MeetingService {
       profileImageUrl: string;
       authority: AttendeeListRow['authority'];
     };
-    joinMessage: string;
     requestedAt: string;
   } {
     return {
@@ -475,7 +474,6 @@ export class MeetingService {
         profileImageUrl: row.profileImageUrl,
         authority: row.authority,
       },
-      joinMessage: row.joinMessage,
       requestedAt: toKstIso(row.requestedAt),
     };
   }


### PR DESCRIPTION
## 이슈 번호
close #278 

## 주요 변경사항
- `APPROVAL_REQUIRED → AUTO` 전환 후 기존 PENDING 신청 유저가 `MEETING_ALREADY_REQUESTED`로 영구 차단되던 버그 수정: 
  - `joinMeeting`의 PENDING 중복 차단을 `isApproval`로 가드하여, AUTO 상태에서 재참석 시 정원 체크 후 ACTIVE로 승격
- `DELETE /clubs/{clubId}/meetings/{meetingId}/attendees/me` 취소 범위를 `status ∈ {ACTIVE, PENDING}`으로 한정(REJECTED 제외)해 대기중 유저가 신청을 철회할 수 있게 하고, Swagger/`MEETING_NOT_JOINED` 문구를 "참석/신청 취소"로 정정
- 미사용 `joinMessage` 필드 제거(정모 참석 신청은 신청 메시지를 받지 않음): 스키마/DTO/repository/service에서 제거. **이미 머지된 `20260708000000` 마이그레이션은 건드리지 않고, `20260709000000_remove_meeting_member_join_message`(DROP COLUMN) 신규 마이그레이션으로 분리**
- README 로컬 마이그레이션 안내를 `prisma:migrate:dev` → `prisma:migrate:deploy`로 변경

## 테스트 결과
**참석신청**
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/6603c728-0d55-4123-8f27-43c06eebc81d" />

**참석신청목록확인**
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/4042b8de-cd90-489e-b941-b86ccb106aac" />

**정모가입정책 AUTO로 변경**
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/b961eb53-b9ca-44db-ace7-0a709a3e6121" />

**재참석신청(바로승인)**
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/cb524976-a8bf-44a8-be05-371313b7fb4b" />


## 참고 및 개선사항
- 배포/로컬 DB는 `npm run prisma:migrate:deploy`로 신규 `DROP COLUMN` 마이그레이션만 추가 적용됨. 이미 머지된 마이그레이션은 불변으로 유지되어 checksum 문제 없음
- 정모 승인 시 신청자 알림은 이번 범위 제외