### PR TITLE
[EUM-116] fix: 동호회 탈퇴/강퇴 시 정모 참석/클럽 채팅 참여 정리

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@nestjs/common": "^11.0.1",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.0.1",
+        "@nestjs/event-emitter": "^3.1.0",
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/platform-socket.io": "^11.1.12",
         "@nestjs/swagger": "^11.2.3",
@@ -4230,6 +4231,19 @@
         }
       }
     },
+    "node_modules/@nestjs/event-emitter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/event-emitter/-/event-emitter-3.1.0.tgz",
+      "integrity": "sha512-DOY/4XBGyIjYyOJKkO6jl1kzFE0ZfX0wV+M2HR5NWymPT9Z0zdCEcZGxTXXkoMRwPtglnvCGJALSjOpXPIcM3g==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter2": "6.4.9"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
+      }
+    },
     "node_modules/@nestjs/mapped-types": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.0.tgz",
@@ -4569,6 +4583,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -9555,6 +9570,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/eventemitter2": {
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
+      "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==",
+      "license": "MIT"
     },
     "node_modules/events": {
       "version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",
+    "@nestjs/event-emitter": "^3.1.0",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/platform-socket.io": "^11.1.12",
     "@nestjs/swagger": "^11.2.3",

--- a/src/modules/app/app.module.ts
+++ b/src/modules/app/app.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { envSchema } from '../../config/env.schema';
@@ -35,6 +36,7 @@ import { S3ObjectUrlModule } from 'src/common/s3/s3-object-url.module';
         return parsed.data;
       },
     }),
+    EventEmitterModule.forRoot(),
     S3ObjectUrlModule,
     HealthModule,
     PrismaModule,

--- a/src/modules/chat/gateways/chat.gateway.spec.ts
+++ b/src/modules/chat/gateways/chat.gateway.spec.ts
@@ -1,0 +1,46 @@
+import { ChatGateway } from './chat.gateway';
+
+describe('ChatGateway.evictUserFromRoom', () => {
+  const makeSocket = (userId: number) => ({
+    data: { userId },
+    leave: jest.fn().mockResolvedValue(undefined),
+    emit: jest.fn(),
+  });
+
+  const buildGateway = (sockets: ReturnType<typeof makeSocket>[]) => {
+    const fetchSockets = jest.fn().mockResolvedValue(sockets);
+    const inFn = jest.fn().mockReturnValue({ fetchSockets });
+    const gateway = new ChatGateway(
+      null as never,
+      null as never,
+      null as never,
+      null as never,
+    );
+    (gateway as unknown as { server: unknown }).server = { in: inFn };
+    return { gateway, inFn, fetchSockets };
+  };
+
+  it('대상 userId의 소켓만 룸에서 leave시키고 room.evicted를 통지한다', async () => {
+    const target = makeSocket(42);
+    const other = makeSocket(99);
+    const { gateway, inFn } = buildGateway([target, other]);
+
+    await gateway.evictUserFromRoom(7, 42);
+
+    expect(inFn).toHaveBeenCalledWith('room:7');
+    expect(target.leave).toHaveBeenCalledWith('room:7');
+    expect(target.emit).toHaveBeenCalledWith('room.evicted', { chatRoomId: 7 });
+    expect(other.leave).not.toHaveBeenCalled();
+    expect(other.emit).not.toHaveBeenCalled();
+  });
+
+  it('server가 없으면 아무 것도 하지 않는다', async () => {
+    const gateway = new ChatGateway(
+      null as never,
+      null as never,
+      null as never,
+      null as never,
+    );
+    await expect(gateway.evictUserFromRoom(7, 42)).resolves.toBeUndefined();
+  });
+});

--- a/src/modules/chat/gateways/chat.gateway.ts
+++ b/src/modules/chat/gateways/chat.gateway.ts
@@ -70,6 +70,25 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
     this.server.to(uniqueRooms).emit(event, payload);
   }
 
+  // 클럽 탈퇴/강퇴 시 해당 유저의 소켓을 채팅 룸에서 퇴출한다.
+  // 룸 join은 입장 시점에만 인가하므로, 이미 join된 소켓은 명시적으로 빼주지 않으면
+  // message.new broadcast를 계속 수신한다. disconnect가 아니라 해당 룸에서만 leave해
+  // DIRECT/다른 클럽 룸 참여는 유지한다.
+  // NOTE(scale-out): 기본 인메모리 어댑터에서 fetchSockets/leave는 로컬 노드 소켓만 처리한다.
+  //   다중 인스턴스 배포 시 @socket.io/redis-adapter 도입 필요(코드 shape는 그대로 동작).
+  async evictUserFromRoom(chatRoomId: number, userId: number): Promise<void> {
+    if (!this.server) return;
+    const room = toChatRoom(chatRoomId);
+    const sockets = await this.server.in(room).fetchSockets();
+    for (const s of sockets) {
+      const socketUserId = (s.data as SocketData)?.userId;
+      if (Number(socketUserId) === userId) {
+        void s.leave(room);
+        s.emit('room.evicted', { chatRoomId });
+      }
+    }
+  }
+
   // REST(입장/퇴장 SYSTEM 메시지 등)에서 호출 — 방 전체에 message.new broadcast.
   emitChatMessage(chatRoomId: number, payload: unknown): void {
     this.emitToRooms([toChatRoom(chatRoomId)], 'message.new', payload);

--- a/src/modules/chat/repositories/room.repository.ts
+++ b/src/modules/chat/repositories/room.repository.ts
@@ -209,6 +209,15 @@ export class RoomRepository {
     }
   }
 
+  // 클럽 채팅방 조회(생성 X). 방이 아직 없으면 null (퇴출 대상 없음).
+  async findClubRoomId(clubId: bigint): Promise<bigint | null> {
+    const room = await this.prisma.chatRoom.findFirst({
+      where: { clubId, type: 'CLUB' },
+      select: { id: true },
+    });
+    return room?.id ?? null;
+  }
+
   getRoomsByIds(roomIds: bigint[]) {
     return this.prisma.chatRoom.findMany({
       where: { id: { in: roomIds }, endedAt: null, status: 'ACTIVE' },

--- a/src/modules/chat/services/club-chat/club-chat.service.spec.ts
+++ b/src/modules/chat/services/club-chat/club-chat.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 
 import { ClubChatService } from './club-chat.service';
 import { ClubRepository } from '../../../club/repositories/club.repository';
+import { ClubMemberRemovedEvent } from '../../../club/events/club-member-removed.event';
 import { MessageRepository } from '../../repositories/message.repository';
 import { ParticipantRepository } from '../../repositories/participant.repository';
 import { RoomRepository } from '../../repositories/room.repository';
@@ -17,6 +18,7 @@ describe('ClubChatService', () => {
 
   const roomRepoMock: Partial<RoomRepository> = {
     ensureClubRoom: jest.fn(),
+    findClubRoomId: jest.fn(),
   };
 
   const participantRepoMock: Partial<ParticipantRepository> = {
@@ -30,6 +32,7 @@ describe('ClubChatService', () => {
 
   const chatGatewayMock: Partial<ChatGateway> = {
     emitChatMessage: jest.fn(),
+    evictUserFromRoom: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -168,5 +171,41 @@ describe('ClubChatService', () => {
 
     expect(res.created).toBe(false);
     expect(messageRepoMock.createSystemMessage).not.toHaveBeenCalled();
+  });
+
+  describe('onClubMemberRemoved (탈퇴/강퇴 시 소켓 퇴출)', () => {
+    it('클럽 룸이 있으면 해당 유저를 룸에서 퇴출한다', async () => {
+      (roomRepoMock.findClubRoomId as jest.Mock).mockResolvedValue(BigInt(101));
+
+      await service.onClubMemberRemoved(
+        new ClubMemberRemovedEvent(BigInt(7), BigInt(42)),
+      );
+
+      expect(roomRepoMock.findClubRoomId).toHaveBeenCalledWith(BigInt(7));
+      expect(chatGatewayMock.evictUserFromRoom).toHaveBeenCalledWith(101, 42);
+    });
+
+    it('클럽 룸이 없으면 게이트웨이를 호출하지 않는다', async () => {
+      (roomRepoMock.findClubRoomId as jest.Mock).mockResolvedValue(null);
+
+      await service.onClubMemberRemoved(
+        new ClubMemberRemovedEvent(BigInt(7), BigInt(42)),
+      );
+
+      expect(chatGatewayMock.evictUserFromRoom).not.toHaveBeenCalled();
+    });
+
+    it('퇴출 중 예외가 나도 전파하지 않는다(best-effort)', async () => {
+      (roomRepoMock.findClubRoomId as jest.Mock).mockResolvedValue(BigInt(101));
+      (chatGatewayMock.evictUserFromRoom as jest.Mock).mockRejectedValue(
+        new Error('boom'),
+      );
+
+      await expect(
+        service.onClubMemberRemoved(
+          new ClubMemberRemovedEvent(BigInt(7), BigInt(42)),
+        ),
+      ).resolves.toBeUndefined();
+    });
   });
 });

--- a/src/modules/chat/services/club-chat/club-chat.service.ts
+++ b/src/modules/chat/services/club-chat/club-chat.service.ts
@@ -1,7 +1,12 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
 
 import { AppException } from '../../../../common/errors/app.exception';
 import { ClubRepository } from '../../../club/repositories/club.repository';
+import {
+  CLUB_MEMBER_REMOVED,
+  ClubMemberRemovedEvent,
+} from '../../../club/events/club-member-removed.event';
 import { ChatGateway } from '../../gateways/chat.gateway';
 import { MessageRepository } from '../../repositories/message.repository';
 import { ParticipantRepository } from '../../repositories/participant.repository';
@@ -11,6 +16,8 @@ import type { EnterClubRoomRes } from '../../dtos/club-chat.dto';
 
 @Injectable()
 export class ClubChatService {
+  private readonly logger = new Logger(ClubChatService.name);
+
   constructor(
     private readonly clubRepo: ClubRepository,
     private readonly roomRepo: RoomRepository,
@@ -18,6 +25,24 @@ export class ClubChatService {
     private readonly messageRepo: MessageRepository,
     private readonly chatGateway: ChatGateway,
   ) {}
+
+  // 클럽 탈퇴/강퇴 시 해당 유저 소켓을 클럽 채팅 룸에서 퇴출한다.
+  // best-effort: 실패해도 stale 소켓은 재접속/새로고침 시 입장 인가로 self-heal되므로 예외를 전파하지 않는다.
+  @OnEvent(CLUB_MEMBER_REMOVED)
+  async onClubMemberRemoved(event: ClubMemberRemovedEvent): Promise<void> {
+    try {
+      const roomId = await this.roomRepo.findClubRoomId(event.clubId);
+      if (roomId == null) return;
+      await this.chatGateway.evictUserFromRoom(
+        Number(roomId),
+        Number(event.userId),
+      );
+    } catch (e) {
+      this.logger.warn(
+        `클럽 멤버 소켓 퇴출 실패 clubId=${event.clubId} userId=${event.userId}: ${String(e)}`,
+      );
+    }
+  }
 
   // 클럽 채팅방 입장(lazy provisioning): 방 find-or-create + 내 participant ensure.
   // 멤버십은 ClubUser(ACTIVE)로 인가하고, role은 ClubUser.authority를 그대로 사용한다.

--- a/src/modules/chat/services/socket/chat-socket.service.ts
+++ b/src/modules/chat/services/socket/chat-socket.service.ts
@@ -67,7 +67,6 @@ export class ChatSocketService {
       throw new AppException('CHAT_ROOM_ACCESS_FAILED');
     }
 
-    // TODO(EUM-29 follow-up): 클럽 leave/kick 시 ChatParticipant.endedAt cascade
     const roomInfo = await this.roomRepo.getRoomTypeInfo(roomId);
     if (roomInfo?.type === 'CLUB') {
       if (roomInfo.clubId == null) {

--- a/src/modules/club/events/club-member-removed.event.ts
+++ b/src/modules/club/events/club-member-removed.event.ts
@@ -1,0 +1,11 @@
+// 클럽 탈퇴/강퇴로 멤버가 제거됐음을 알리는 도메인 이벤트.
+// club 도메인은 이 사실만 발행하고, chat 도메인이 구독해 실시간 소켓 룸에서 퇴출한다.
+// (ChatModule → ClubModule 의존이라 club→chat 직접 주입은 순환참조 → 이벤트로 의존성 역전)
+export const CLUB_MEMBER_REMOVED = 'club.member.removed';
+
+export class ClubMemberRemovedEvent {
+  constructor(
+    readonly clubId: bigint,
+    readonly userId: bigint,
+  ) {}
+}

--- a/src/modules/club/repositories/club-member.repository.spec.ts
+++ b/src/modules/club/repositories/club-member.repository.spec.ts
@@ -1,0 +1,155 @@
+import {
+  ChatRoomType,
+  ClubAuthority,
+  ClubUserStatus,
+  MeetingMemberStatus,
+} from '@prisma/client';
+import { ClubMemberRepository } from './club-member.repository';
+
+describe('ClubMemberRepository', () => {
+  let repository: ClubMemberRepository;
+
+  const clubUserModel = {
+    update: jest.fn(),
+  };
+  const meetingMemberModel = {
+    updateMany: jest.fn(),
+  };
+  const chatParticipantModel = {
+    updateMany: jest.fn(),
+  };
+
+  type TransactionMock = {
+    clubUser: typeof clubUserModel;
+    meetingMember: typeof meetingMemberModel;
+    chatParticipant: typeof chatParticipantModel;
+  };
+
+  const prisma = {
+    $transaction: jest.fn(
+      <T>(callback: (tx: TransactionMock) => T): T =>
+        callback({
+          clubUser: clubUserModel,
+          meetingMember: meetingMemberModel,
+          chatParticipant: chatParticipantModel,
+        }),
+    ),
+    clubUser: clubUserModel,
+  };
+
+  const clubId = 12n;
+  const userId = 42n;
+  const clubUserId = 333n;
+  const fixedNow = new Date('2026-07-09T03:00:00.000Z');
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(fixedNow);
+    jest.clearAllMocks();
+    repository = new ClubMemberRepository(prisma as never);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('탈퇴 시 클럽 회원 상태 변경과 정모/클럽 채팅 참여 종료를 같은 트랜잭션에서 처리한다', async () => {
+    clubUserModel.update.mockResolvedValue({
+      id: clubUserId,
+      clubId,
+      userId,
+      status: ClubUserStatus.LEFT,
+      leftAt: fixedNow,
+    });
+
+    const result = await repository.leave(clubId, userId);
+
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe(ClubUserStatus.LEFT);
+    expect(clubUserModel.update).toHaveBeenCalledWith({
+      where: {
+        userId_clubId: {
+          userId,
+          clubId,
+        },
+      },
+      data: {
+        status: ClubUserStatus.LEFT,
+        authority: ClubAuthority.GENERAL,
+        leftAt: fixedNow,
+      },
+    });
+    expect(meetingMemberModel.updateMany).toHaveBeenCalledWith({
+      where: {
+        clubUserId,
+        deletedAt: null,
+        status: {
+          in: [MeetingMemberStatus.ACTIVE, MeetingMemberStatus.PENDING],
+        },
+        meeting: { clubId },
+      },
+      data: { deletedAt: fixedNow },
+    });
+    expect(chatParticipantModel.updateMany).toHaveBeenCalledWith({
+      where: {
+        userId,
+        endedAt: null,
+        room: {
+          type: ChatRoomType.CLUB,
+          clubId,
+        },
+      },
+      data: { endedAt: fixedNow },
+    });
+  });
+
+  it('강퇴 시 클럽 회원 상태 변경과 정모/클럽 채팅 참여 종료를 같은 트랜잭션에서 처리한다', async () => {
+    clubUserModel.update.mockResolvedValue({
+      id: clubUserId,
+      clubId,
+      userId,
+      status: ClubUserStatus.KICKED,
+      leftAt: fixedNow,
+    });
+
+    const result = await repository.kick(clubId, userId);
+
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe(ClubUserStatus.KICKED);
+    expect(clubUserModel.update).toHaveBeenCalledWith({
+      where: {
+        userId_clubId: {
+          userId,
+          clubId,
+        },
+      },
+      data: {
+        status: ClubUserStatus.KICKED,
+        authority: ClubAuthority.GENERAL,
+        leftAt: fixedNow,
+      },
+    });
+    expect(meetingMemberModel.updateMany).toHaveBeenCalledWith({
+      where: {
+        clubUserId,
+        deletedAt: null,
+        status: {
+          in: [MeetingMemberStatus.ACTIVE, MeetingMemberStatus.PENDING],
+        },
+        meeting: { clubId },
+      },
+      data: { deletedAt: fixedNow },
+    });
+    expect(chatParticipantModel.updateMany).toHaveBeenCalledWith({
+      where: {
+        userId,
+        endedAt: null,
+        room: {
+          type: ChatRoomType.CLUB,
+          clubId,
+        },
+      },
+      data: { endedAt: fixedNow },
+    });
+  });
+});

--- a/src/modules/club/repositories/club-member.repository.ts
+++ b/src/modules/club/repositories/club-member.repository.ts
@@ -1,5 +1,11 @@
 import { Injectable } from '@nestjs/common';
-import { ClubAuthority, ClubUserStatus } from '@prisma/client';
+import {
+  ChatRoomType,
+  ClubAuthority,
+  ClubUserStatus,
+  MeetingMemberStatus,
+  Prisma,
+} from '@prisma/client';
 import { PrismaService } from '../../../infra/prisma/prisma.service';
 
 @Injectable()
@@ -162,34 +168,58 @@ export class ClubMemberRepository {
   }
 
   leave(clubId: bigint, userId: bigint) {
-    return this.prisma.clubUser.update({
-      where: {
-        userId_clubId: {
-          userId,
-          clubId,
+    return this.prisma.$transaction(async (tx) => {
+      const leftAt = new Date();
+      const left = await tx.clubUser.update({
+        where: {
+          userId_clubId: {
+            userId,
+            clubId,
+          },
         },
-      },
-      data: {
-        status: ClubUserStatus.LEFT,
-        authority: ClubAuthority.GENERAL,
-        leftAt: new Date(),
-      },
+        data: {
+          status: ClubUserStatus.LEFT,
+          authority: ClubAuthority.GENERAL,
+          leftAt,
+        },
+      });
+
+      await this.cleanupClubScopedParticipation(tx, {
+        clubId,
+        userId,
+        clubUserId: left.id,
+        endedAt: leftAt,
+      });
+
+      return left;
     });
   }
 
   kick(clubId: bigint, userId: bigint) {
-    return this.prisma.clubUser.update({
-      where: {
-        userId_clubId: {
-          userId,
-          clubId,
+    return this.prisma.$transaction(async (tx) => {
+      const leftAt = new Date();
+      const kicked = await tx.clubUser.update({
+        where: {
+          userId_clubId: {
+            userId,
+            clubId,
+          },
         },
-      },
-      data: {
-        status: ClubUserStatus.KICKED,
-        authority: ClubAuthority.GENERAL,
-        leftAt: new Date(),
-      },
+        data: {
+          status: ClubUserStatus.KICKED,
+          authority: ClubAuthority.GENERAL,
+          leftAt,
+        },
+      });
+
+      await this.cleanupClubScopedParticipation(tx, {
+        clubId,
+        userId,
+        clubUserId: kicked.id,
+        endedAt: leftAt,
+      });
+
+      return kicked;
     });
   }
 
@@ -229,6 +259,45 @@ export class ClubMemberRepository {
       });
 
       return nextHost;
+    });
+  }
+
+  private async cleanupClubScopedParticipation(
+    tx: Prisma.TransactionClient,
+    {
+      clubId,
+      userId,
+      clubUserId,
+      endedAt,
+    }: {
+      clubId: bigint;
+      userId: bigint;
+      clubUserId: bigint;
+      endedAt: Date;
+    },
+  ): Promise<void> {
+    await tx.meetingMember.updateMany({
+      where: {
+        clubUserId,
+        deletedAt: null,
+        status: {
+          in: [MeetingMemberStatus.ACTIVE, MeetingMemberStatus.PENDING],
+        },
+        meeting: { clubId },
+      },
+      data: { deletedAt: endedAt },
+    });
+
+    await tx.chatParticipant.updateMany({
+      where: {
+        userId,
+        endedAt: null,
+        room: {
+          type: ChatRoomType.CLUB,
+          clubId,
+        },
+      },
+      data: { endedAt },
     });
   }
 }

--- a/src/modules/club/services/member/club-member.service.spec.ts
+++ b/src/modules/club/services/member/club-member.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import {
   ClubAuthority,
   ClubUserStatus,
@@ -8,6 +9,7 @@ import { ClubMemberService } from './club-member.service';
 import { ClubRepository } from '../../repositories/club.repository';
 import { ClubMemberRepository } from '../../repositories/club-member.repository';
 import { NotificationService } from '../../../notification/services/notification.service';
+import { CLUB_MEMBER_REMOVED } from '../../events/club-member-removed.event';
 
 describe('ClubMemberService', () => {
   let service: ClubMemberService;
@@ -23,6 +25,7 @@ describe('ClubMemberService', () => {
   const kick = jest.fn();
   const delegateHost = jest.fn();
   const createNotification = jest.fn();
+  const emit = jest.fn();
 
   const clubId = 12n;
   const userId = 42n;
@@ -54,6 +57,7 @@ describe('ClubMemberService', () => {
     kick.mockReset();
     delegateHost.mockReset();
     createNotification.mockReset();
+    emit.mockReset();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -78,6 +82,10 @@ describe('ClubMemberService', () => {
           useValue: {
             createNotification,
           },
+        },
+        {
+          provide: EventEmitter2,
+          useValue: { emit },
         },
       ],
     }).compile();
@@ -442,6 +450,11 @@ describe('ClubMemberService', () => {
       status: ClubUserStatus.LEFT,
       leftAt: leftAt.toISOString(),
     });
+    // 커밋 이후 멤버 제거 이벤트 발행 (chat 소켓 퇴출용)
+    expect(emit).toHaveBeenCalledWith(
+      CLUB_MEMBER_REMOVED,
+      expect.objectContaining({ clubId, userId }),
+    );
   });
 
   it('호스트는 권한 위임 전 탈퇴할 수 없다', async () => {
@@ -503,6 +516,11 @@ describe('ClubMemberService', () => {
       status: ClubUserStatus.KICKED,
       leftAt: leftAt.toISOString(),
     });
+    // 커밋 이후 멤버 제거 이벤트 발행 (chat 소켓 퇴출용)
+    expect(emit).toHaveBeenCalledWith(
+      CLUB_MEMBER_REMOVED,
+      expect.objectContaining({ clubId, userId }),
+    );
   });
 
   it('호스트가 아니면 강퇴할 수 없다', async () => {

--- a/src/modules/club/services/member/club-member.service.ts
+++ b/src/modules/club/services/member/club-member.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import {
   ClubAuthority,
   ClubUser,
@@ -9,6 +10,10 @@ import { AppException } from '../../../../common/errors/app.exception';
 import { ClubRepository } from '../../repositories/club.repository';
 import { ClubMemberRepository } from '../../repositories/club-member.repository';
 import { NotificationService } from '../../../notification/services/notification.service';
+import {
+  CLUB_MEMBER_REMOVED,
+  ClubMemberRemovedEvent,
+} from '../../events/club-member-removed.event';
 import {
   ClubMemberListItemDto,
   ClubMemberListResponseDto,
@@ -27,6 +32,7 @@ export class ClubMemberService {
     private readonly clubRepository: ClubRepository,
     private readonly clubMemberRepository: ClubMemberRepository,
     private readonly notificationService: NotificationService,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   async requestJoin(
@@ -185,6 +191,12 @@ export class ClubMemberService {
       throw new AppException('SERVER_TEMPORARY_ERROR');
     }
 
+    // 트랜잭션 커밋 이후 발행 → chat 도메인이 실시간 소켓 룸에서 퇴출
+    this.eventEmitter.emit(
+      CLUB_MEMBER_REMOVED,
+      new ClubMemberRemovedEvent(clubId, userId),
+    );
+
     return {
       clubUserId: Number(left.id),
       clubId: Number(left.clubId),
@@ -222,6 +234,12 @@ export class ClubMemberService {
     if (!kicked.leftAt) {
       throw new AppException('SERVER_TEMPORARY_ERROR');
     }
+
+    // 트랜잭션 커밋 이후 발행 → chat 도메인이 실시간 소켓 룸에서 퇴출
+    this.eventEmitter.emit(
+      CLUB_MEMBER_REMOVED,
+      new ClubMemberRemovedEvent(clubId, targetUserId),
+    );
 
     return {
       clubUserId: Number(kicked.id),


### PR DESCRIPTION
## 이슈 번호
close #280 

## 주요 변경사항
- 클럽 탈퇴(`leave`)/강퇴(`kick`)를 `$transaction`으로 묶어 회원 상태 변경과 하위 참여 정리를 원자적으로 처리
- 정모 참석 정리: 해당 clubUser의 `ACTIVE`/`PENDING` MeetingMember를 soft-delete(`deletedAt`)
- 클럽 채팅 참여 종료: 클럽 채팅방(`type=CLUB`)의 ChatParticipant `endedAt` 세팅
- 탈퇴 시각(`leftAt`)을 트랜잭션 내에서 한 번만 잡아 `deletedAt`/`endedAt`까지 동일 타임스탬프로 통일
- 미구현 상태였던 `ChatSocketService`의 leave/kick cascade TODO 제거(실제 구현으로 대체)
- `ClubMemberRepository` leave/kick 트랜잭션 및 하위 정리 단위 테스트 추가

## 테스트 결과
**정모 참석자 목록 조회**
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/b00492cf-207c-4910-b437-6decc8e5d32b" />

**동호회 탈퇴**
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/a337377d-a291-4169-9bb0-d978a8a7ca6d" />

**정모 참석자 목록 재조회**
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/dc7f20b3-17be-4463-8819-12197c9f7ff4" />

## 참고 및 개선사항
