### PR TITLE
fix: 게시글 목록에서 삭제된 댓글까지 집계하던거 수정

### DIFF
--- a/src/modules/article/repositories/article.repository.spec.ts
+++ b/src/modules/article/repositories/article.repository.spec.ts
@@ -86,6 +86,25 @@ describe('ArticleRepository', () => {
         }),
       );
     });
+
+    it('counts only non-deleted comments', async () => {
+      articleModel.findMany.mockResolvedValue([]);
+
+      await repository.findArticlesByClub(20, {
+        sort: 'recent',
+        take: 20,
+      });
+
+      const findManyArgs = articleModel.findMany.mock.calls[0][0];
+
+      expect(findManyArgs.include?._count).toEqual({
+        select: {
+          comments: {
+            where: { deletedAt: null },
+          },
+        },
+      });
+    });
   });
 
   describe('pinArticle', () => {

--- a/src/modules/article/repositories/article.repository.ts
+++ b/src/modules/article/repositories/article.repository.ts
@@ -21,7 +21,11 @@ type ArticleWithRelations = Prisma.ArticleGetPayload<{
     };
     _count: {
       select: {
-        comments: true;
+        comments: {
+          where: {
+            deletedAt: null;
+          };
+        };
       };
     };
   };
@@ -199,7 +203,11 @@ export class ArticleRepository {
         },
         _count: {
           select: {
-            comments: true,
+            comments: {
+              where: {
+                deletedAt: null,
+              },
+            },
           },
         },
       },
@@ -243,7 +251,11 @@ export class ArticleRepository {
         },
         _count: {
           select: {
-            comments: true,
+            comments: {
+              where: {
+                deletedAt: null,
+              },
+            },
           },
         },
       },


### PR DESCRIPTION
## 이슈 번호
close #284 

## 주요 변경사항
- 게시글 목록에서 삭제된 댓글개수까지 집계해서 보이던 이슈를 수정했습니다.

## 테스트 결과 (스크린샷)
- 삭제 후 commentCount가 성공적응로 0으로 집계됩니다. (삭제된 댓글을 제외하고)
<img width="1482" height="478" alt="image" src="https://github.com/user-attachments/assets/75c988a0-54c8-4a33-98e4-a91ad0dfa7a3" />


## 참고 및 개선사항
- 
