### PR TITLE
[EUM-122] fix: DIRECT 채팅방 목록에서 퇴장한 상대방 정보 유지

### DIFF
--- a/src/modules/chat/repositories/participant.repository.ts
+++ b/src/modules/chat/repositories/participant.repository.ts
@@ -79,7 +79,7 @@ export class ParticipantRepository {
     me: bigint,
   ): Promise<Map<bigint, bigint>> {
     const rows = await this.prisma.chatParticipant.findMany({
-      where: { roomId: { in: roomIds }, userId: { not: me }, endedAt: null },
+      where: { roomId: { in: roomIds }, userId: { not: me } },
       select: { roomId: true, userId: true },
     });
 

--- a/src/modules/chat/services/room/room.service.spec.ts
+++ b/src/modules/chat/services/room/room.service.spec.ts
@@ -26,10 +26,12 @@ describe('RoomService', () => {
     isParticipant: jest.fn(),
     findPeerUserId: jest.fn(),
     getMyRoomIds: jest.fn(),
+    getMyJoinedAtByRoomIds: jest.fn(),
     findPeerUserIdsByRoomIds: jest.fn(),
     getMyReadStateByRoomIds: jest.fn(),
     getMyActiveParticipation: jest.fn(),
     getActiveParticipantsWithUser: jest.fn(),
+    countActiveByRoomIds: jest.fn(),
   };
 
   const messageRepoMock: Partial<MessageRepository> = {
@@ -52,6 +54,8 @@ describe('RoomService', () => {
   };
 
   beforeEach(async () => {
+    jest.clearAllMocks();
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         RoomService,
@@ -118,6 +122,81 @@ describe('RoomService', () => {
 
       expect(res.items).toEqual([]);
       expect(res.nextCursor).toBeNull();
+    });
+
+    it('should keep DIRECT room in my list when peer already left the room', async () => {
+      const roomId = BigInt(10);
+      const me = BigInt(2);
+      const peer = BigInt(7);
+      const joinedAt = new Date('2026-01-01T00:00:00.000Z');
+
+      (participantRepoMock.getMyRoomIds as jest.Mock).mockResolvedValue([
+        roomId,
+      ]);
+      (roomRepoMock.getRoomsByIds as jest.Mock).mockResolvedValue([
+        {
+          id: roomId,
+          type: 'DIRECT',
+          clubId: null,
+          startedAt: joinedAt,
+        },
+      ]);
+      (clubRepoMock.findActiveMembershipClubIds as jest.Mock).mockResolvedValue(
+        [],
+      );
+      (
+        participantRepoMock.getMyJoinedAtByRoomIds as jest.Mock
+      ).mockResolvedValue(new Map([[roomId, joinedAt]]));
+      (messageRepoMock.getLastSentAtByRoomIds as jest.Mock).mockResolvedValue(
+        new Map(),
+      );
+      (
+        participantRepoMock.findPeerUserIdsByRoomIds as jest.Mock
+      ).mockResolvedValue(new Map([[roomId, peer]]));
+      (roomRepoMock.getPeerBasicsByIds as jest.Mock).mockResolvedValue([
+        {
+          id: peer,
+          nickname: '상대',
+          profileImageUrl: null,
+          status: 'ACTIVE',
+          address: { fullName: '서울특별시 강남구' },
+        },
+      ]);
+      (clubRepoMock.findClubBriefsByIds as jest.Mock).mockResolvedValue([]);
+      (participantRepoMock.countActiveByRoomIds as jest.Mock).mockResolvedValue(
+        new Map(),
+      );
+      (
+        participantRepoMock.getMyReadStateByRoomIds as jest.Mock
+      ).mockResolvedValue(new Map());
+      (messageRepoMock.countUnreadByCursor as jest.Mock).mockResolvedValue(
+        new Map(),
+      );
+      (messageRepoMock.getLastMessageSummary as jest.Mock).mockResolvedValue(
+        null,
+      );
+
+      const res = await service.listRooms(Number(me), {});
+
+      expect(participantRepoMock.findPeerUserIdsByRoomIds).toHaveBeenCalledWith(
+        [roomId],
+        me,
+      );
+      expect(res.items).toEqual([
+        {
+          chatRoomId: Number(roomId),
+          type: 'DIRECT',
+          peer: {
+            userId: Number(peer),
+            nickname: '상대',
+            profileImageUrl: null,
+            areaName: '서울특별시 강남구',
+            isWithdrawn: false,
+          },
+          lastMessage: null,
+          unreadCount: 0,
+        },
+      ]);
     });
   });
 });


### PR DESCRIPTION
## 이슈 번호
close #283 

## 주요 변경사항
- `findPeerUserIdsByRoomIds`에서 `endedAt: null` 필터 제거 — DIRECT(1:1) 채팅 상대가 방을 나가도 상대 정보를 반환
- 이전에는 상대가 방을 나가면 peer가 조회되지 않아 `listRooms`에서 해당 DIRECT 방이 목록에서 통째로 누락되던 문제 수정 (나는 여전히 활성 참여자인데도 방이 사라짐)
- 상대 나감 시 DIRECT 방이 목록에 유지되는지 검증하는 RoomService 테스트 추가

## 테스트 결과


## 참고 및 개선사항
- DIRECT 방은 `@@unique([roomId, userId])`로 peer가 항상 단 1명이라 필터 제거로 인한 다중 매핑 문제 없음. 호출부도 `directRoomIds`로 DIRECT만 넘김
- 단수 `findPeerUserId`는 `endedAt: null`을 그대로 유지 — 메시지 전송/알림 수신자 조회용이라 나간 상대에겐 전달하지 않는 게 의도된 동작 (목록 표시와 전달 대상의 분리)
- `isWithdrawn`은 상대의 계정 탈퇴(user.status) 기준이지 방 나감 기준이 아님