### PR TITLE
fix: 이상형 음성 녹음시 DB 없는 키워드라는 에러 해결

### DIFF
--- a/src/modules/user/dtos/user-ideal-personalities-update-request.dto.spec.ts
+++ b/src/modules/user/dtos/user-ideal-personalities-update-request.dto.spec.ts
@@ -1,0 +1,30 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { UserIdealPersonalitiesUpdateRequestDto } from './user-ideal-personalities-update-request.dto';
+
+describe('UserIdealPersonalitiesUpdateRequestDto', () => {
+  const validateDto = (payload: Record<string, unknown>) =>
+    validate(plainToInstance(UserIdealPersonalitiesUpdateRequestDto, payload), {
+      whitelist: true,
+      forbidNonWhitelisted: true,
+    });
+
+  it('allows optional interest keywords without treating them as unknown fields', async () => {
+    const errors = await validateDto({
+      personalityKeywords: ['차분함', '신중함'],
+      interest: ['영화감상', '문학'],
+    });
+
+    expect(errors).toEqual([]);
+  });
+
+  it('still rejects unrelated unknown fields', async () => {
+    const errors = await validateDto({
+      personalityKeywords: ['차분함', '신중함'],
+      unknown: ['영화감상'],
+    });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('unknown');
+  });
+});

--- a/src/modules/user/dtos/user-ideal-personalities-update-request.dto.ts
+++ b/src/modules/user/dtos/user-ideal-personalities-update-request.dto.ts
@@ -1,5 +1,11 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { ArrayNotEmpty, ArrayUnique, IsArray, IsString } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  ArrayNotEmpty,
+  ArrayUnique,
+  IsArray,
+  IsOptional,
+  IsString,
+} from 'class-validator';
 
 export class UserIdealPersonalitiesUpdateRequestDto {
   @ApiProperty({ example: ['차분함', '신중함', '계획성'] })
@@ -8,4 +14,14 @@ export class UserIdealPersonalitiesUpdateRequestDto {
   @ArrayNotEmpty()
   @ArrayUnique()
   personalityKeywords: string[];
+
+  @ApiPropertyOptional({
+    example: ['영화감상', '문학'],
+    description: '허용만 하며 이상형 성향 업데이트 처리에는 사용하지 않습니다.',
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  @ArrayUnique()
+  interest?: string[];
 }


### PR DESCRIPTION
## 이슈 번호
close 

## 주요 변경사항
- Fastapi 에서 던져주는 interest 키워드를 이상형 음성분석시에는 사용하지않는다. 
- 이상형 음성분석시에는 interest를 optional 로 받아와서 아무 로직을 수행하지 않는것으로 수정
- 즉 , DB에 없는 키워드라는 에러를 더 이상 띄우지 않을것.

## 테스트 결과 (스크린샷)
- 

## 참고 및 개선사항
- 
