### PR TITLE
[EUM-127] fix: 소켓 핸드셰이크 인증 실패 시 연결 거부

### DIFF
--- a/src/infra/websocket/auth/ws-auth.service.spec.ts
+++ b/src/infra/websocket/auth/ws-auth.service.spec.ts
@@ -1,0 +1,97 @@
+import { ActiveStatus } from '@prisma/client';
+
+import { WsAuthService } from './ws-auth.service';
+
+describe('WsAuthService.attachUser', () => {
+  const buildService = () => {
+    const prisma = {
+      user: {
+        findFirst: jest.fn(),
+      },
+    };
+    const jwtTokenService = {
+      verify: jest.fn(),
+    };
+    const configService = {
+      getOrThrow: jest.fn().mockReturnValue('access-secret'),
+    };
+    const service = new WsAuthService(
+      prisma as never,
+      jwtTokenService as never,
+      configService as never,
+    );
+
+    return { service, prisma, jwtTokenService, configService };
+  };
+
+  const makeClient = (auth: Record<string, unknown> = {}) => ({
+    id: 'socket-1',
+    data: {} as { userId?: number },
+    handshake: {
+      auth,
+      query: {},
+      address: '127.0.0.1',
+    },
+    join: jest.fn().mockResolvedValue(undefined),
+  });
+
+  it('토큰이 없으면 인증하지 않는다', async () => {
+    const { service, prisma, jwtTokenService } = buildService();
+    const client = makeClient();
+
+    await expect(service.attachUser(client as never)).resolves.toBeNull();
+
+    expect(jwtTokenService.verify).not.toHaveBeenCalled();
+    expect(prisma.user.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('JWT 검증에 실패하면 인증하지 않는다', async () => {
+    const { service, prisma, jwtTokenService } = buildService();
+    const client = makeClient({ token: 'invalid-token' });
+    jwtTokenService.verify.mockImplementation(() => {
+      throw new Error('invalid signature');
+    });
+
+    await expect(service.attachUser(client as never)).resolves.toBeNull();
+
+    expect(jwtTokenService.verify).toHaveBeenCalledWith(
+      'invalid-token',
+      'access-secret',
+    );
+    expect(prisma.user.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('활성 사용자를 찾지 못하면 인증하지 않는다', async () => {
+    const { service, prisma, jwtTokenService } = buildService();
+    const client = makeClient({ accessToken: 'valid-token' });
+    jwtTokenService.verify.mockReturnValue({ sub: '42' });
+    prisma.user.findFirst.mockResolvedValue(null);
+
+    await expect(service.attachUser(client as never)).resolves.toBeNull();
+
+    expect(prisma.user.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: 42n,
+        deletedAt: null,
+        status: ActiveStatus.ACTIVE,
+      },
+      select: { id: true },
+    });
+  });
+
+  it('인증 성공 시 userId를 저장하고 사용자 room에 참여시킨다', async () => {
+    const { service, prisma, jwtTokenService } = buildService();
+    const client = makeClient({ token: 'Bearer valid-token' });
+    jwtTokenService.verify.mockReturnValue({ sub: 42 });
+    prisma.user.findFirst.mockResolvedValue({ id: 42n });
+
+    await expect(service.attachUser(client as never)).resolves.toBe(42);
+
+    expect(jwtTokenService.verify).toHaveBeenCalledWith(
+      'valid-token',
+      'access-secret',
+    );
+    expect(client.data.userId).toBe(42);
+    expect(client.join).toHaveBeenCalledWith('user:42');
+  });
+});

--- a/src/modules/chat/gateways/chat.gateway.spec.ts
+++ b/src/modules/chat/gateways/chat.gateway.spec.ts
@@ -1,5 +1,112 @@
 import { ChatGateway } from './chat.gateway';
 
+describe('ChatGateway handshake authentication', () => {
+  type Middleware = (
+    client: { id: string; data: { userId?: number } },
+    next: (error?: Error) => void,
+  ) => void;
+
+  const buildGateway = () => {
+    const wsAuthService = { attachUser: jest.fn() };
+    const presenceStore = {
+      onConnect: jest.fn(),
+      onDisconnect: jest.fn(),
+      getLastSeenAt: jest.fn(),
+      touch: jest.fn(),
+    };
+    const userActivityService = {
+      recordActivity: jest.fn().mockResolvedValue(undefined),
+      clearActivityThrottle: jest.fn(),
+    };
+    const gateway = new ChatGateway(
+      wsAuthService as never,
+      presenceStore as never,
+      null as never,
+      userActivityService as never,
+    );
+    let middleware: Middleware | undefined;
+    const use = jest.fn((registeredMiddleware: Middleware) => {
+      middleware = registeredMiddleware;
+    });
+
+    gateway.afterInit({ use } as never);
+
+    if (!middleware) {
+      throw new Error('handshake middleware was not registered');
+    }
+
+    return {
+      gateway,
+      wsAuthService,
+      presenceStore,
+      userActivityService,
+      middleware,
+      use,
+    };
+  };
+
+  const runMiddleware = (
+    middleware: Middleware,
+    client: Parameters<Middleware>[0],
+  ) =>
+    new Promise<Error | undefined>((resolve) => {
+      middleware(client, resolve);
+    });
+
+  it('네임스페이스 초기화 시 인증 미들웨어를 등록한다', () => {
+    const { use } = buildGateway();
+
+    expect(use).toHaveBeenCalledTimes(1);
+    expect(use).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('인증 성공 시 연결을 허용하고 handleConnection에서 presence를 등록한다', async () => {
+    const { gateway, wsAuthService, presenceStore, middleware } =
+      buildGateway();
+    const client = { id: 'socket-1', data: { userId: 42 } };
+    wsAuthService.attachUser.mockResolvedValue(42);
+
+    await expect(runMiddleware(middleware, client)).resolves.toBeUndefined();
+    gateway.handleConnection(client as never);
+
+    expect(wsAuthService.attachUser).toHaveBeenCalledWith(client);
+    expect(presenceStore.onConnect).toHaveBeenCalledWith(42, 'socket-1');
+  });
+
+  it('인증 실패 시 AUTH_LOGIN_REQUIRED connect_error로 연결을 거부한다', async () => {
+    const { wsAuthService, presenceStore, middleware } = buildGateway();
+    const client = { id: 'socket-1', data: {} };
+    wsAuthService.attachUser.mockResolvedValue(null);
+
+    const error = await runMiddleware(middleware, client);
+
+    expect(error).toMatchObject({
+      message: '로그인이 필요한 서비스입니다. 로그인 후 이용해주세요.',
+      data: {
+        code: 'AUTH-001',
+        internalCode: 'AUTH_LOGIN_REQUIRED',
+      },
+    });
+    expect(presenceStore.onConnect).not.toHaveBeenCalled();
+  });
+
+  it('인증 서비스가 예외를 던져도 인증 오류로 연결을 거부한다', async () => {
+    const { wsAuthService, middleware } = buildGateway();
+    const client = { id: 'socket-1', data: {} };
+    wsAuthService.attachUser.mockRejectedValue(new Error('database failed'));
+
+    const error = await runMiddleware(middleware, client);
+
+    expect(error).toMatchObject({
+      data: {
+        code: 'AUTH-001',
+        internalCode: 'AUTH_LOGIN_REQUIRED',
+      },
+    });
+    expect(error?.message).not.toContain('database failed');
+  });
+});
+
 describe('ChatGateway.evictUserFromRoom', () => {
   const makeSocket = (userId: number) => ({
     data: { userId },

--- a/src/modules/chat/gateways/chat.gateway.ts
+++ b/src/modules/chat/gateways/chat.gateway.ts
@@ -4,6 +4,7 @@ import {
   SubscribeMessage,
   ConnectedSocket,
   MessageBody,
+  OnGatewayInit,
   OnGatewayConnection,
   OnGatewayDisconnect,
 } from '@nestjs/websockets';
@@ -16,6 +17,7 @@ import {
 } from '@nestjs/common';
 import type { Server, Socket, DefaultEventsMap } from 'socket.io';
 
+import { getErrorDefinition } from '../../../common/errors/error-codes';
 import { WsExceptionFilter } from '../../../common/filters/ws-exception.filter';
 import { WsAuthService } from '../../../infra/websocket/auth/ws-auth.service';
 import { WsUserGuard } from '../../../infra/websocket/guards/ws-user.guard';
@@ -37,6 +39,13 @@ import { UserActivityService } from '../../user/services/user/user-activity.serv
 
 type SocketData = { userId?: number };
 
+type SocketAuthError = Error & {
+  data: {
+    code: string;
+    internalCode: 'AUTH_LOGIN_REQUIRED';
+  };
+};
+
 type AuthedSocket = Socket<
   DefaultEventsMap,
   DefaultEventsMap,
@@ -50,7 +59,9 @@ type AuthedSocket = Socket<
 })
 @UseFilters(new WsExceptionFilter())
 @Injectable()
-export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
+export class ChatGateway
+  implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect
+{
   private readonly logger = new Logger(ChatGateway.name);
 
   constructor(
@@ -63,6 +74,41 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
   @WebSocketServer()
   server!: Server;
+
+  afterInit(server: Server): void {
+    server.use((client, next) => {
+      void this.authenticateConnection(client as AuthedSocket, next);
+    });
+  }
+
+  private async authenticateConnection(
+    client: AuthedSocket,
+    next: (error?: Error) => void,
+  ): Promise<void> {
+    try {
+      const userId = await this.wsAuthService.attachUser(client);
+      if (!userId) {
+        this.logger.warn('reject connection: auth failed');
+        next(this.createAuthError());
+        return;
+      }
+
+      next();
+    } catch (e) {
+      this.logger.warn(`reject connection: ${String(e)}`);
+      next(this.createAuthError());
+    }
+  }
+
+  private createAuthError(): SocketAuthError {
+    const definition = getErrorDefinition('AUTH_LOGIN_REQUIRED');
+    const error = new Error(definition.message) as SocketAuthError;
+    error.data = {
+      code: definition.code,
+      internalCode: 'AUTH_LOGIN_REQUIRED',
+    };
+    return error;
+  }
 
   private emitToRooms(rooms: string[], event: string, payload: unknown): void {
     if (!this.server) return;
@@ -139,23 +185,13 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
     this.emitToRooms([...rooms], 'message.deleted', payload);
   }
 
-  async handleConnection(client: AuthedSocket) {
-    try {
-      const userId = await this.wsAuthService.attachUser(client);
-      if (!userId) {
-        this.logger.warn('reject connection: auth failed');
-        client.disconnect(true);
-        return;
-      }
+  handleConnection(client: AuthedSocket) {
+    const userId = client.data.userId as number;
 
-      this.presenceStore.onConnect(userId, client.id);
-      void this.recordUserActivity(userId);
+    this.presenceStore.onConnect(userId, client.id);
+    void this.recordUserActivity(userId);
 
-      this.logger.log(`connected: socket=${client.id} userId=${userId}`);
-    } catch (e) {
-      this.logger.warn(`reject connection: ${String(e)}`);
-      client.disconnect(true);
-    }
+    this.logger.log(`connected: socket=${client.id} userId=${userId}`);
   }
 
   handleDisconnect(client: AuthedSocket) {


### PR DESCRIPTION
## 주요 변경사항
- `/chats` 네임스페이스에 Socket.IO 핸드셰이크 인증 미들웨어를 추가했습니다.
- 토큰 누락, JWT 검증 실패, 비활성/삭제/미존재 사용자의 연결을 `connect_error`로 거부합니다.
- 인증 실패 시 `AUTH-001`과 `AUTH_LOGIN_REQUIRED` 정보를 클라이언트에 전달합니다.
- 인증에 성공한 소켓만 presence 등록과 사용자 활동 기록을 수행합니다.
- 기존 이벤트 단위 `WsUserGuard`를 추가 방어선으로 유지했습니다.
- 게이트웨이 인증 흐름과 `WsAuthService` 인증 케이스 테스트를 추가했습니다.

## 테스트 결과 (스크린샷)

## 참고 및 개선사항
- 인증 실패 소켓은 연결 자체가 거부되므로 이벤트 ACK timeout 상태로 남지 않습니다.