### PR TITLE
회원탈퇴 계정 삭제 처리 및 Apple 로그인 연결 해제 추가

### DIFF
--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -33,6 +33,6 @@ import { UserRepository } from '../user/repositories/user.repository';
     AuthRepository,
     UserRepository,
   ],
-  exports: [JwtTokenService, AccessTokenGuard],
+  exports: [JwtTokenService, AccessTokenGuard, AppleAuthService],
 })
 export class AuthModule {}

--- a/src/modules/auth/services/apple-auth.service.spec.ts
+++ b/src/modules/auth/services/apple-auth.service.spec.ts
@@ -164,4 +164,42 @@ describe('AppleAuthService', () => {
       expect.anything(),
     );
   });
+
+  it('authorization code를 Apple 토큰으로 교환한 뒤 revoke endpoint를 호출한다', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => ({
+          refresh_token: 'apple-refresh-token',
+          access_token: 'apple-access-token',
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () => '',
+      });
+
+    await service.revokeAuthorizationCode('apple-auth-code');
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      'https://appleid.apple.com/auth/token',
+      expect.objectContaining({
+        method: 'POST',
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'https://appleid.apple.com/auth/revoke',
+      expect.objectContaining({
+        method: 'POST',
+      }),
+    );
+    const fetchCalls = fetchMock.mock.calls as unknown as Array<
+      [string, { body?: string }]
+    >;
+    const revokeBody = fetchCalls[1]?.[1]?.body ?? '';
+    expect(revokeBody).toContain('token=apple-refresh-token');
+    expect(revokeBody).toContain('token_type_hint=refresh_token');
+  });
 });

--- a/src/modules/auth/services/apple-auth.service.ts
+++ b/src/modules/auth/services/apple-auth.service.ts
@@ -35,6 +35,11 @@ type AppleIdentityPayload = JwtPayload & {
   email?: string;
 };
 
+type AppleTokenResponse = {
+  access_token?: string;
+  refresh_token?: string;
+};
+
 @Injectable()
 export class AppleAuthService {
   private static readonly APPLE_ISSUER = 'https://appleid.apple.com';
@@ -251,45 +256,42 @@ export class AppleAuthService {
     return jwks;
   }
 
+  async revokeAuthorizationCode(
+    authorizationCode: string,
+    clientIdOverride?: string,
+  ): Promise<void> {
+    const clientId =
+      clientIdOverride ?? this.configService.get<string>('APPLE_CLIENT_ID');
+
+    if (!clientId) {
+      throw new AppException('SERVER_TEMPORARY_ERROR', {
+        message: 'Apple client ID is not configured.',
+      });
+    }
+
+    const tokenResponse = await this.exchangeAuthorizationCode(
+      authorizationCode,
+      clientId,
+    );
+    const token = tokenResponse.refresh_token ?? tokenResponse.access_token;
+    const tokenTypeHint = tokenResponse.refresh_token
+      ? 'refresh_token'
+      : 'access_token';
+
+    if (!token) {
+      throw new AppException('AUTH_APPLE_TOKEN_EXCHANGE_FAILED', {
+        message: 'Apple token response did not include a revocable token.',
+      });
+    }
+
+    await this.revokeToken(token, tokenTypeHint, clientId);
+  }
+
   private async exchangeAuthorizationCode(
     authorizationCode: string,
     clientId: string,
-  ): Promise<void> {
-    const teamId = this.configService.get<string>('APPLE_TEAM_ID');
-    const keyId = this.configService.get<string>('APPLE_KEY_ID');
-    const privateKey = this.normalizePrivateKey(
-      this.configService.get<string>('APPLE_PRIVATE_KEY'),
-    );
-
-    if (!teamId || !keyId || !privateKey) {
-      throw new AppException('SERVER_TEMPORARY_ERROR', {
-        message: 'Apple token exchange credentials are not configured.',
-      });
-    }
-
-    let clientSecret: string;
-    try {
-      clientSecret = jwt.sign(
-        {
-          iss: teamId,
-          iat: Math.floor(Date.now() / 1000),
-          exp: Math.floor(Date.now() / 1000) + 60 * 60,
-          aud: AppleAuthService.APPLE_ISSUER,
-          sub: clientId,
-        },
-        createPrivateKey(privateKey),
-        {
-          algorithm: 'ES256',
-          keyid: keyId,
-        },
-      );
-    } catch (error) {
-      throw new AppException('SERVER_TEMPORARY_ERROR', {
-        message: 'Apple private key is invalid.',
-        details: error,
-      });
-    }
-
+  ): Promise<AppleTokenResponse> {
+    const clientSecret = this.buildClientSecret(clientId);
     const params = new URLSearchParams({
       grant_type: 'authorization_code',
       code: authorizationCode,
@@ -300,6 +302,45 @@ export class AppleAuthService {
     let response: Response;
     try {
       response = await fetch('https://appleid.apple.com/auth/token', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: params.toString(),
+      });
+    } catch (error) {
+      throw new AppException('NETWORK_CONNECTION_FAILED', { details: error });
+    }
+
+    if (!response.ok) {
+      const body = await response.text();
+      if (response.status === 400 || response.status === 401) {
+        throw new AppException('AUTH_APPLE_TOKEN_INVALID', { details: body });
+      }
+      throw new AppException('AUTH_APPLE_TOKEN_EXCHANGE_FAILED', {
+        details: body,
+      });
+    }
+
+    return (await response.json()) as AppleTokenResponse;
+  }
+
+  private async revokeToken(
+    token: string,
+    tokenTypeHint: 'access_token' | 'refresh_token',
+    clientId: string,
+  ): Promise<void> {
+    const clientSecret = this.buildClientSecret(clientId);
+    const params = new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      token,
+      token_type_hint: tokenTypeHint,
+    });
+
+    let response: Response;
+    try {
+      response = await fetch('https://appleid.apple.com/auth/revoke', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',
@@ -336,6 +377,42 @@ export class AppleAuthService {
       .replaceAll('\\\\n', '\n')
       .replaceAll('\\n', '\n')
       .replaceAll('\r\n', '\n');
+  }
+
+  private buildClientSecret(clientId: string): string {
+    const teamId = this.configService.get<string>('APPLE_TEAM_ID');
+    const keyId = this.configService.get<string>('APPLE_KEY_ID');
+    const privateKey = this.normalizePrivateKey(
+      this.configService.get<string>('APPLE_PRIVATE_KEY'),
+    );
+
+    if (!teamId || !keyId || !privateKey) {
+      throw new AppException('SERVER_TEMPORARY_ERROR', {
+        message: 'Apple token exchange credentials are not configured.',
+      });
+    }
+
+    try {
+      return jwt.sign(
+        {
+          iss: teamId,
+          iat: Math.floor(Date.now() / 1000),
+          exp: Math.floor(Date.now() / 1000) + 60 * 60,
+          aud: AppleAuthService.APPLE_ISSUER,
+          sub: clientId,
+        },
+        createPrivateKey(privateKey),
+        {
+          algorithm: 'ES256',
+          keyid: keyId,
+        },
+      );
+    } catch (error) {
+      throw new AppException('SERVER_TEMPORARY_ERROR', {
+        message: 'Apple private key is invalid.',
+        details: error,
+      });
+    }
   }
 
   private async rotateRefreshTokens(refreshToken: string, userId: number) {

--- a/src/modules/user/controllers/user/user.controller.ts
+++ b/src/modules/user/controllers/user/user.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   Param,
   Patch,
@@ -9,6 +10,7 @@ import {
   Query,
   UseGuards,
 } from '@nestjs/common';
+import { AuthProvider } from '@prisma/client';
 import {
   ApiBearerAuth,
   ApiHeader,
@@ -33,6 +35,7 @@ import {
 import { UserVisitorsResponseDto } from '../../dtos/user-visitors-response.dto';
 import { UserPublicProfileResponseDto } from '../../dtos/user-public-profile-response.dto';
 import { ActiveUsersResponseDto } from '../../dtos/user-active-response.dto';
+import { DeleteAccountRequestDto } from '../../dtos/delete-account-request.dto';
 import { UserService } from '../../services/user/user.service';
 import { UserActivityService } from '../../services/user/user-activity.service';
 
@@ -177,6 +180,18 @@ export class UserController {
   @ApiOkResponse({ schema: { example: null } })
   deactivateMe(@CurrentUser('userId') userId: number | null) {
     return this.userService.deactivateMe(userId ?? 0);
+  }
+
+  @Delete('me')
+  @UseGuards(AccessTokenGuard)
+  @ApiOperation({ summary: 'Delete my account and personal data' })
+  @ApiOkResponse({ schema: { example: null } })
+  deleteMe(
+    @CurrentUser('userId') userId: number | null,
+    @CurrentUser('provider') provider: AuthProvider | null,
+    @Body() body: DeleteAccountRequestDto,
+  ) {
+    return this.userService.deleteMe(userId ?? 0, provider, body);
   }
 
   @Put('me/interests')

--- a/src/modules/user/dtos/delete-account-request.dto.ts
+++ b/src/modules/user/dtos/delete-account-request.dto.ts
@@ -1,0 +1,13 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
+
+export class DeleteAccountRequestDto {
+  @ApiPropertyOptional({
+    description:
+      'Apple 로그인 사용자가 탈퇴할 때 Apple 재인증으로 받은 authorization code',
+    example: 'apple_authorization_code',
+  })
+  @IsString()
+  @IsOptional()
+  appleAuthorizationCode?: string;
+}

--- a/src/modules/user/repositories/user.repository.ts
+++ b/src/modules/user/repositories/user.repository.ts
@@ -713,6 +713,179 @@ export class UserRepository {
     });
   }
 
+  async deleteAccount(userId: number) {
+    const deletedAt = new Date();
+    const userBigIntId = BigInt(userId);
+    const anonymizedEmail = `deleted-user-${userId}@deleted.local`;
+
+    return this.prismaService.$transaction(async (tx) => {
+      const user = await tx.user.findFirst({
+        where: {
+          id: userBigIntId,
+          deletedAt: null,
+          status: ActiveStatus.ACTIVE,
+        },
+        select: { id: true },
+      });
+
+      if (!user) {
+        return { count: 0 };
+      }
+
+      const articleIds = (
+        await tx.article.findMany({
+          where: { userId: userBigIntId },
+          select: { id: true },
+        })
+      ).map((article) => article.id);
+      const participantIds = (
+        await tx.chatParticipant.findMany({
+          where: { userId: userBigIntId },
+          select: { id: true },
+        })
+      ).map((participant) => participant.id);
+
+      await tx.refreshToken.deleteMany({ where: { userId: userBigIntId } });
+      await tx.pushDeviceToken.deleteMany({ where: { userId: userBigIntId } });
+      await tx.localAuthAccount.deleteMany({ where: { userId: userBigIntId } });
+
+      await tx.userPhoto.deleteMany({ where: { userId: userBigIntId } });
+      await tx.userInterest.deleteMany({ where: { userId: userBigIntId } });
+      await tx.userPersonality.deleteMany({ where: { userId: userBigIntId } });
+      await tx.userIdealPersonality.deleteMany({
+        where: { userId: userBigIntId },
+      });
+      await tx.userMarketingAgreement.deleteMany({
+        where: { userId: userBigIntId },
+      });
+      await tx.recentSearchKeyword.deleteMany({
+        where: { userId: userBigIntId },
+      });
+      await tx.userWatchLog.deleteMany({
+        where: {
+          OR: [{ visitedTo: userBigIntId }, { visitedBy: userBigIntId }],
+        },
+      });
+
+      await tx.heart.updateMany({
+        where: {
+          OR: [{ sentById: userBigIntId }, { sentToId: userBigIntId }],
+        },
+        data: {
+          sentById: null,
+          sentToId: null,
+          status: ActiveStatus.INACTIVE,
+          deletedAt,
+        },
+      });
+      await tx.block.deleteMany({
+        where: {
+          OR: [{ blockedById: userBigIntId }, { blockedId: userBigIntId }],
+        },
+      });
+      await tx.notification.deleteMany({ where: { userId: userBigIntId } });
+      await tx.notification.updateMany({
+        where: { sentById: userBigIntId },
+        data: { sentById: null },
+      });
+
+      await tx.report.updateMany({
+        where: { reportedById: userBigIntId },
+        data: { reportedById: null },
+      });
+      await tx.userReport.updateMany({
+        where: { reportedUserId: userBigIntId },
+        data: { reportedUserId: null },
+      });
+
+      await tx.articleLike.deleteMany({ where: { userId: userBigIntId } });
+      await tx.clubLike.deleteMany({ where: { userId: userBigIntId } });
+      await tx.club.updateMany({
+        where: { hostId: userBigIntId },
+        data: { hostId: null },
+      });
+      await tx.clubUser.deleteMany({ where: { userId: userBigIntId } });
+
+      if (articleIds.length > 0) {
+        await tx.articlePhoto.updateMany({
+          where: { articleId: { in: articleIds } },
+          data: {
+            photoUrl: '',
+            deletedAt,
+          },
+        });
+      }
+      await tx.comment.updateMany({
+        where: { userId: userBigIntId },
+        data: {
+          contents: '',
+          userId: null,
+          deletedAt,
+        },
+      });
+      await tx.article.updateMany({
+        where: { userId: userBigIntId },
+        data: {
+          title: '삭제된 게시물',
+          contents: '',
+          userId: null,
+          deletedAt,
+        },
+      });
+
+      if (participantIds.length > 0) {
+        await tx.chatMedia.deleteMany({
+          where: {
+            message: {
+              participantId: { in: participantIds },
+            },
+          },
+        });
+        await tx.chatMessage.updateMany({
+          where: { participantId: { in: participantIds } },
+          data: {
+            deletedAt,
+          },
+        });
+      }
+      await tx.chatRoom.updateMany({
+        where: { userId: userBigIntId },
+        data: { userId: null },
+      });
+      await tx.chatParticipant.updateMany({
+        where: { userId: userBigIntId },
+        data: {
+          userId: null,
+          endedAt: deletedAt,
+        },
+      });
+
+      const result = await tx.user.updateMany({
+        where: {
+          id: userBigIntId,
+          deletedAt: null,
+          status: ActiveStatus.ACTIVE,
+        },
+        data: {
+          email: anonymizedEmail,
+          nickname: '탈퇴한 사용자',
+          age: 0,
+          code: null,
+          introText: '',
+          introVoiceUrl: '',
+          profileImageUrl: '',
+          idealVoiceUrl: null,
+          provider: null,
+          providerUserId: null,
+          status: ActiveStatus.INACTIVE,
+          deletedAt,
+        },
+      });
+
+      return result;
+    });
+  }
+
   private async ensureDefaultAddress(defaultAddressCode: string) {
     await this.prismaService.address.upsert({
       where: { code: defaultAddressCode },

--- a/src/modules/user/services/user/user.service.spec.ts
+++ b/src/modules/user/services/user/user.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import {
+  AuthProvider,
   ClubAuthority,
   ClubCategory,
   ClubUserStatus,
@@ -7,6 +8,7 @@ import {
 } from '@prisma/client';
 import { UserService } from './user.service';
 import { UserRepository } from '../../repositories/user.repository';
+import { AppleAuthService } from '../../../auth/services/apple-auth.service';
 
 describe('UserService', () => {
   let service: UserService;
@@ -28,10 +30,15 @@ describe('UserService', () => {
     updatePersonalities: jest.fn(),
     updateIdealPersonalities: jest.fn(),
     deactivateProfile: jest.fn(),
+    deleteAccount: jest.fn(),
+  };
+  const appleAuthServiceMock = {
+    revokeAuthorizationCode: jest.fn(),
   };
 
   beforeEach(async () => {
     Object.values(repositoryMock).forEach((mock) => mock.mockReset());
+    Object.values(appleAuthServiceMock).forEach((mock) => mock.mockReset());
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -39,6 +46,10 @@ describe('UserService', () => {
         {
           provide: UserRepository,
           useValue: repositoryMock,
+        },
+        {
+          provide: AppleAuthService,
+          useValue: appleAuthServiceMock,
         },
       ],
     }).compile();
@@ -491,5 +502,40 @@ describe('UserService', () => {
     expect(result).toBeNull();
     expect(repositoryMock.findActiveUserId).toHaveBeenCalledWith(7);
     expect(repositoryMock.createProfileVisitLog).not.toHaveBeenCalled();
+  });
+
+  it('Apple 로그인 사용자는 authorization code 없이 계정 삭제를 할 수 없다', async () => {
+    await expect(
+      service.deleteMe(7, AuthProvider.APPLE, {}),
+    ).rejects.toMatchObject({
+      internalCode: 'VALIDATION_REQUIRED_FIELD_MISSING',
+    });
+
+    expect(appleAuthServiceMock.revokeAuthorizationCode).not.toHaveBeenCalled();
+    expect(repositoryMock.deleteAccount).not.toHaveBeenCalled();
+  });
+
+  it('Apple 로그인 사용자는 Apple revoke 후 계정 데이터를 삭제한다', async () => {
+    repositoryMock.deleteAccount.mockResolvedValue({ count: 1 });
+
+    const result = await service.deleteMe(7, AuthProvider.APPLE, {
+      appleAuthorizationCode: 'apple-auth-code',
+    });
+
+    expect(result).toBeNull();
+    expect(appleAuthServiceMock.revokeAuthorizationCode).toHaveBeenCalledWith(
+      'apple-auth-code',
+    );
+    expect(repositoryMock.deleteAccount).toHaveBeenCalledWith(7);
+  });
+
+  it('Apple 외 로그인 사용자는 계정 데이터를 바로 삭제한다', async () => {
+    repositoryMock.deleteAccount.mockResolvedValue({ count: 1 });
+
+    const result = await service.deleteMe(7, AuthProvider.KAKAO, {});
+
+    expect(result).toBeNull();
+    expect(appleAuthServiceMock.revokeAuthorizationCode).not.toHaveBeenCalled();
+    expect(repositoryMock.deleteAccount).toHaveBeenCalledWith(7);
   });
 });

--- a/src/modules/user/services/user/user.service.ts
+++ b/src/modules/user/services/user/user.service.ts
@@ -1,10 +1,12 @@
 import { Injectable } from '@nestjs/common';
+import { AuthProvider } from '@prisma/client';
 import { AppException } from '../../../../common/errors/app.exception';
 import { UserMeResponseDto } from '../../dtos/user-me-response.dto';
 import { UserProfileUpdateRequestDto } from '../../dtos/user-profile-update-request.dto';
 import { UserInterestsUpdateRequestDto } from '../../dtos/user-interests-update-request.dto';
 import { UserPersonalitiesUpdateRequestDto } from '../../dtos/user-personalities-update-request.dto';
 import { UserIdealPersonalitiesUpdateRequestDto } from '../../dtos/user-ideal-personalities-update-request.dto';
+import { DeleteAccountRequestDto } from '../../dtos/delete-account-request.dto';
 import {
   UserClubsResponseDto,
   UserLikedClubsResponseDto,
@@ -13,6 +15,7 @@ import { UserVisitorsResponseDto } from '../../dtos/user-visitors-response.dto';
 import { UserPublicProfileResponseDto } from '../../dtos/user-public-profile-response.dto';
 import { UserRepository } from '../../repositories/user.repository';
 import { normalizeS3ObjectRef } from '../../../../common/s3/s3-object-url.service';
+import { AppleAuthService } from '../../../auth/services/apple-auth.service';
 
 type ProfileVisitorsCursor = {
   visitedAt: string;
@@ -24,7 +27,10 @@ export class UserService {
   private static readonly DEFAULT_VISITORS_PAGE_SIZE = 20;
   private static readonly MAX_VISITORS_PAGE_SIZE = 50;
 
-  constructor(private readonly userRepository: UserRepository) {}
+  constructor(
+    private readonly userRepository: UserRepository,
+    private readonly appleAuthService: AppleAuthService,
+  ) {}
 
   async getMe(userId: number): Promise<UserMeResponseDto> {
     if (!userId) {
@@ -383,6 +389,35 @@ export class UserService {
     }
 
     const result = await this.userRepository.deactivateProfile(userId);
+
+    if (result.count === 0) {
+      throw new AppException('AUTH_LOGIN_REQUIRED');
+    }
+
+    return null;
+  }
+
+  async deleteMe(
+    userId: number,
+    provider: AuthProvider | null,
+    payload: DeleteAccountRequestDto,
+  ): Promise<null> {
+    if (!userId) {
+      throw new AppException('AUTH_LOGIN_REQUIRED');
+    }
+
+    if (provider === AuthProvider.APPLE) {
+      const authorizationCode = payload.appleAuthorizationCode?.trim();
+      if (!authorizationCode) {
+        throw new AppException('VALIDATION_REQUIRED_FIELD_MISSING', {
+          message:
+            'Apple 로그인 사용자는 탈퇴 전 Apple 재인증 authorization code가 필요합니다.',
+        });
+      }
+      await this.appleAuthService.revokeAuthorizationCode(authorizationCode);
+    }
+
+    const result = await this.userRepository.deleteAccount(userId);
 
     if (result.count === 0) {
       throw new AppException('AUTH_LOGIN_REQUIRED');


### PR DESCRIPTION
## 이슈 번호
close #291 

## Summary

  회원탈퇴가 단순 비활성화로만 처리되던 흐름을 보완

  앱 출시 심사 기준 대응을 위해 실제 탈퇴 API를 새로 추가하고, Apple 로그인 사용자는 탈퇴 시 Apple 연결 해제(revoke)를 수행하도록 수정

  ### Backend

  - `DELETE /users/me` 계정 삭제 API 추가
  - 기존 `PATCH /users/me/deactivate`는 유지하되, 출시 앱에서는 새 `DELETE /users/me`를 사용해야
  - Apple 로그인 사용자는 탈퇴 요청 시 `appleAuthorizationCode`가 필요
  - 서버는 프런트에서 전달받은 Apple authorization code를 Apple token endpoint에 전달해 토큰을 교환
  - 교환한 `refresh_token` 또는 `access_token`으로 Apple revoke endpoint를 호출
  - Apple revoke가 성공한 뒤 계정 삭제/익명화 트랜잭션을 실행
  - 탈퇴 시 아래 데이터를 삭제 또는 익명화한다. 
    - refresh token
    - push device token
    - local auth account
    - user photos
    - interests
    - personalities
    - ideal personalities
    - marketing agreements
    - recent search keywords
    - profile visit logs
    - heart/block/notification 관련 데이터
    - user 식별 정보: `email`, `provider`, `providerUserId`
    - profile 정보: `nickname`, `introText`, `introVoiceUrl`, `profileImageUrl`, `idealVoiceUrl`, `code`
  - 게시글/댓글/채팅처럼 다른 사용자 화면과 연결된 데이터는 row 자체를 무조건 삭제하지 않고, 작성자 연결과 본문/미디어를 제거한 뒤
  `deletedAt` 처리하도록

  ### Frontend Required Changes

  프런트에서는 기존 탈퇴 API 대신 새 API를 호출해야

  #### Apple 로그인 사용자

  Apple 로그인 사용자는 탈퇴 직전에 Apple 재인증을 수행해야

  1. 사용자가 탈퇴 버튼 클릭
  2. 프런트에서 Apple 재인증 실행
  3. Apple에서 받은 authorizationCode를 서버에 전달
  4. 서버가 Apple token revoke 후 계정 삭제 처리

  DELETE /users/me
  Authorization: Bearer <accessToken>
  Content-Type: application/json

  {
    "appleAuthorizationCode": "apple_authorization_code"
  }

  Apple 사용자가 appleAuthorizationCode 없이 탈퇴 요청을 보내면 서버는 요청을 거부해야

  ## Why

  앱 출시 심사 기준상 계정 생성 기능이 있는 앱은 앱 내에서 계정 삭제를 시작할 수 있어야 하며, 단순 비활성화만 제공하는 것은 부족

  또한 Sign in with Apple을 사용하는 경우, 계정 삭제 시 Apple token revoke를 통해 앱과 Apple 계정 연결을 해제해야

  ## Files Changed

  - src/modules/user/controllers/user/user.controller.ts
      - DELETE /users/me 추가

  - src/modules/user/services/user/user.service.ts
      - Apple authorization code 확인 및 revoke 호출
      - 계정 삭제 처리 호출

  - src/modules/user/repositories/user.repository.ts
      - 계정 삭제/익명화 트랜잭션 추가

  - src/modules/user/dtos/delete-account-request.dto.ts
      - 탈퇴 요청 DTO 추가

  - src/modules/auth/services/apple-auth.service.ts
      - Apple authorization code 교환
      - Apple revoke endpoint 호출

  - src/modules/auth/auth.module.ts
      - AppleAuthService export 추가

  - src/modules/auth/services/apple-auth.service.spec.ts
      - Apple revoke 테스트 추가

  - src/modules/user/services/user/user.service.spec.ts
      - 계정 삭제/Apple authorization code 테스트 추가


  ## Release Checklist

  - [ ] 프런트에서 탈퇴 API를 DELETE /users/me로 교체
  - [ ] iOS Apple 로그인 사용자는 탈퇴 직전 Apple 재인증 후 appleAuthorizationCode 전달
  - [ ] Android/Kakao/일반 로그인 사용자는 빈 body로 DELETE /users/me 호출
  - [ ] 탈퇴 성공 후 앱 로컬 토큰/캐시 삭제
  - [ ] Google Play Console에 계정 삭제 요청 웹 URL 등록
  - [ ] 개인정보처리방침에 삭제/보관 데이터 항목 반영
  - [ ] staging DB에서 탈퇴 트랜잭션 FK 제약 확인