### PR TITLE
[EUM-13] [Feat] UCG 부적절한 언행 및 사진에 대해서 사전 필터링 기능 추가 

### DIFF
--- a/docs/moderation.md
+++ b/docs/moderation.md
@@ -1,0 +1,161 @@
+# 콘텐츠 모더레이션 정책 및 구현 정리
+
+## 목적
+
+앱 출시 심사에서는 사용자 생성 콘텐츠(UGC)가 다른 사용자에게 노출되기 전에 부적절한 콘텐츠를 사전 필터링할 수 있어야 합니다.
+
+현재 백엔드는 공개 또는 반공개 성격의 UGC를 저장하기 전에 OpenAI Moderations API로 텍스트와 이미지를 검수합니다.
+
+채팅 메시지는 이번 모더레이션 대상에서 제외했습니다. 채팅은 사적인 커뮤니케이션에 가까우며, 서버가 채팅 본문을 필터링하는 방식은 개인정보 처리 및 서비스 정책 측면에서 별도 검토가 필요합니다.
+
+## 현재 적용 범위
+
+아래 API는 저장 전에 모더레이션 검사를 수행합니다.
+
+| 영역        | API 범위                                           | 검사 필드                                        |
+| ----------- | -------------------------------------------------- | ------------------------------------------------ |
+| 게시글      | `POST/PATCH /clubs/:clubId/articles`               | `title`, `contents`, `photoUrls`                 |
+| 댓글        | `POST /clubs/:clubId/articles/:articleId/comments` | `contents`                                       |
+| 유저 프로필 | `PATCH /users/me`                                  | `nickname`, `introText`, `profileImageUrl`       |
+| 클럽        | `POST/PATCH /clubs`                                | `name`, `introText`, `thumbnailUrl`, `imageUrls` |
+
+현재 모더레이션을 적용하지 않는 영역은 다음과 같습니다.
+
+- 1:1 채팅 텍스트
+- 클럽 채팅 텍스트
+- 채팅 사진, 음성, 영상 미디어
+- 프로필 또는 클럽의 음성 소개 파일
+
+음성 파일은 바로 검사하지 않고, 추후 STT로 텍스트 변환 후 모더레이션하는 별도 작업으로 분리합니다.
+
+## 구현 구조
+
+주요 파일은 다음과 같습니다.
+
+- `src/common/moderation/content-moderation.module.ts`
+- `src/common/moderation/content-moderation.service.ts`
+- `src/common/moderation/content-moderation.interceptor.ts`
+- `src/common/moderation/moderate-content.decorator.ts`
+- `src/common/errors/error-codes.ts`
+- `src/common/filters/global-exception.filter.ts`
+
+컨트롤러에서는 모더레이션 대상 API에 다음과 같이 데코레이터를 붙입니다.
+
+```ts
+@ModerateContent({
+  surface: 'ARTICLE',
+  textFields: ['title', 'contents'],
+  imageFields: ['photoUrls'],
+})
+```
+
+`ContentModerationInterceptor`는 `src/main.ts`에 전역 인터셉터로 등록되어 있습니다. 다만 모든 요청에 동작하는 것은 아니고, `@ModerateContent(...)` 메타데이터가 붙은 핸들러에서만 실행됩니다.
+
+`ContentModerationService`는 요청 body에서 지정된 텍스트와 이미지 필드를 수집해서 OpenAI Moderations API로 전송합니다.
+
+- 텍스트 필드: `{ type: 'text', text }`
+- 이미지 필드: `{ type: 'image_url', image_url: { url } }`
+- `s3://...` 형태의 S3 참조값은 `S3ObjectUrlService`를 통해 presigned URL로 변환한 뒤 OpenAI에 전달합니다.
+
+## 차단 기준
+
+현재 백엔드는 OpenAI 응답의 최종 판정값인 `flagged`를 기준으로 차단합니다.
+
+- `flagged: false`이면 통과
+- `flagged: true`이면 차단
+
+현재는 `category_scores`에 대해 별도 임계값을 적용하지 않습니다.
+
+출시 심사 직전에는 정책을 단순하고 보수적으로 가져가는 것이 목적이므로, OpenAI의 최종 판정값을 그대로 신뢰합니다. 추후 오탐 또는 미탐 문제가 확인되면 카테고리별 점수 임계값을 별도로 둘 수 있습니다.
+
+## 에러 응답
+
+모더레이션에 걸린 콘텐츠는 다음 에러로 응답합니다.
+
+- 내부 에러 코드: `CONTENT_POLICY_VIOLATION`
+- 외부 에러 코드: `VALID-003`
+- HTTP 상태 코드: `422 Unprocessable Entity`
+
+응답 예시는 다음과 같습니다.
+
+```json
+{
+  "resultType": "FAIL",
+  "success": null,
+  "error": {
+    "code": "VALID-003",
+    "message": "커뮤니티 가이드라인에 맞지 않는 내용이 포함되어 있어 등록할 수 없습니다.",
+    "details": {
+      "surface": "ARTICLE",
+      "violatedCategories": ["폭력적 언행"]
+    }
+  },
+  "meta": {
+    "timestamp": "2026-07-16T04:00:00.000Z",
+    "path": "/api/v1/clubs/1/articles"
+  }
+}
+```
+
+클라이언트에는 실제 위반된 카테고리만 반환합니다. OpenAI가 내려주는 전체 카테고리 boolean map이나 `category_scores`는 응답에 포함하지 않습니다.
+
+일반적인 `AppException.details`는 기존처럼 클라이언트에 노출하지 않습니다. 현재는 `CONTENT_POLICY_VIOLATION`일 때만 클라이언트에 안전한 details를 내려줍니다.
+
+## 위반 카테고리 매핑
+
+OpenAI 카테고리 키는 클라이언트 응답에서 한국어 값으로 변환됩니다.
+
+| OpenAI 카테고리          | 클라이언트 반환값      |
+| ------------------------ | ---------------------- |
+| `sexual`                 | `성적 콘텐츠`          |
+| `sexual/minors`          | `미성년자 성적 콘텐츠` |
+| `harassment`             | `괴롭힘`               |
+| `harassment/threatening` | `위협적 괴롭힘`        |
+| `hate`                   | `혐오 표현`            |
+| `hate/threatening`       | `위협적 혐오 표현`     |
+| `illicit`                | `불법 행위`            |
+| `illicit/violent`        | `폭력적 불법 행위`     |
+| `self-harm`              | `자해 관련 콘텐츠`     |
+| `self-harm/intent`       | `자해 의도`            |
+| `self-harm/instructions` | `자해 방법 안내`       |
+| `violence`               | `폭력적 언행`          |
+| `violence/graphic`       | `잔혹한 폭력 콘텐츠`   |
+
+예를 들어 OpenAI 응답에서 `violence: true`만 내려오면 클라이언트 응답의 `violatedCategories`는 다음처럼 내려갑니다.
+
+```json
+["폭력적 언행"]
+```
+
+## 환경 변수
+
+모더레이션이 동작하는 환경에는 아래 환경 변수가 필요합니다.
+
+```env
+OPENAI_API_KEY=...
+OPENAI_MODERATION_MODEL=omni-moderation-latest
+```
+
+`OPENAI_MODERATION_MODEL`은 기본값이 `omni-moderation-latest`입니다.
+
+`OPENAI_API_KEY`가 없는 상태에서 모더레이션 대상 API가 호출되면 `SERVER_TEMPORARY_ERROR`로 응답합니다. 이는 OpenAI 설정 누락으로 인해 검수되지 않은 UGC가 저장되는 것을 막기 위한 fail-closed 정책입니다.
+
+## 팀원 공유 사항
+
+- 공개 또는 반공개 UGC를 저장하는 새 API를 만들 때는 `@ModerateContent(...)` 적용 여부를 반드시 검토해야 합니다.
+- 채팅 API에는 제품/개인정보 정책 검토 없이 모더레이션을 붙이지 않습니다.
+- OpenAI `category_scores`는 현재 클라이언트에 노출하지 않습니다.
+- 새로 검사해야 하는 request body 필드가 생기면 DTO, Swagger 문서, `@ModerateContent(...)` 설정을 함께 맞춰야 합니다.
+- 하나의 요청에 텍스트와 이미지가 함께 들어오면, 둘 중 하나라도 `flagged: true`일 경우 전체 요청을 차단합니다.
+- 모더레이션은 service/repository 저장 전에 수행됩니다.
+- S3 업로드 자체를 막는 구조는 아닙니다. 파일은 S3에 이미 업로드되어 있을 수 있지만, 모더레이션에 걸리면 해당 URL이 앱 콘텐츠로 저장되지 않습니다.
+
+## 추후 작업 후보
+
+출시 이후 필요에 따라 아래 작업을 검토할 수 있습니다.
+
+- 모더레이션 판정 결과를 DB 감사 로그 테이블에 저장
+- 카테고리별 점수 임계값 정책 추가
+- 애매한 콘텐츠를 위한 관리자 검수 큐 추가
+- 이미지/영상 검수 보강을 위한 AWS Rekognition 연동
+- 음성 파일 검수를 위한 STT + 텍스트 모더레이션 파이프라인 추가

--- a/docs/moderation.md
+++ b/docs/moderation.md
@@ -56,6 +56,7 @@
 - 텍스트 필드: `{ type: 'text', text }`
 - 이미지 필드: `{ type: 'image_url', image_url: { url } }`
 - `s3://...` 형태의 S3 참조값은 `S3ObjectUrlService`를 통해 presigned URL로 변환한 뒤 OpenAI에 전달합니다.
+- 이미지는 여러 장을 한 요청에 묶지 않고, 이미지별로 한 장씩 개별 moderation 요청을 보냅니다.
 
 ## 차단 기준
 
@@ -182,6 +183,7 @@ OPENAI_MODERATION_MODEL=omni-moderation-latest
 - OpenAI `category_scores`는 현재 클라이언트에 노출하지 않습니다.
 - 새로 검사해야 하는 request body 필드가 생기면 DTO, Swagger 문서, `@ModerateContent(...)` 설정을 함께 맞춰야 합니다.
 - 하나의 요청에 텍스트와 이미지가 함께 들어오면, 둘 중 하나라도 `flagged: true`일 경우 전체 요청을 차단합니다.
+- 이미지가 여러 장인 경우 각 이미지를 개별 검사하며, 한 장이라도 차단되면 전체 요청을 차단합니다.
 - 통과된 콘텐츠는 DB에 기록하지 않고, 차단된 콘텐츠만 `ContentModerationLog`에 저장합니다.
 - 모더레이션은 service/repository 저장 전에 수행됩니다.
 - S3 업로드 자체를 막는 구조는 아닙니다. 파일은 S3에 이미 업로드되어 있을 수 있지만, 모더레이션에 걸리면 해당 URL이 앱 콘텐츠로 저장되지 않습니다.

--- a/docs/moderation.md
+++ b/docs/moderation.md
@@ -140,6 +140,41 @@ OPENAI_MODERATION_MODEL=omni-moderation-latest
 
 `OPENAI_API_KEY`가 없는 상태에서 모더레이션 대상 API가 호출되면 `SERVER_TEMPORARY_ERROR`로 응답합니다. 이는 OpenAI 설정 누락으로 인해 검수되지 않은 UGC가 저장되는 것을 막기 위한 fail-closed 정책입니다.
 
+## DB 기록
+
+모더레이션 결과는 `ContentModerationLog` 테이블에 저장합니다.
+
+원문 텍스트나 이미지 URL 전체를 저장하지 않고, 운영 조회와 감사에 필요한 메타데이터만 저장합니다.
+
+주요 컬럼은 다음과 같습니다.
+
+| 컬럼                 | 설명                                         |
+| -------------------- | -------------------------------------------- |
+| `userId`             | 요청 사용자 ID. 유저 삭제 시 `null` 처리     |
+| `surface`            | 검사 영역. 예: `ARTICLE`, `COMMENT`, `CLUB`  |
+| `targetType`         | 저장된 대상 타입. 예: `ARTICLE`, `CLUB`      |
+| `targetId`           | 저장된 대상 ID. 사전 차단 로그는 `null` 가능 |
+| `decision`           | `BLOCK`, `REVIEW`                            |
+| `provider`           | 현재는 `OPENAI`                              |
+| `model`              | 사용한 moderation 모델                       |
+| `providerResponseId` | OpenAI moderation 응답 ID                    |
+| `violatedCategories` | 실제 위반된 한국어 카테고리 배열             |
+| `inputTypes`         | 검사 입력 타입. 예: `text`, `image`          |
+| `categoryScores`     | OpenAI 카테고리 점수 JSON                    |
+| `contentHash`        | 원문 대신 저장하는 SHA-256 해시              |
+| `requestPath`        | 요청 경로                                    |
+| `createdAt`          | 생성 시각                                    |
+
+조회 효율을 위해 아래 인덱스를 둡니다.
+
+| 인덱스                           | 목적                                       |
+| -------------------------------- | ------------------------------------------ |
+| `[userId, createdAt]`            | 특정 유저의 모더레이션 이력 조회           |
+| `[decision, surface, createdAt]` | 차단/검토 내역을 영역별 최신순으로 조회    |
+| `[targetType, targetId]`         | 특정 게시글/댓글/클럽 관련 로그 조회       |
+| `[createdAt]`                    | 기간 조회 및 보관 기간 만료 데이터 정리    |
+| `violatedCategories GIN`         | 특정 위반 카테고리가 포함된 로그 빠른 조회 |
+
 ## 팀원 공유 사항
 
 - 공개 또는 반공개 UGC를 저장하는 새 API를 만들 때는 `@ModerateContent(...)` 적용 여부를 반드시 검토해야 합니다.
@@ -147,6 +182,7 @@ OPENAI_MODERATION_MODEL=omni-moderation-latest
 - OpenAI `category_scores`는 현재 클라이언트에 노출하지 않습니다.
 - 새로 검사해야 하는 request body 필드가 생기면 DTO, Swagger 문서, `@ModerateContent(...)` 설정을 함께 맞춰야 합니다.
 - 하나의 요청에 텍스트와 이미지가 함께 들어오면, 둘 중 하나라도 `flagged: true`일 경우 전체 요청을 차단합니다.
+- 통과된 콘텐츠는 DB에 기록하지 않고, 차단된 콘텐츠만 `ContentModerationLog`에 저장합니다.
 - 모더레이션은 service/repository 저장 전에 수행됩니다.
 - S3 업로드 자체를 막는 구조는 아닙니다. 파일은 S3에 이미 업로드되어 있을 수 있지만, 모더레이션에 걸리면 해당 URL이 앱 콘텐츠로 저장되지 않습니다.
 

--- a/prisma/dbml/schema.dbml
+++ b/prisma/dbml/schema.dbml
@@ -49,6 +49,7 @@ Table User {
   clubLikes ClubLike [not null]
   userReports UserReport [not null]
   recentSearchKeywords RecentSearchKeyword [not null]
+  contentModerationLogs ContentModerationLog [not null]
 
   indexes {
     (provider, providerUserId) [unique]
@@ -207,6 +208,25 @@ Table Report {
   reportedBy User
   userReport UserReport
   clubReport ClubReport
+}
+
+Table ContentModerationLog {
+  id BigInt [pk, increment]
+  userId BigInt
+  surface ModerationSurface [not null]
+  targetType ModerationTargetType
+  targetId BigInt
+  decision ModerationDecision [not null]
+  provider String [not null, default: 'OPENAI']
+  model String [not null]
+  providerResponseId String
+  violatedCategories String[] [not null]
+  inputTypes String[] [not null]
+  categoryScores Json
+  contentHash String
+  requestPath String
+  createdAt DateTime [default: `now()`, not null]
+  user User
 }
 
 Table Notification {
@@ -668,6 +688,26 @@ Enum ReportTargetType {
   COMMENT
 }
 
+Enum ModerationSurface {
+  ARTICLE
+  COMMENT
+  USER_PROFILE
+  CLUB
+  CHAT
+}
+
+Enum ModerationTargetType {
+  USER
+  CLUB
+  ARTICLE
+  COMMENT
+}
+
+Enum ModerationDecision {
+  BLOCK
+  REVIEW
+}
+
 Enum ChatRoomType {
   DIRECT
   CLUB
@@ -714,6 +754,8 @@ Ref: Block.blockedById > User.id [delete: Cascade]
 Ref: Block.blockedId > User.id [delete: Cascade]
 
 Ref: Report.reportedById > User.id [delete: Set Null]
+
+Ref: ContentModerationLog.userId > User.id [delete: Set Null]
 
 Ref: Notification.userId > User.id [delete: Cascade]
 

--- a/prisma/migrations/20260716000000_add_content_moderation_log/migration.sql
+++ b/prisma/migrations/20260716000000_add_content_moderation_log/migration.sql
@@ -1,0 +1,59 @@
+CREATE TYPE "ModerationSurface" AS ENUM (
+  'ARTICLE',
+  'COMMENT',
+  'USER_PROFILE',
+  'CLUB',
+  'CHAT'
+);
+
+CREATE TYPE "ModerationTargetType" AS ENUM (
+  'USER',
+  'CLUB',
+  'ARTICLE',
+  'COMMENT'
+);
+
+CREATE TYPE "ModerationDecision" AS ENUM (
+  'BLOCK',
+  'REVIEW'
+);
+
+CREATE TABLE "ContentModerationLog" (
+  "id" BIGSERIAL NOT NULL,
+  "userId" BIGINT,
+  "surface" "ModerationSurface" NOT NULL,
+  "targetType" "ModerationTargetType",
+  "targetId" BIGINT,
+  "decision" "ModerationDecision" NOT NULL,
+  "provider" VARCHAR(30) NOT NULL DEFAULT 'OPENAI',
+  "model" VARCHAR(80) NOT NULL,
+  "providerResponseId" VARCHAR(100),
+  "violatedCategories" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  "inputTypes" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  "categoryScores" JSONB,
+  "contentHash" VARCHAR(64),
+  "requestPath" VARCHAR(255),
+  "createdAt" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "ContentModerationLog_pkey" PRIMARY KEY ("id")
+);
+
+ALTER TABLE "ContentModerationLog"
+  ADD CONSTRAINT "ContentModerationLog_userId_fkey"
+  FOREIGN KEY ("userId") REFERENCES "User"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+
+CREATE INDEX "ContentModerationLog_userId_createdAt_idx"
+  ON "ContentModerationLog"("userId", "createdAt");
+
+CREATE INDEX "ContentModerationLog_decision_surface_createdAt_idx"
+  ON "ContentModerationLog"("decision", "surface", "createdAt");
+
+CREATE INDEX "ContentModerationLog_targetType_targetId_idx"
+  ON "ContentModerationLog"("targetType", "targetId");
+
+CREATE INDEX "ContentModerationLog_createdAt_idx"
+  ON "ContentModerationLog"("createdAt");
+
+CREATE INDEX "ContentModerationLog_violatedCategories_gin_idx"
+  ON "ContentModerationLog" USING GIN ("violatedCategories");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -137,6 +137,26 @@ enum ReportTargetType {
   COMMENT
 }
 
+enum ModerationSurface {
+  ARTICLE
+  COMMENT
+  USER_PROFILE
+  CLUB
+  CHAT
+}
+
+enum ModerationTargetType {
+  USER
+  CLUB
+  ARTICLE
+  COMMENT
+}
+
+enum ModerationDecision {
+  BLOCK
+  REVIEW
+}
+
 enum ChatRoomType {
   DIRECT
   CLUB
@@ -201,6 +221,7 @@ model User {
   clubLikes              ClubLike[]
   userReports            UserReport[]
   recentSearchKeywords   RecentSearchKeyword[]
+  contentModerationLogs  ContentModerationLog[]
 
   @@unique([provider, providerUserId])
   @@index([status])
@@ -376,24 +397,49 @@ model Block {
 }
 
 model Report {
-  id           BigInt         @id @default(autoincrement()) @db.BigInt
-  reportedById BigInt?        @db.BigInt
+  id           BigInt            @id @default(autoincrement()) @db.BigInt
+  reportedById BigInt?           @db.BigInt
   targetType   ReportTargetType?
-  targetId     BigInt?        @db.BigInt
-  chatRoomId   BigInt?        @db.BigInt
-  reportedAt   DateTime       @db.Timestamp(6)
-  reason       String         @db.VarChar(100)
-  category     ReportCategory @default(OTHERS)
-  deletedAt    DateTime?      @db.Timestamp(6)
+  targetId     BigInt?           @db.BigInt
+  chatRoomId   BigInt?           @db.BigInt
+  reportedAt   DateTime          @db.Timestamp(6)
+  reason       String            @db.VarChar(100)
+  category     ReportCategory    @default(OTHERS)
+  deletedAt    DateTime?         @db.Timestamp(6)
 
   reportedBy User?       @relation(name: "UserReportsBy", fields: [reportedById], references: [id], onDelete: SetNull) //신고한 사람이 삭제되는 경우 신고당한 기록은 남겨둬야 함.
-  userReport    UserReport?
-  clubReport    ClubReport?
+  userReport UserReport?
+  clubReport ClubReport?
 
   @@index([reportedById])
   @@index([targetType, targetId])
   @@index([chatRoomId])
   @@index([reportedAt])
+}
+
+model ContentModerationLog {
+  id                 BigInt                @id @default(autoincrement()) @db.BigInt
+  userId             BigInt?               @db.BigInt
+  surface            ModerationSurface
+  targetType         ModerationTargetType?
+  targetId           BigInt?               @db.BigInt
+  decision           ModerationDecision
+  provider           String                @default("OPENAI") @db.VarChar(30)
+  model              String                @db.VarChar(80)
+  providerResponseId String?               @db.VarChar(100)
+  violatedCategories String[]              @default([])
+  inputTypes         String[]              @default([])
+  categoryScores     Json?
+  contentHash        String?               @db.VarChar(64)
+  requestPath        String?               @db.VarChar(255)
+  createdAt          DateTime              @default(now()) @db.Timestamp(6)
+
+  user User? @relation(fields: [userId], references: [id], onDelete: SetNull)
+
+  @@index([userId, createdAt])
+  @@index([decision, surface, createdAt])
+  @@index([targetType, targetId])
+  @@index([createdAt])
 }
 
 model Notification {

--- a/src/common/dto/api-response.dto.ts
+++ b/src/common/dto/api-response.dto.ts
@@ -17,7 +17,11 @@ export interface ApiSuccessResponse<T> {
 export interface ApiFailResponse {
   resultType: 'FAIL';
   success: null;
-  error: { code: ExternalErrorCode; message: string };
+  error: {
+    code: ExternalErrorCode;
+    message: string;
+    details?: unknown;
+  };
   meta: ApiMeta;
 }
 

--- a/src/common/errors/error-codes.ts
+++ b/src/common/errors/error-codes.ts
@@ -79,6 +79,12 @@ export const ERROR_DEFINITIONS = {
     code: 'VALID-002',
     message: '필수 입력값이 누락되었습니다. 입력 내용을 확인해 주세요.',
   },
+  CONTENT_POLICY_VIOLATION: {
+    status: HttpStatus.UNPROCESSABLE_ENTITY,
+    code: 'VALID-003',
+    message:
+      '커뮤니티 가이드라인에 맞지 않는 내용이 포함되어 있어 등록할 수 없습니다.',
+  },
   KEYWORD_NOT_FOUND: {
     status: HttpStatus.UNPROCESSABLE_ENTITY,
     code: 'KEYWORD-001',

--- a/src/common/filters/global-exception.filter.spec.ts
+++ b/src/common/filters/global-exception.filter.spec.ts
@@ -1,0 +1,70 @@
+import type { ArgumentsHost } from '@nestjs/common';
+import { GlobalExceptionFilter } from './global-exception.filter';
+import { AppException } from '../errors/app.exception';
+
+function createHost() {
+  const json = jest.fn();
+  const status = jest.fn().mockReturnValue({ json });
+  const host = {
+    switchToHttp: () => ({
+      getResponse: () => ({ status }),
+      getRequest: () => ({
+        originalUrl: '/api/v1/articles',
+        url: '/api/v1/articles',
+        method: 'POST',
+      }),
+    }),
+  } as unknown as ArgumentsHost;
+
+  return { host, status, json };
+}
+
+describe('GlobalExceptionFilter', () => {
+  it('exposes moderation violation categories to clients', () => {
+    const filter = new GlobalExceptionFilter();
+    const { host, status, json } = createHost();
+    const details = {
+      surface: 'ARTICLE',
+      violatedCategories: ['폭력적 언행'],
+    };
+
+    filter.catch(
+      new AppException('CONTENT_POLICY_VIOLATION', { details }),
+      host,
+    );
+
+    expect(status).toHaveBeenCalledWith(422);
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: {
+          code: 'VALID-003',
+          message:
+            '커뮤니티 가이드라인에 맞지 않는 내용이 포함되어 있어 등록할 수 없습니다.',
+          details,
+        },
+      }),
+    );
+  });
+
+  it('does not expose generic exception details to clients', () => {
+    const filter = new GlobalExceptionFilter();
+    const { host, json } = createHost();
+
+    filter.catch(
+      new AppException('VALIDATION_INVALID_FORMAT', {
+        details: { field: 'cursor' },
+      }),
+      host,
+    );
+
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: {
+          code: 'VALID-001',
+          message:
+            '입력 형식이 올바르지 않습니다. 형식에 맞게 다시 입력해 주세요.',
+        },
+      }),
+    );
+  });
+});

--- a/src/common/filters/global-exception.filter.ts
+++ b/src/common/filters/global-exception.filter.ts
@@ -31,6 +31,7 @@ export class GlobalExceptionFilter implements ExceptionFilter {
     let code: ExternalErrorCode = 'SYS-001';
     let message = '잠시 문제가 발생했어요. 잠시 후 다시 시도해 주세요.';
     let detailsForLog: unknown;
+    let detailsForClient: unknown;
 
     // 1) AppException
     if (exception instanceof AppException) {
@@ -46,6 +47,9 @@ export class GlobalExceptionFilter implements ExceptionFilter {
         }
         if (body.details !== undefined) {
           detailsForLog = body.details;
+          if (exception.internalCode === 'CONTENT_POLICY_VIOLATION') {
+            detailsForClient = body.details;
+          }
         }
       } else if (typeof body === 'string') {
         message = body;
@@ -79,7 +83,13 @@ export class GlobalExceptionFilter implements ExceptionFilter {
     const responseBody: ApiFailResponse = {
       resultType: 'FAIL',
       success: null,
-      error: { code, message },
+      error: {
+        code,
+        message,
+        ...(detailsForClient !== undefined
+          ? { details: detailsForClient }
+          : {}),
+      },
       meta: { timestamp, path },
     };
 

--- a/src/common/moderation/content-moderation.interceptor.ts
+++ b/src/common/moderation/content-moderation.interceptor.ts
@@ -46,6 +46,7 @@ export class ContentModerationInterceptor implements NestInterceptor {
     await this.moderationService.assertAllowed({
       userId: request.user?.userId ?? null,
       surface: options.surface,
+      requestPath: request.originalUrl || request.url,
       texts: this.collectStringValues(body, options.textFields),
       imageUrls: this.collectStringValues(body, options.imageFields),
     });

--- a/src/common/moderation/content-moderation.interceptor.ts
+++ b/src/common/moderation/content-moderation.interceptor.ts
@@ -1,0 +1,75 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import type { Request } from 'express';
+import type { Observable } from 'rxjs';
+import type { AuthRequest } from '../../modules/auth/decorators/auth-user.types';
+import { ContentModerationService } from './content-moderation.service';
+import { MODERATE_CONTENT_METADATA } from './moderate-content.decorator';
+import type { ModerateContentOptions } from './content-moderation.types';
+
+type RequestBody = Record<string, unknown>;
+
+function isRequestBody(value: unknown): value is RequestBody {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+@Injectable()
+export class ContentModerationInterceptor implements NestInterceptor {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly moderationService: ContentModerationService,
+  ) {}
+
+  async intercept(
+    context: ExecutionContext,
+    next: CallHandler,
+  ): Promise<Observable<unknown>> {
+    const options = this.reflector.getAllAndOverride<ModerateContentOptions>(
+      MODERATE_CONTENT_METADATA,
+      [context.getHandler(), context.getClass()],
+    );
+
+    if (!options) {
+      return next.handle();
+    }
+
+    const request = context
+      .switchToHttp()
+      .getRequest<Request & AuthRequest & { body?: RequestBody }>();
+    const body = isRequestBody(request.body) ? request.body : {};
+
+    await this.moderationService.assertAllowed({
+      userId: request.user?.userId ?? null,
+      surface: options.surface,
+      texts: this.collectStringValues(body, options.textFields),
+      imageUrls: this.collectStringValues(body, options.imageFields),
+    });
+
+    return next.handle();
+  }
+
+  private collectStringValues(
+    body: RequestBody,
+    fields: string[] | undefined,
+  ): string[] {
+    const values: string[] = [];
+
+    for (const field of fields ?? []) {
+      const value = body[field];
+      if (typeof value === 'string') {
+        values.push(value);
+      } else if (Array.isArray(value)) {
+        values.push(
+          ...value.filter((item): item is string => typeof item === 'string'),
+        );
+      }
+    }
+
+    return values;
+  }
+}

--- a/src/common/moderation/content-moderation.module.ts
+++ b/src/common/moderation/content-moderation.module.ts
@@ -1,11 +1,12 @@
 import { Global, Module } from '@nestjs/common';
+import { PrismaModule } from '../../infra/prisma/prisma.module';
 import { S3ObjectUrlModule } from '../s3/s3-object-url.module';
 import { ContentModerationInterceptor } from './content-moderation.interceptor';
 import { ContentModerationService } from './content-moderation.service';
 
 @Global()
 @Module({
-  imports: [S3ObjectUrlModule],
+  imports: [S3ObjectUrlModule, PrismaModule],
   providers: [ContentModerationService, ContentModerationInterceptor],
   exports: [ContentModerationService, ContentModerationInterceptor],
 })

--- a/src/common/moderation/content-moderation.module.ts
+++ b/src/common/moderation/content-moderation.module.ts
@@ -1,0 +1,12 @@
+import { Global, Module } from '@nestjs/common';
+import { S3ObjectUrlModule } from '../s3/s3-object-url.module';
+import { ContentModerationInterceptor } from './content-moderation.interceptor';
+import { ContentModerationService } from './content-moderation.service';
+
+@Global()
+@Module({
+  imports: [S3ObjectUrlModule],
+  providers: [ContentModerationService, ContentModerationInterceptor],
+  exports: [ContentModerationService, ContentModerationInterceptor],
+})
+export class ContentModerationModule {}

--- a/src/common/moderation/content-moderation.service.ts
+++ b/src/common/moderation/content-moderation.service.ts
@@ -1,5 +1,8 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { ModerationDecision } from '@prisma/client';
+import { createHash } from 'crypto';
+import { PrismaService } from '../../infra/prisma/prisma.service';
 import { AppException } from '../errors/app.exception';
 import { S3ObjectUrlService } from '../s3/s3-object-url.service';
 import type { ModerateContentInput } from './content-moderation.types';
@@ -12,6 +15,8 @@ type OpenAiModerationResult = {
 };
 
 type OpenAiModerationResponse = {
+  id?: string;
+  model?: string;
   results?: OpenAiModerationResult[];
 };
 
@@ -67,6 +72,7 @@ export class ContentModerationService {
   constructor(
     private readonly configService: ConfigService,
     private readonly s3ObjectUrlService: S3ObjectUrlService,
+    private readonly prisma: PrismaService,
   ) {}
 
   async assertAllowed(input: ModerateContentInput): Promise<void> {
@@ -131,20 +137,24 @@ export class ContentModerationService {
     }
 
     const data = (await response.json()) as OpenAiModerationResponse;
-    const flagged = data.results?.find((result) => result.flagged);
+    const results = data.results ?? [];
+    const isFlagged = results.some((result) => result.flagged);
+    const violatedCategories = this.collectViolatedCategories(results);
 
-    if (!flagged) {
+    if (!isFlagged) {
       return;
     }
 
-    const categories = flagged.categories ?? {};
-    const violatedCategories = Object.entries(categories)
-      .filter(([, isViolated]) => isViolated)
-      .map(
-        ([category]) =>
-          VIOLATION_CATEGORY_LABELS[category] ??
-          (category as ModerationViolationCategory),
-      );
+    await this.recordModerationLog({
+      input,
+      model: data.model ?? model,
+      providerResponseId: data.id ?? null,
+      decision: ModerationDecision.BLOCK,
+      texts,
+      imageUrls,
+      violatedCategories,
+      categoryScores: this.collectCategoryScores(results),
+    });
 
     throw new AppException('CONTENT_POLICY_VIOLATION', {
       details: {
@@ -164,5 +174,91 @@ export class ContentModerationService {
     return (values ?? [])
       .map((value) => value.trim())
       .filter((value) => value.length > 0);
+  }
+
+  private collectViolatedCategories(
+    results: OpenAiModerationResult[],
+  ): string[] {
+    const categories = new Set<string>();
+
+    for (const result of results) {
+      for (const [category, isViolated] of Object.entries(
+        result.categories ?? {},
+      )) {
+        if (!isViolated) {
+          continue;
+        }
+        categories.add(
+          VIOLATION_CATEGORY_LABELS[category] ??
+            (category as ModerationViolationCategory),
+        );
+      }
+    }
+
+    return [...categories];
+  }
+
+  private collectCategoryScores(
+    results: OpenAiModerationResult[],
+  ): Record<string, number> | null {
+    const scores: Record<string, number> = {};
+
+    for (const result of results) {
+      for (const [category, score] of Object.entries(
+        result.category_scores ?? {},
+      )) {
+        scores[category] = Math.max(scores[category] ?? 0, score);
+      }
+    }
+
+    return Object.keys(scores).length > 0 ? scores : null;
+  }
+
+  private buildContentHash(texts: string[], imageUrls: string[]): string {
+    return createHash('sha256')
+      .update(JSON.stringify({ texts, imageUrls }))
+      .digest('hex');
+  }
+
+  private async recordModerationLog(params: {
+    input: ModerateContentInput;
+    model: string;
+    providerResponseId: string | null;
+    decision: ModerationDecision;
+    texts: string[];
+    imageUrls: string[];
+    violatedCategories: string[];
+    categoryScores: Record<string, number> | null;
+  }): Promise<void> {
+    const inputTypes = [
+      ...(params.texts.length > 0 ? ['text'] : []),
+      ...(params.imageUrls.length > 0 ? ['image'] : []),
+    ];
+
+    try {
+      await this.prisma.contentModerationLog.create({
+        data: {
+          userId: params.input.userId ? BigInt(params.input.userId) : null,
+          surface: params.input.surface,
+          targetType: params.input.targetType,
+          targetId: params.input.targetId
+            ? BigInt(params.input.targetId)
+            : null,
+          decision: params.decision,
+          provider: 'OPENAI',
+          model: params.model,
+          providerResponseId: params.providerResponseId,
+          violatedCategories: params.violatedCategories,
+          inputTypes,
+          categoryScores: params.categoryScores ?? undefined,
+          contentHash: this.buildContentHash(params.texts, params.imageUrls),
+          requestPath: params.input.requestPath ?? null,
+        },
+      });
+    } catch (error) {
+      this.logger.warn(
+        `content moderation log write failed surface=${params.input.surface} userId=${params.input.userId ?? 'N/A'}: ${String(error)}`,
+      );
+    }
   }
 }

--- a/src/common/moderation/content-moderation.service.ts
+++ b/src/common/moderation/content-moderation.service.ts
@@ -32,6 +32,12 @@ type OpenAiModerationInput =
       };
     };
 
+type ModerationCheckPayload = {
+  openAiInput: OpenAiModerationInput[];
+  texts: string[];
+  imageUrls: string[];
+};
+
 enum ModerationViolationCategory {
   Sexual = '성적 콘텐츠',
   SexualMinors = '미성년자 성적 콘텐츠',
@@ -90,53 +96,55 @@ export class ContentModerationService {
       });
     }
 
-    const moderationInput: OpenAiModerationInput[] = [
-      ...texts.map((text) => ({ type: 'text' as const, text })),
-      ...(await Promise.all(
-        imageUrls.map(async (imageUrl) => ({
-          type: 'image_url' as const,
-          image_url: {
-            url:
-              (await this.s3ObjectUrlService.toClientUrl(imageUrl)) ?? imageUrl,
-          },
-        })),
-      )),
-    ];
-
     const model = this.configService.get<string>(
       'OPENAI_MODERATION_MODEL',
       'omni-moderation-latest',
     );
 
-    let response: Response;
-    try {
-      response = await fetch(this.moderationUrl, {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
+    if (texts.length > 0) {
+      await this.assertPayloadAllowed({
+        input,
+        apiKey,
+        model,
+        payload: {
+          openAiInput: texts.map((text) => ({ type: 'text' as const, text })),
+          texts,
+          imageUrls: [],
         },
-        body: JSON.stringify({
-          model,
-          input: moderationInput,
-        }),
       });
-    } catch (error) {
-      this.logger.warn(
-        `OpenAI moderation request failed surface=${input.surface} userId=${input.userId ?? 'N/A'}: ${String(error)}`,
-      );
-      throw new AppException('SERVER_TEMPORARY_ERROR');
     }
 
-    if (!response.ok) {
-      const message = await response.text().catch(() => '');
-      this.logger.warn(
-        `OpenAI moderation rejected status=${response.status} surface=${input.surface} userId=${input.userId ?? 'N/A'} body=${message.slice(0, 300)}`,
-      );
-      throw new AppException('SERVER_TEMPORARY_ERROR');
-    }
+    for (const imageUrl of imageUrls) {
+      const clientUrl =
+        (await this.s3ObjectUrlService.toClientUrl(imageUrl)) ?? imageUrl;
 
-    const data = (await response.json()) as OpenAiModerationResponse;
+      await this.assertPayloadAllowed({
+        input,
+        apiKey,
+        model,
+        payload: {
+          openAiInput: [
+            {
+              type: 'image_url',
+              image_url: {
+                url: clientUrl,
+              },
+            },
+          ],
+          texts: [],
+          imageUrls: [imageUrl],
+        },
+      });
+    }
+  }
+
+  private async assertPayloadAllowed(params: {
+    input: ModerateContentInput;
+    apiKey: string;
+    model: string;
+    payload: ModerationCheckPayload;
+  }): Promise<void> {
+    const data = await this.requestModeration(params);
     const results = data.results ?? [];
     const isFlagged = results.some((result) => result.flagged);
     const violatedCategories = this.collectViolatedCategories(results);
@@ -146,22 +154,59 @@ export class ContentModerationService {
     }
 
     await this.recordModerationLog({
-      input,
-      model: data.model ?? model,
+      input: params.input,
+      model: data.model ?? params.model,
       providerResponseId: data.id ?? null,
       decision: ModerationDecision.BLOCK,
-      texts,
-      imageUrls,
+      texts: params.payload.texts,
+      imageUrls: params.payload.imageUrls,
       violatedCategories,
       categoryScores: this.collectCategoryScores(results),
     });
 
     throw new AppException('CONTENT_POLICY_VIOLATION', {
       details: {
-        surface: input.surface,
+        surface: params.input.surface,
         violatedCategories,
       },
     });
+  }
+
+  private async requestModeration(params: {
+    input: ModerateContentInput;
+    apiKey: string;
+    model: string;
+    payload: ModerationCheckPayload;
+  }): Promise<OpenAiModerationResponse> {
+    let response: Response;
+    try {
+      response = await fetch(this.moderationUrl, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${params.apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: params.model,
+          input: params.payload.openAiInput,
+        }),
+      });
+    } catch (error) {
+      this.logger.warn(
+        `OpenAI moderation request failed surface=${params.input.surface} userId=${params.input.userId ?? 'N/A'} inputTypes=${this.describeInputTypes(params.payload)}: ${String(error)}`,
+      );
+      throw new AppException('SERVER_TEMPORARY_ERROR');
+    }
+
+    if (!response.ok) {
+      const message = await response.text().catch(() => '');
+      this.logger.warn(
+        `OpenAI moderation rejected status=${response.status} surface=${params.input.surface} userId=${params.input.userId ?? 'N/A'} inputTypes=${this.describeInputTypes(params.payload)} body=${message.slice(0, 300)}`,
+      );
+      throw new AppException('SERVER_TEMPORARY_ERROR');
+    }
+
+    return (await response.json()) as OpenAiModerationResponse;
   }
 
   private normalizeTexts(values?: string[]): string[] {
@@ -174,6 +219,15 @@ export class ContentModerationService {
     return (values ?? [])
       .map((value) => value.trim())
       .filter((value) => value.length > 0);
+  }
+
+  private describeInputTypes(payload: ModerationCheckPayload): string {
+    return [
+      ...(payload.texts.length > 0 ? [`text:${payload.texts.length}`] : []),
+      ...(payload.imageUrls.length > 0
+        ? [`image:${payload.imageUrls.length}`]
+        : []),
+    ].join(',');
   }
 
   private collectViolatedCategories(

--- a/src/common/moderation/content-moderation.service.ts
+++ b/src/common/moderation/content-moderation.service.ts
@@ -1,0 +1,168 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { AppException } from '../errors/app.exception';
+import { S3ObjectUrlService } from '../s3/s3-object-url.service';
+import type { ModerateContentInput } from './content-moderation.types';
+
+type OpenAiModerationResult = {
+  flagged?: boolean;
+  categories?: Record<string, boolean>;
+  category_scores?: Record<string, number>;
+  category_applied_input_types?: Record<string, string[]>;
+};
+
+type OpenAiModerationResponse = {
+  results?: OpenAiModerationResult[];
+};
+
+type OpenAiModerationInput =
+  | {
+      type: 'text';
+      text: string;
+    }
+  | {
+      type: 'image_url';
+      image_url: {
+        url: string;
+      };
+    };
+
+enum ModerationViolationCategory {
+  Sexual = '성적 콘텐츠',
+  SexualMinors = '미성년자 성적 콘텐츠',
+  Harassment = '괴롭힘',
+  HarassmentThreatening = '위협적 괴롭힘',
+  Hate = '혐오 표현',
+  HateThreatening = '위협적 혐오 표현',
+  Illicit = '불법 행위',
+  IllicitViolent = '폭력적 불법 행위',
+  SelfHarm = '자해 관련 콘텐츠',
+  SelfHarmIntent = '자해 의도',
+  SelfHarmInstructions = '자해 방법 안내',
+  Violence = '폭력적 언행',
+  ViolenceGraphic = '잔혹한 폭력 콘텐츠',
+}
+
+const VIOLATION_CATEGORY_LABELS: Record<string, ModerationViolationCategory> = {
+  sexual: ModerationViolationCategory.Sexual,
+  'sexual/minors': ModerationViolationCategory.SexualMinors,
+  harassment: ModerationViolationCategory.Harassment,
+  'harassment/threatening': ModerationViolationCategory.HarassmentThreatening,
+  hate: ModerationViolationCategory.Hate,
+  'hate/threatening': ModerationViolationCategory.HateThreatening,
+  illicit: ModerationViolationCategory.Illicit,
+  'illicit/violent': ModerationViolationCategory.IllicitViolent,
+  'self-harm': ModerationViolationCategory.SelfHarm,
+  'self-harm/intent': ModerationViolationCategory.SelfHarmIntent,
+  'self-harm/instructions': ModerationViolationCategory.SelfHarmInstructions,
+  violence: ModerationViolationCategory.Violence,
+  'violence/graphic': ModerationViolationCategory.ViolenceGraphic,
+};
+
+@Injectable()
+export class ContentModerationService {
+  private readonly logger = new Logger(ContentModerationService.name);
+  private readonly moderationUrl = 'https://api.openai.com/v1/moderations';
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly s3ObjectUrlService: S3ObjectUrlService,
+  ) {}
+
+  async assertAllowed(input: ModerateContentInput): Promise<void> {
+    const texts = this.normalizeTexts(input.texts);
+    const imageUrls = this.normalizeImageUrls(input.imageUrls);
+
+    if (texts.length === 0 && imageUrls.length === 0) {
+      return;
+    }
+
+    const apiKey = this.configService.get<string>('OPENAI_API_KEY');
+    if (!apiKey) {
+      throw new AppException('SERVER_TEMPORARY_ERROR', {
+        message: '콘텐츠 검수 설정이 완료되지 않았습니다.',
+      });
+    }
+
+    const moderationInput: OpenAiModerationInput[] = [
+      ...texts.map((text) => ({ type: 'text' as const, text })),
+      ...(await Promise.all(
+        imageUrls.map(async (imageUrl) => ({
+          type: 'image_url' as const,
+          image_url: {
+            url:
+              (await this.s3ObjectUrlService.toClientUrl(imageUrl)) ?? imageUrl,
+          },
+        })),
+      )),
+    ];
+
+    const model = this.configService.get<string>(
+      'OPENAI_MODERATION_MODEL',
+      'omni-moderation-latest',
+    );
+
+    let response: Response;
+    try {
+      response = await fetch(this.moderationUrl, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          model,
+          input: moderationInput,
+        }),
+      });
+    } catch (error) {
+      this.logger.warn(
+        `OpenAI moderation request failed surface=${input.surface} userId=${input.userId ?? 'N/A'}: ${String(error)}`,
+      );
+      throw new AppException('SERVER_TEMPORARY_ERROR');
+    }
+
+    if (!response.ok) {
+      const message = await response.text().catch(() => '');
+      this.logger.warn(
+        `OpenAI moderation rejected status=${response.status} surface=${input.surface} userId=${input.userId ?? 'N/A'} body=${message.slice(0, 300)}`,
+      );
+      throw new AppException('SERVER_TEMPORARY_ERROR');
+    }
+
+    const data = (await response.json()) as OpenAiModerationResponse;
+    const flagged = data.results?.find((result) => result.flagged);
+
+    if (!flagged) {
+      return;
+    }
+
+    const categories = flagged.categories ?? {};
+    const violatedCategories = Object.entries(categories)
+      .filter(([, isViolated]) => isViolated)
+      .map(
+        ([category]) =>
+          VIOLATION_CATEGORY_LABELS[category] ??
+          (category as ModerationViolationCategory),
+      );
+
+    throw new AppException('CONTENT_POLICY_VIOLATION', {
+      details: {
+        surface: input.surface,
+        violatedCategories,
+      },
+    });
+  }
+
+  private normalizeTexts(values?: string[]): string[] {
+    return (values ?? [])
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0);
+  }
+
+  private normalizeImageUrls(values?: string[]): string[] {
+    return (values ?? [])
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0);
+  }
+}

--- a/src/common/moderation/content-moderation.types.ts
+++ b/src/common/moderation/content-moderation.types.ts
@@ -1,0 +1,19 @@
+export type ModerationSurface =
+  | 'ARTICLE'
+  | 'COMMENT'
+  | 'USER_PROFILE'
+  | 'CLUB'
+  | 'CHAT';
+
+export type ModerateContentOptions = {
+  surface: ModerationSurface;
+  textFields?: string[];
+  imageFields?: string[];
+};
+
+export type ModerateContentInput = {
+  userId?: number | null;
+  surface: ModerationSurface;
+  texts?: string[];
+  imageUrls?: string[];
+};

--- a/src/common/moderation/content-moderation.types.ts
+++ b/src/common/moderation/content-moderation.types.ts
@@ -1,9 +1,4 @@
-export type ModerationSurface =
-  | 'ARTICLE'
-  | 'COMMENT'
-  | 'USER_PROFILE'
-  | 'CLUB'
-  | 'CHAT';
+import type { ModerationSurface, ModerationTargetType } from '@prisma/client';
 
 export type ModerateContentOptions = {
   surface: ModerationSurface;
@@ -14,6 +9,9 @@ export type ModerateContentOptions = {
 export type ModerateContentInput = {
   userId?: number | null;
   surface: ModerationSurface;
+  targetType?: ModerationTargetType;
+  targetId?: number | null;
+  requestPath?: string | null;
   texts?: string[];
   imageUrls?: string[];
 };

--- a/src/common/moderation/moderate-content.decorator.ts
+++ b/src/common/moderation/moderate-content.decorator.ts
@@ -1,0 +1,8 @@
+import { SetMetadata } from '@nestjs/common';
+import type { ModerateContentOptions } from './content-moderation.types';
+
+export const MODERATE_CONTENT_METADATA = 'moderate_content_options';
+
+export function ModerateContent(options: ModerateContentOptions) {
+  return SetMetadata(MODERATE_CONTENT_METADATA, options);
+}

--- a/src/config/env.schema.ts
+++ b/src/config/env.schema.ts
@@ -58,6 +58,8 @@ export const envSchema = z.object({
   FIREBASE_PROJECT_ID: z.string().min(1).optional(),
   FIREBASE_CLIENT_EMAIL: z.string().email().optional(),
   FIREBASE_PRIVATE_KEY: z.string().min(1).optional(),
+  OPENAI_API_KEY: z.string().min(1).optional(),
+  OPENAI_MODERATION_MODEL: z.string().min(1).default('omni-moderation-latest'),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ import { ResponseInterceptor } from './common/interceptors/response.interceptor'
 import { AppException } from './common/errors/app.exception';
 import { setupSwagger } from './swagger';
 import { S3ObjectUrlService } from './common/s3/s3-object-url.service';
+import { ContentModerationInterceptor } from './common/moderation/content-moderation.interceptor';
 
 import { SocketIoAdapter } from './infra/websocket/socket-io.adapter';
 
@@ -85,6 +86,7 @@ async function bootstrap() {
   );
 
   app.useGlobalInterceptors(
+    app.get(ContentModerationInterceptor),
     new ResponseInterceptor(app.get(S3ObjectUrlService)),
   );
   app.useGlobalFilters(new GlobalExceptionFilter(logger));

--- a/src/modules/app/app.module.ts
+++ b/src/modules/app/app.module.ts
@@ -19,6 +19,7 @@ import { WebsocketCommonModule } from 'src/infra/websocket/websocket-common.modu
 import { ArticleModule } from '../article/article.module';
 import { CommentModule } from '../comment/comment.module';
 import { S3ObjectUrlModule } from 'src/common/s3/s3-object-url.module';
+import { ContentModerationModule } from '../../common/moderation/content-moderation.module';
 
 @Module({
   imports: [
@@ -38,6 +39,7 @@ import { S3ObjectUrlModule } from 'src/common/s3/s3-object-url.module';
     }),
     EventEmitterModule.forRoot(),
     S3ObjectUrlModule,
+    ContentModerationModule,
     HealthModule,
     PrismaModule,
     WebsocketCommonModule,

--- a/src/modules/article/controllers/article.controller.ts
+++ b/src/modules/article/controllers/article.controller.ts
@@ -35,6 +35,7 @@ import {
 import { CreateArticleDto } from '../dtos/create-article.dto';
 import { ListArticlesQueryDto } from '../dtos/list-articles-query.dto';
 import { UpdateArticleDto } from '../dtos/update-article.dto';
+import { ModerateContent } from '../../../common/moderation/moderate-content.decorator';
 
 @ApiBearerAuth('access-token')
 @Controller('clubs/:clubId/articles')
@@ -126,6 +127,11 @@ export class ArticleController {
   @ApiOkResponse({ type: ArticleDto })
   @Post()
   @UseGuards(AccessTokenGuard)
+  @ModerateContent({
+    surface: 'ARTICLE',
+    textFields: ['title', 'contents'],
+    imageFields: ['photoUrls'],
+  })
   createArticle(
     @RequiredUserId() userId: number,
     @Param('clubId', new ParsePositiveIntPipe()) clubId: number,
@@ -141,6 +147,11 @@ export class ArticleController {
   @ApiOkResponse({ type: UpdateArticleResponseDto })
   @Patch(':articleId')
   @UseGuards(AccessTokenGuard)
+  @ModerateContent({
+    surface: 'ARTICLE',
+    textFields: ['title', 'contents'],
+    imageFields: ['photoUrls'],
+  })
   updateArticle(
     @RequiredUserId() userId: number,
     @Param('clubId', new ParsePositiveIntPipe()) clubId: number,

--- a/src/modules/chat/services/socket/chat-socket.service.spec.ts
+++ b/src/modules/chat/services/socket/chat-socket.service.spec.ts
@@ -28,6 +28,7 @@ describe('ChatSocketService', () => {
   };
   const chatMediaServiceMock: Partial<ChatMediaService> = {
     toClientUrl: jest.fn(),
+    normalizeChatMediaRef: jest.fn(),
   };
   const notificationServiceMock: Partial<NotificationService> = {
     createNotification: jest.fn(),

--- a/src/modules/club/controllers/club/club.controller.ts
+++ b/src/modules/club/controllers/club/club.controller.ts
@@ -48,6 +48,7 @@ import { RecentClubSearchService } from '../../services/club/recent-club-search.
 import { AccessTokenGuard } from '../../../auth/guards/access-token.guard';
 import { RequiredUserId } from '../../../auth/decorators';
 import { ParsePositiveIntPipe } from '../../../../common/pipes/parse-positive-int.pipe';
+import { ModerateContent } from '../../../../common/moderation/moderate-content.decorator';
 
 @ApiTags('Club')
 @Controller('clubs')
@@ -61,6 +62,11 @@ export class ClubController {
 
   @Post()
   @UseGuards(AccessTokenGuard)
+  @ModerateContent({
+    surface: 'CLUB',
+    textFields: ['name', 'introText'],
+    imageFields: ['thumbnailUrl', 'imageUrls'],
+  })
   @ApiBearerAuth('access-token')
   @ApiOperation({
     summary: '클럽 생성',
@@ -415,6 +421,10 @@ export class ClubController {
 
   @Patch(':clubId')
   @UseGuards(AccessTokenGuard)
+  @ModerateContent({
+    surface: 'CLUB',
+    textFields: ['name', 'introText'],
+  })
   @ApiBearerAuth('access-token')
   @ApiOperation({
     summary: '클럽 정보 부분 수정',

--- a/src/modules/comment/controllers/comment.controller.ts
+++ b/src/modules/comment/controllers/comment.controller.ts
@@ -34,6 +34,7 @@ import {
 } from '../dtos/comment.dto';
 import { AccessTokenGuard } from '../../auth/guards/access-token.guard';
 import { RequiredUserId } from '../../auth/decorators';
+import { ModerateContent } from '../../../common/moderation/moderate-content.decorator';
 
 type ApiSuccessExample<T> = {
   resultType: 'SUCCESS';
@@ -181,6 +182,10 @@ export class CommentController {
   })
   @ApiUnprocessableEntityResponse({ description: '입력값 형식 오류' })
   @ApiBadRequestResponse({ description: '대댓글까지만 작성 가능' })
+  @ModerateContent({
+    surface: 'COMMENT',
+    textFields: ['contents'],
+  })
   async createComment(
     @RequiredUserId() userId: number,
     @Param('clubId', new ParsePositiveIntPipe()) clubId: number,

--- a/src/modules/user/controllers/user/user.controller.ts
+++ b/src/modules/user/controllers/user/user.controller.ts
@@ -35,6 +35,7 @@ import { UserPublicProfileResponseDto } from '../../dtos/user-public-profile-res
 import { ActiveUsersResponseDto } from '../../dtos/user-active-response.dto';
 import { UserService } from '../../services/user/user.service';
 import { UserActivityService } from '../../services/user/user-activity.service';
+import { ModerateContent } from '../../../../common/moderation/moderate-content.decorator';
 
 @ApiTags('User')
 @ApiBearerAuth('access-token')
@@ -164,6 +165,11 @@ export class UserController {
   @UseGuards(AccessTokenGuard)
   @ApiOperation({ summary: 'Update my profile' })
   @ApiOkResponse({ type: UserMeResponseDto })
+  @ModerateContent({
+    surface: 'USER_PROFILE',
+    textFields: ['nickname', 'introText'],
+    imageFields: ['profileImageUrl'],
+  })
   updateMe(
     @CurrentUser('userId') userId: number | null,
     @Body() body: UserProfileUpdateRequestDto,


### PR DESCRIPTION
## 이슈 번호
close #296 

## 주요 변경사항
- Open AI를 이용한 Moderation 구현
- 적용 분야 (게시글 작성 , 게시글 댓글 작성, 유저 프로필 수정, 동호회 생성)
- 필터링 될 경우, 필터링 관련 카테고리 응답값으로 반환. FE에서 받아 에러메세지를 쉽게 띄울수 있도록


## 테스트 결과 (스크린샷)
<img width="1512" height="982" alt="스크린샷 2026-07-16 오후 2 15 34" src="https://github.com/user-attachments/assets/d14ef4f0-9be0-4b58-9bfd-884f4fff2ade" />

> 필터링 예시 text - "너같은 병신은 걍 죽어버려"

<img width="1512" height="982" alt="스크린샷 2026-07-16 오후 2 16 26" src="https://github.com/user-attachments/assets/20540ce2-4ec1-43ac-8aa1-e42b7e29dd13" />

> moderation log 저장하는 테이블 생성 , 추가적으로 구체적인 내용은 암호화가 되어있어 접근하지 못하고 , score와 reqeust path만 저장해두는 방식으로 구현.

## 참고 및 개선사항
- 현재 환경변수 주입을 어떻게 하고있는지 알아본후, OpenAI API키를 Nestjs에도 주입해줘야할것같습니다.
