### PR TITLE
fix: 회원 탈퇴 시 콘텐츠를 보존하고 사용자 정보를 삭제

### DIFF
--- a/src/modules/article/dtos/article.dto.ts
+++ b/src/modules/article/dtos/article.dto.ts
@@ -3,16 +3,17 @@ import { ArticleCategory, ClubAuthority } from '@prisma/client';
 import { IsBoolean } from 'class-validator';
 
 export class ArticleAuthorDto {
-  @ApiProperty({ example: 42 })
-  userId!: number;
+  @ApiProperty({ example: 42, nullable: true })
+  userId!: number | null;
 
   @ApiProperty({ example: '달콤한목소리' })
   nickname!: string;
 
   @ApiProperty({
     example: 'https://cdn.example.com/profile/42.jpg',
+    nullable: true,
   })
-  profileImageUrl!: string;
+  profileImageUrl!: string | null;
 }
 
 export class ArticleDetailAuthorDto extends ArticleAuthorDto {

--- a/src/modules/article/services/article.service.ts
+++ b/src/modules/article/services/article.service.ts
@@ -72,13 +72,7 @@ export class ArticleService {
         likeCount: article.likes,
         commentCount: article._count.comments,
         thumbnailUrl: firstPhoto ? firstPhoto.photoUrl : null,
-        author: article.user
-          ? {
-              userId: Number(article.user.id),
-              nickname: article.user.nickname,
-              profileImageUrl: article.user.profileImageUrl,
-            }
-          : null,
+        author: this.toArticleAuthor(article.user),
         createdAt: article.createdAt.toISOString(),
       } as ArticleListItemDto;
     });
@@ -387,13 +381,7 @@ export class ArticleService {
       viewCount: article.view,
       likeCount: article.likes,
       commentCount: article._count.comments,
-      author: article.user
-        ? {
-            userId: Number(article.user.id),
-            nickname: article.user.nickname,
-            profileImageUrl: article.user.profileImageUrl,
-          }
-        : null,
+      author: this.toArticleAuthor(article.user),
       photos: article.articlePhotos.map((photo) => ({
         photoId: Number(photo.id),
         photoUrl: photo.photoUrl,
@@ -475,12 +463,33 @@ export class ArticleService {
     }));
   }
 
+  private toArticleAuthor(
+    user: { id: bigint; nickname: string; profileImageUrl: string } | null,
+  ): ArticleListItemDto['author'] {
+    return user
+      ? {
+          userId: Number(user.id),
+          nickname: user.nickname,
+          profileImageUrl: user.profileImageUrl,
+        }
+      : {
+          userId: null,
+          nickname: '탈퇴한 사용자',
+          profileImageUrl: null,
+        };
+  }
+
   private toDetailAuthor(
     user: { id: bigint; nickname: string; profileImageUrl: string } | null,
     authorAuthorities: ArticleDetailResult['authorAuthorities'],
   ): ArticleDetailAuthorDto | null {
     if (!user) {
-      return null;
+      return {
+        userId: null,
+        nickname: '탈퇴한 사용자',
+        profileImageUrl: null,
+        authority: ClubAuthority.GENERAL,
+      };
     }
 
     return {

--- a/src/modules/chat/dtos/message.dto.ts
+++ b/src/modules/chat/dtos/message.dto.ts
@@ -85,7 +85,7 @@ export class ListMessagesQueryDto {
 }
 
 export type MessageSender = {
-  userId: number;
+  userId: number | null;
   nickname: string;
   profileImageUrl: string | null;
   isWithdrawn: boolean;
@@ -97,7 +97,7 @@ export type MessageItem = {
   text: string | null;
   mediaUrl: string | null;
   durationSec: number | null;
-  senderUserId: number;
+  senderUserId: number | null;
   sentAt: string;
   readAt: string | null;
   isMine: boolean;

--- a/src/modules/chat/repositories/message.repository.ts
+++ b/src/modules/chat/repositories/message.repository.ts
@@ -17,7 +17,7 @@ export type MessageWithMedia = {
   id: bigint;
   sentAt: Date;
   readAt: Date | null;
-  sentById: bigint;
+  sentById: bigint | null;
   senderNickname: string | null;
   senderProfileImageUrl: string | null;
   senderStatus: ActiveStatus | null;
@@ -195,13 +195,13 @@ export class MessageRepository {
       },
     });
 
-    // participant.userId가 null인 경우(hard delete)만 0n fallback. soft-delete 탈퇴 유저는 userId가 유지되며
-    // 응답 단계에서 isWithdrawn으로 '탈퇴한 사용자' 표시를 처리한다. (withdrawn.util)
+    // hard delete된 회원은 participant.userId가 null이다. 참여자와 메시지는 보존하고
+    // 응답 단계에서 '탈퇴한 사용자'로 표시한다. (withdrawn.util)
     return rows.map((r) => ({
       id: r.id,
       sentAt: r.sentAt,
       readAt: r.readAt,
-      sentById: r.participant.userId ?? 0n,
+      sentById: r.participant.userId,
       senderNickname: r.participant.user?.nickname ?? null,
       senderProfileImageUrl: r.participant.user?.profileImageUrl ?? null,
       senderStatus: r.participant.user?.status ?? null,

--- a/src/modules/chat/services/message/message.service.ts
+++ b/src/modules/chat/services/message/message.service.ts
@@ -141,7 +141,8 @@ export class MessageService {
       page.map(async (msg) => {
         const media = msg.chatMedia[0] ?? null;
         const isSystem = (media?.type ?? 'TEXT') === 'SYSTEM';
-        const isMine = !isSystem && msg.sentById === me;
+        const isMine =
+          !isSystem && msg.sentById !== null && msg.sentById === me;
         const mediaUrl = await this.chatMediaService.toClientUrl(
           media?.url ?? null,
         );
@@ -156,7 +157,7 @@ export class MessageService {
           text: media?.text ?? null,
           mediaUrl,
           durationSec: media?.durationSec ?? null,
-          senderUserId: Number(msg.sentById),
+          senderUserId: msg.sentById === null ? null : Number(msg.sentById),
           sentAt: msg.sentAt.toISOString(),
           readAt,
           isMine,
@@ -211,7 +212,8 @@ export class MessageService {
       page.map(async (msg) => {
         const media = msg.chatMedia[0] ?? null;
         const isSystem = (media?.type ?? 'TEXT') === 'SYSTEM';
-        const isMine = !isSystem && msg.sentById === me;
+        const isMine =
+          !isSystem && msg.sentById !== null && msg.sentById === me;
         const mediaUrl = await this.chatMediaService.toClientUrl(
           media?.url ?? null,
         );
@@ -223,7 +225,7 @@ export class MessageService {
         // 읽은 인원수(발신자 제외) = lastReadAt >= sentAt 인 다른 활성 참여자 수
         const readCount = members.filter(
           (p) =>
-            p.userId !== msg.sentById &&
+            (msg.sentById === null || p.userId !== msg.sentById) &&
             p.lastReadAt != null &&
             p.lastReadAt >= msg.sentAt,
         ).length;
@@ -234,7 +236,7 @@ export class MessageService {
           text: media?.text ?? null,
           mediaUrl,
           durationSec: media?.durationSec ?? null,
-          senderUserId: Number(msg.sentById),
+          senderUserId: msg.sentById === null ? null : Number(msg.sentById),
           sentAt: msg.sentAt.toISOString(),
           readAt: null,
           isMine,
@@ -243,7 +245,7 @@ export class MessageService {
           sender: isSystem
             ? null
             : {
-                userId: Number(msg.sentById),
+                userId: msg.sentById === null ? null : Number(msg.sentById),
                 nickname: senderIdentity.nickname,
                 profileImageUrl: senderIdentity.profileImageUrl,
                 isWithdrawn: senderIdentity.isWithdrawn,

--- a/src/modules/comment/dtos/comment.dto.ts
+++ b/src/modules/comment/dtos/comment.dto.ts
@@ -118,14 +118,17 @@ export class ListCommentsQueryDto {
 }
 
 export class CommentListAuthorDto {
-  @ApiProperty({ example: 7 })
-  userId!: number;
+  @ApiProperty({ example: 7, nullable: true })
+  userId!: number | null;
 
   @ApiProperty({ example: '보이스마스터' })
   nickname!: string;
 
-  @ApiProperty({ example: 'https://cdn.example.com/profile/7.jpg' })
-  profileImageUrl!: string;
+  @ApiProperty({
+    example: 'https://cdn.example.com/profile/7.jpg',
+    nullable: true,
+  })
+  profileImageUrl!: string | null;
 
   @ApiProperty({ enum: ClubAuthority, example: ClubAuthority.HOST })
   authority!: ClubAuthority;

--- a/src/modules/comment/services/comment.service.ts
+++ b/src/modules/comment/services/comment.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { NotificationType } from '@prisma/client';
+import { ClubAuthority, NotificationType } from '@prisma/client';
 import { AppException } from '../../../common/errors/app.exception';
 import { ClubRepository } from '../../club/repositories/club.repository';
 import { NotificationService } from '../../notification/services/notification.service';
@@ -327,7 +327,12 @@ export class CommentService {
     user: CommentListEntity['user'],
   ): CommentListAuthorDto | null {
     if (!user) {
-      return null;
+      return {
+        userId: null,
+        nickname: '탈퇴한 사용자',
+        profileImageUrl: null,
+        authority: ClubAuthority.GENERAL,
+      };
     }
 
     const clubUser = user.clubUsers[0];

--- a/src/modules/user/repositories/user.repository.ts
+++ b/src/modules/user/repositories/user.repository.ts
@@ -730,7 +730,6 @@ export class UserRepository {
   async deleteAccount(userId: number) {
     const deletedAt = new Date();
     const userBigIntId = BigInt(userId);
-    const anonymizedEmail = `deleted-user-${userId}@deleted.local`;
 
     return this.prismaService.$transaction(async (tx) => {
       const user = await tx.user.findFirst({
@@ -745,19 +744,6 @@ export class UserRepository {
       if (!user) {
         return { count: 0 };
       }
-
-      const articleIds = (
-        await tx.article.findMany({
-          where: { userId: userBigIntId },
-          select: { id: true },
-        })
-      ).map((article) => article.id);
-      const participantIds = (
-        await tx.chatParticipant.findMany({
-          where: { userId: userBigIntId },
-          select: { id: true },
-        })
-      ).map((participant) => participant.id);
 
       await tx.refreshToken.deleteMany({ where: { userId: userBigIntId } });
       await tx.pushDeviceToken.deleteMany({ where: { userId: userBigIntId } });
@@ -820,79 +806,23 @@ export class UserRepository {
       });
       await tx.clubUser.deleteMany({ where: { userId: userBigIntId } });
 
-      if (articleIds.length > 0) {
-        await tx.articlePhoto.updateMany({
-          where: { articleId: { in: articleIds } },
-          data: {
-            photoUrl: '',
-            deletedAt,
-          },
-        });
-      }
-      await tx.comment.updateMany({
-        where: { userId: userBigIntId },
-        data: {
-          contents: '',
-          userId: null,
-          deletedAt,
-        },
-      });
-      await tx.article.updateMany({
-        where: { userId: userBigIntId },
-        data: {
-          title: '삭제된 게시물',
-          contents: '',
-          userId: null,
-          deletedAt,
-        },
-      });
-
-      if (participantIds.length > 0) {
-        await tx.chatMedia.deleteMany({
-          where: {
-            message: {
-              participantId: { in: participantIds },
-            },
-          },
-        });
-        await tx.chatMessage.updateMany({
-          where: { participantId: { in: participantIds } },
-          data: {
-            deletedAt,
-          },
-        });
-      }
-      await tx.chatRoom.updateMany({
-        where: { userId: userBigIntId },
-        data: { userId: null },
-      });
+      // 작성한 게시글/댓글과 채팅 메시지는 탈퇴 후에도 보존한다.
+      // 작성자 FK 역시 익명화된 User를 가리키도록 유지하여 조회 시
+      // '탈퇴한 사용자'로 표시하면서 대화와 콘텐츠의 맥락을 잃지 않게 한다.
       await tx.chatParticipant.updateMany({
         where: { userId: userBigIntId },
         data: {
-          userId: null,
           endedAt: deletedAt,
         },
       });
 
-      const result = await tx.user.updateMany({
+      // 콘텐츠의 FK는 ON DELETE SET NULL, 계정 종속 데이터는 ON DELETE CASCADE로
+      // 정리된다. User 행 자체를 제거해 개인정보와 내부 사용자 ID를 남기지 않는다.
+      const result = await tx.user.deleteMany({
         where: {
           id: userBigIntId,
           deletedAt: null,
           status: ActiveStatus.ACTIVE,
-        },
-        data: {
-          email: anonymizedEmail,
-          nickname: '탈퇴한 사용자',
-          age: 0,
-          code: null,
-          introText: '',
-          introVoiceUrl: '',
-          profileImageUrl: '',
-          idealVoiceUrl: null,
-          provider: null,
-          providerUserId: null,
-          status: ActiveStatus.INACTIVE,
-          deletedAt,
         },
       });
 


### PR DESCRIPTION
close #321 
## 변경 사항

- 회원 탈퇴 시 User 행을 익명화하여 남기는 대신 hard delete하도록 변경
- 게시글, 댓글, 채팅 참여자의 사용자 FK는 기존 `ON DELETE SET NULL`을 사용해 콘텐츠 보존
- 탈퇴 회원이 작성한 게시글과 댓글은 본문 및 첨부 콘텐츠 유지
- 채팅 메시지와 미디어를 유지하고, 탈퇴 회원의 발신자 ID는 `null`로 반환
- 작성자 정보가 없는 게시글·댓글·채팅은 `탈퇴한 사용자`와 빈 프로필로 응답하도록
- 채팅 참여 상태는 탈퇴 시점에 종료 처리

## 영향

- `DELETE /users/me` 호출 시 User 데이터가 완전히 삭제
- 기존 콘텐츠는 계속 조회할 수 있으며 작성자는 탈퇴 사용자로 표시
- 게시글·댓글 작성자 ID와 채팅 발신자 ID는 탈퇴 후 `null`로