### PR TITLE
[Fix] [EUM-142] 이상형 키워드 저장 에러 해결 및 club 이미지 수정 필드 추가

### DIFF
--- a/src/modules/club/controllers/club/club.controller.spec.ts
+++ b/src/modules/club/controllers/club/club.controller.spec.ts
@@ -175,6 +175,8 @@ describe('ClubController', () => {
       category: ClubCategory.HOBBY,
       introText: '더 즐겁게 모여요',
       introVoice: null,
+      thumbnailUrl: 'https://cdn.example.com/clubs/12/thumbnail.jpg',
+      imageUrls: ['https://cdn.example.com/clubs/12/images/1.jpg'],
       capacity: 60,
       updatedAt: '2026-05-01T20:25:00.000Z',
     };

--- a/src/modules/club/controllers/club/club.controller.ts
+++ b/src/modules/club/controllers/club/club.controller.ts
@@ -424,6 +424,7 @@ export class ClubController {
   @ModerateContent({
     surface: 'CLUB',
     textFields: ['name', 'introText'],
+    imageFields: ['thumbnailUrl', 'imageUrls'],
   })
   @ApiBearerAuth('access-token')
   @ApiOperation({
@@ -452,6 +453,17 @@ export class ClubController {
           introVoice: null,
         },
       },
+      updateImages: {
+        summary: '사진 수정',
+        value: {
+          thumbnailUrl:
+            's3://eum-voice-staging/images/42/club/thumbnail-v2.jpg',
+          imageUrls: [
+            's3://eum-voice-staging/images/42/club/1-v2.jpg',
+            's3://eum-voice-staging/images/42/club/2-v2.jpg',
+          ],
+        },
+      },
     },
   })
   @ApiOkResponse({
@@ -466,6 +478,11 @@ export class ClubController {
             category: 'HOBBY',
             introText: '더 즐겁게 모여요',
             introVoice: null,
+            thumbnailUrl: 'https://cdn.example.com/clubs/12/thumbnail-v2.jpg',
+            imageUrls: [
+              'https://cdn.example.com/clubs/12/images/1-v2.jpg',
+              'https://cdn.example.com/clubs/12/images/2-v2.jpg',
+            ],
             capacity: 60,
             updatedAt: '2026-05-01T20:25:00.000Z',
           },

--- a/src/modules/club/dtos/club.dto.ts
+++ b/src/modules/club/dtos/club.dto.ts
@@ -229,6 +229,31 @@ export class UpdateClubRequestDto {
   @IsOptional()
   @IsEnum(ClubCategory)
   category?: ClubCategory;
+
+  @ApiPropertyOptional({
+    description: '클럽 대표 썸네일 이미지 S3 참조',
+    example: 's3://eum-voice-staging/images/42/club/thumbnail-v2.jpg',
+  })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  thumbnailUrl?: string;
+
+  @ApiPropertyOptional({
+    description:
+      '클럽 추가 이미지 S3 참조 목록. 제공하면 기존 추가 이미지 목록을 전체 교체합니다. 빈 배열이면 추가 이미지를 모두 제거합니다.',
+    example: [
+      's3://eum-voice-staging/images/42/club/1-v2.jpg',
+      's3://eum-voice-staging/images/42/club/2-v2.jpg',
+    ],
+    isArray: true,
+    maxItems: 4,
+  })
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(4)
+  @IsString({ each: true })
+  imageUrls?: string[];
 }
 
 export class UpdateClubResponseDto {
@@ -258,6 +283,22 @@ export class UpdateClubResponseDto {
     nullable: true,
   })
   introVoice: string | null;
+
+  @ApiProperty({
+    description: '클럽 대표 썸네일 이미지 URL',
+    example: 'https://cdn.example.com/clubs/12/thumbnail.jpg',
+    nullable: true,
+  })
+  thumbnailUrl: string | null;
+
+  @ApiProperty({
+    description: '클럽 추가 이미지 URL 목록',
+    example: [
+      'https://cdn.example.com/clubs/12/images/1.jpg',
+      'https://cdn.example.com/clubs/12/images/2.jpg',
+    ],
+  })
+  imageUrls: string[];
 
   @ApiProperty({ description: '정원', example: 60 })
   capacity: number;

--- a/src/modules/club/repositories/club.repository.ts
+++ b/src/modules/club/repositories/club.repository.ts
@@ -216,6 +216,22 @@ export class ClubRepository {
         });
       }
 
+      if (params.imageUrls !== undefined) {
+        await tx.clubImage.deleteMany({
+          where: { clubId: params.clubId },
+        });
+
+        if (params.imageUrls.length > 0) {
+          await tx.clubImage.createMany({
+            data: params.imageUrls.map((imageUrl, index) => ({
+              clubId: params.clubId,
+              imageUrl,
+              sortOrder: index + 1,
+            })),
+          });
+        }
+      }
+
       if (vibeVectorLiteral !== undefined) {
         await tx.$executeRaw`
           UPDATE "Club"

--- a/src/modules/club/repositories/club.repository.types.ts
+++ b/src/modules/club/repositories/club.repository.types.ts
@@ -116,10 +116,21 @@ export const UPDATE_CLUB_SELECT = {
   id: true,
   name: true,
   category: true,
+  thumbnailUrl: true,
   introVoiceUrl: true,
   introText: true,
   capacity: true,
   updatedAt: true,
+  clubImages: {
+    where: { deletedAt: null },
+    select: {
+      imageUrl: true,
+      sortOrder: true,
+    },
+    orderBy: {
+      sortOrder: 'asc',
+    },
+  },
 } satisfies Prisma.ClubSelect;
 
 export type UpdatedClubRow = Prisma.ClubGetPayload<{
@@ -129,6 +140,7 @@ export type UpdatedClubRow = Prisma.ClubGetPayload<{
 export interface UpdateClubRepositoryParams {
   clubId: bigint;
   data: Prisma.ClubUpdateInput;
+  imageUrls?: string[];
   vibeVector?: number[];
 }
 

--- a/src/modules/club/services/club/club.service.spec.ts
+++ b/src/modules/club/services/club/club.service.spec.ts
@@ -429,6 +429,13 @@ describe('ClubService', () => {
       category: ClubCategory.HOBBY,
       introVoiceUrl: 'https://cdn.example.com/voice/12.mp3',
       introText: '등산으로 친해져요',
+      thumbnailUrl: 'https://cdn.example.com/clubs/12/thumbnail.jpg',
+      clubImages: [
+        {
+          imageUrl: 'https://cdn.example.com/clubs/12/images/1.jpg',
+          sortOrder: 1,
+        },
+      ],
       capacity: 30,
       updatedAt: new Date('2026-05-01T20:25:00.000Z'),
     });
@@ -441,6 +448,8 @@ describe('ClubService', () => {
       category: ClubCategory.HOBBY,
       introVoice: 'https://cdn.example.com/voice/12.mp3',
       introText: '등산으로 친해져요',
+      thumbnailUrl: 'https://cdn.example.com/clubs/12/thumbnail.jpg',
+      imageUrls: ['https://cdn.example.com/clubs/12/images/1.jpg'],
       capacity: 30,
       updatedAt: '2026-05-01T20:25:00.000Z',
     });
@@ -468,6 +477,8 @@ describe('ClubService', () => {
       category: ClubCategory.HOBBY,
       introVoiceUrl: null,
       introText: '더 즐겁게 모여요',
+      thumbnailUrl: 'https://cdn.example.com/clubs/12/thumbnail.jpg',
+      clubImages: [],
       capacity: 60,
       updatedAt: null,
     });
@@ -504,6 +515,8 @@ describe('ClubService', () => {
       category: ClubCategory.HOBBY,
       introVoiceUrl: null,
       introText: '등산으로 친해져요',
+      thumbnailUrl: 'https://cdn.example.com/clubs/12/thumbnail.jpg',
+      clubImages: [],
       capacity: 30,
       updatedAt: null,
     });
@@ -528,6 +541,8 @@ describe('ClubService', () => {
       category: ClubCategory.HOBBY,
       introVoiceUrl: null,
       introText: '등산으로 친해져요',
+      thumbnailUrl: 'https://cdn.example.com/clubs/12/thumbnail.jpg',
+      clubImages: [],
       capacity: 30,
       updatedAt: null,
     });
@@ -537,6 +552,61 @@ describe('ClubService', () => {
     expect(updateClub).toHaveBeenCalledWith({
       clubId: 12n,
       data: {},
+    });
+  });
+
+  it('호스트가 클럽 사진을 수정하면 썸네일과 추가 이미지 목록을 교체한다', async () => {
+    findById.mockResolvedValue({
+      id: 12n,
+      hostId: 7n,
+      deletedAt: null,
+    });
+    updateClub.mockResolvedValue({
+      id: 12n,
+      name: '등산 러버즈',
+      category: ClubCategory.HOBBY,
+      introVoiceUrl: null,
+      introText: '등산으로 친해져요',
+      thumbnailUrl: 's3://bucket/images/7/club/thumbnail-v2.jpg',
+      clubImages: [
+        {
+          imageUrl: 's3://bucket/images/7/club/1-v2.jpg',
+          sortOrder: 1,
+        },
+        {
+          imageUrl: 's3://bucket/images/7/club/2-v2.jpg',
+          sortOrder: 2,
+        },
+      ],
+      capacity: 30,
+      updatedAt: null,
+    });
+
+    await expect(
+      service.updateClub(7, 12, {
+        thumbnailUrl: 's3://bucket/images/7/club/thumbnail-v2.jpg',
+        imageUrls: [
+          's3://bucket/images/7/club/1-v2.jpg',
+          's3://bucket/images/7/club/2-v2.jpg',
+        ],
+      }),
+    ).resolves.toMatchObject({
+      thumbnailUrl: 's3://bucket/images/7/club/thumbnail-v2.jpg',
+      imageUrls: [
+        's3://bucket/images/7/club/1-v2.jpg',
+        's3://bucket/images/7/club/2-v2.jpg',
+      ],
+    });
+
+    expect(updateClub).toHaveBeenCalledWith({
+      clubId: 12n,
+      data: {
+        thumbnailUrl: 's3://bucket/images/7/club/thumbnail-v2.jpg',
+      },
+      imageUrls: [
+        's3://bucket/images/7/club/1-v2.jpg',
+        's3://bucket/images/7/club/2-v2.jpg',
+      ],
     });
   });
 

--- a/src/modules/club/services/club/club.service.ts
+++ b/src/modules/club/services/club/club.service.ts
@@ -204,6 +204,13 @@ export class ClubService {
     const updated = await this.clubRepository.updateClub({
       clubId: clubKey,
       data,
+      ...(dto.imageUrls !== undefined
+        ? {
+            imageUrls: dto.imageUrls.map((imageUrl) =>
+              normalizeS3ObjectRef(imageUrl),
+            ),
+          }
+        : {}),
       ...(analysis ? { vibeVector: analysis.vibeVector } : {}),
     });
 
@@ -333,6 +340,9 @@ export class ClubService {
     }
     if (dto.capacity !== undefined) data.capacity = dto.capacity;
     if (dto.category !== undefined) data.category = dto.category;
+    if (dto.thumbnailUrl !== undefined) {
+      data.thumbnailUrl = normalizeS3ObjectRef(dto.thumbnailUrl);
+    }
 
     return data;
   }
@@ -344,6 +354,8 @@ export class ClubService {
       category: row.category,
       introText: row.introText,
       introVoice: row.introVoiceUrl,
+      thumbnailUrl: row.thumbnailUrl,
+      imageUrls: row.clubImages.map((image) => image.imageUrl),
       capacity: row.capacity,
       updatedAt: row.updatedAt?.toISOString() ?? null,
     };

--- a/src/modules/user/controllers/user/user.controller.ts
+++ b/src/modules/user/controllers/user/user.controller.ts
@@ -27,7 +27,10 @@ import { UserMeResponseDto } from '../../dtos/user-me-response.dto';
 import { UserProfileUpdateRequestDto } from '../../dtos/user-profile-update-request.dto';
 import { UserInterestsUpdateRequestDto } from '../../dtos/user-interests-update-request.dto';
 import { UserPersonalitiesUpdateRequestDto } from '../../dtos/user-personalities-update-request.dto';
-import { UserIdealPersonalitiesUpdateRequestDto } from '../../dtos/user-ideal-personalities-update-request.dto';
+import {
+  UserIdealPersonalitiesUpdateRequestDto,
+  UserIdealPersonalitiesUpdateResponseDto,
+} from '../../dtos/user-ideal-personalities-update-request.dto';
 import {
   UserClubsResponseDto,
   UserLikedClubsResponseDto,
@@ -225,7 +228,7 @@ export class UserController {
   @Put('me/ideal-personalities')
   @UseGuards(AccessTokenGuard)
   @ApiOperation({ summary: 'Update my ideal personalities' })
-  @ApiOkResponse({ schema: { example: null } })
+  @ApiOkResponse({ type: UserIdealPersonalitiesUpdateResponseDto })
   updateIdealPersonalities(
     @CurrentUser('userId') userId: number | null,
     @Body() body: UserIdealPersonalitiesUpdateRequestDto,

--- a/src/modules/user/dtos/user-ideal-personalities-update-request.dto.spec.ts
+++ b/src/modules/user/dtos/user-ideal-personalities-update-request.dto.spec.ts
@@ -18,6 +18,27 @@ describe('UserIdealPersonalitiesUpdateRequestDto', () => {
     expect(errors).toEqual([]);
   });
 
+  it('allows matchedKeywords without personalityKeywords', async () => {
+    const errors = await validateDto({
+      matchedKeywords: [
+        {
+          category: 'PERSONALITY',
+          id: 1,
+          keyword: '차분함',
+          score: 0.86,
+        },
+        {
+          category: 'INTEREST',
+          id: 13,
+          keyword: '요리',
+          score: 0.75,
+        },
+      ],
+    });
+
+    expect(errors).toEqual([]);
+  });
+
   it('still rejects unrelated unknown fields', async () => {
     const errors = await validateDto({
       personalityKeywords: ['차분함', '신중함'],

--- a/src/modules/user/dtos/user-ideal-personalities-update-request.dto.ts
+++ b/src/modules/user/dtos/user-ideal-personalities-update-request.dto.ts
@@ -1,19 +1,58 @@
+import { Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
   ArrayNotEmpty,
   ArrayUnique,
   IsArray,
+  IsNumber,
   IsOptional,
   IsString,
+  ValidateIf,
+  ValidateNested,
 } from 'class-validator';
 
+export class UserIdealMatchedKeywordDto {
+  @ApiProperty({ example: 'PERSONALITY' })
+  @IsString()
+  category: string;
+
+  @ApiPropertyOptional({ example: 1 })
+  @IsOptional()
+  @IsNumber()
+  id?: number;
+
+  @ApiProperty({ example: '차분함' })
+  @IsString()
+  keyword: string;
+
+  @ApiPropertyOptional({ example: 0.86 })
+  @IsOptional()
+  @IsNumber()
+  score?: number;
+}
+
 export class UserIdealPersonalitiesUpdateRequestDto {
-  @ApiProperty({ example: ['차분함', '신중함', '계획성'] })
+  @ApiPropertyOptional({ example: ['차분함', '신중함', '계획성'] })
+  @ValidateIf(
+    (dto: UserIdealPersonalitiesUpdateRequestDto) =>
+      !Array.isArray(dto.matchedKeywords) || dto.matchedKeywords.length === 0,
+  )
   @IsArray()
   @IsString({ each: true })
   @ArrayNotEmpty()
   @ArrayUnique()
-  personalityKeywords: string[];
+  personalityKeywords?: string[];
+
+  @ApiPropertyOptional({
+    type: [UserIdealMatchedKeywordDto],
+    description:
+      'FastAPI 이상형 분석 결과입니다. 제공되면 category가 PERSONALITY인 keyword만 이상형 성향으로 저장합니다.',
+  })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => UserIdealMatchedKeywordDto)
+  matchedKeywords?: UserIdealMatchedKeywordDto[];
 
   @ApiPropertyOptional({
     example: ['영화감상', '문학'],
@@ -24,4 +63,9 @@ export class UserIdealPersonalitiesUpdateRequestDto {
   @IsString({ each: true })
   @ArrayUnique()
   interest?: string[];
+}
+
+export class UserIdealPersonalitiesUpdateResponseDto {
+  @ApiProperty({ example: ['차분함', '신중함'] })
+  idealPersonalities: string[];
 }

--- a/src/modules/user/services/user/user.service.spec.ts
+++ b/src/modules/user/services/user/user.service.spec.ts
@@ -71,6 +71,38 @@ describe('UserService', () => {
     expect(service).toBeDefined();
   });
 
+  it('이상형 분석 matchedKeywords에서 PERSONALITY 카테고리만 저장한다', async () => {
+    repositoryMock.findAllPersonalities.mockResolvedValue([
+      { id: 1n, body: '차분함' },
+      { id: 3n, body: '신중함' },
+    ]);
+    repositoryMock.updateIdealPersonalities.mockResolvedValue(undefined);
+
+    const result = await service.updateIdealPersonalities(7, {
+      matchedKeywords: [
+        {
+          category: 'PERSONALITY',
+          id: 1,
+          keyword: '차분함',
+          score: 0.86,
+        },
+        {
+          category: 'INTEREST',
+          id: 13,
+          keyword: '요리',
+          score: 0.75,
+        },
+      ],
+    });
+
+    expect(result).toEqual({ idealPersonalities: ['차분함'] });
+    expect(repositoryMock.findAllPersonalities).toHaveBeenCalled();
+    expect(repositoryMock.updateIdealPersonalities).toHaveBeenCalledWith(
+      7,
+      [1],
+    );
+  });
+
   it('내 ACTIVE/PENDING 동호회 목록을 반환한다', async () => {
     const joinedAt = new Date('2026-05-02T15:40:00.000Z');
     repositoryMock.findMyClubs.mockResolvedValue([

--- a/src/modules/user/services/user/user.service.ts
+++ b/src/modules/user/services/user/user.service.ts
@@ -5,7 +5,10 @@ import { UserMeResponseDto } from '../../dtos/user-me-response.dto';
 import { UserProfileUpdateRequestDto } from '../../dtos/user-profile-update-request.dto';
 import { UserInterestsUpdateRequestDto } from '../../dtos/user-interests-update-request.dto';
 import { UserPersonalitiesUpdateRequestDto } from '../../dtos/user-personalities-update-request.dto';
-import { UserIdealPersonalitiesUpdateRequestDto } from '../../dtos/user-ideal-personalities-update-request.dto';
+import {
+  UserIdealPersonalitiesUpdateRequestDto,
+  UserIdealPersonalitiesUpdateResponseDto,
+} from '../../dtos/user-ideal-personalities-update-request.dto';
 import { DeleteAccountRequestDto } from '../../dtos/delete-account-request.dto';
 import {
   UserClubsResponseDto,
@@ -477,17 +480,32 @@ export class UserService {
   async updateIdealPersonalities(
     userId: number,
     payload: UserIdealPersonalitiesUpdateRequestDto,
-  ): Promise<null> {
+  ): Promise<UserIdealPersonalitiesUpdateResponseDto> {
     if (!userId) {
       throw new AppException('AUTH_LOGIN_REQUIRED');
     }
 
-    await this.updateIdealPersonalitiesByBodies(
+    const personalityKeywords =
+      payload.matchedKeywords !== undefined
+        ? this.extractPersonalityKeywords(payload.matchedKeywords)
+        : (payload.personalityKeywords ?? []);
+
+    const idealPersonalities = await this.updateIdealPersonalitiesByBodies(
       userId,
-      payload.personalityKeywords,
+      personalityKeywords,
     );
 
-    return null;
+    return { idealPersonalities };
+  }
+
+  private extractPersonalityKeywords(
+    matchedKeywords: NonNullable<
+      UserIdealPersonalitiesUpdateRequestDto['matchedKeywords']
+    >,
+  ): string[] {
+    return matchedKeywords
+      .filter((item) => item.category.trim().toUpperCase() === 'PERSONALITY')
+      .map((item) => item.keyword);
   }
 
   // 키워드 검증 + 에러 처리
@@ -560,7 +578,7 @@ export class UserService {
   private async updateIdealPersonalitiesByBodies(
     userId: number,
     personalities: string[],
-  ): Promise<void> {
+  ): Promise<string[]> {
     const normalized = personalities
       .map((personality) => personality.trim())
       .filter(Boolean);
@@ -568,7 +586,7 @@ export class UserService {
 
     if (uniquePersonalities.length === 0) {
       await this.userRepository.updateIdealPersonalities(userId, []);
-      return;
+      return [];
     }
 
     const entries = await this.userRepository.findAllPersonalities();
@@ -598,6 +616,7 @@ export class UserService {
       return Number(entry!.id);
     });
     await this.userRepository.updateIdealPersonalities(userId, ids);
+    return uniquePersonalities;
   }
 
   private parseVisitorsPageSize(size?: string): number {


### PR DESCRIPTION
## 이슈 번호
close #326 

## 주요 변경사항
- 이상형 키워드 저장 api 에서 fastapi의 응답값 파싱 로직 수정 
- Interest , Personality 키워드 구분을 통해 키워드 에러 해결
- PATCH v1/clubs/{clubId} 클럽 이미지 수정 필드 추가

## 테스트 결과 (스크린샷)
- 
<img width="1382" height="835" alt="이상형 키워드 에러 해결" src="https://github.com/user-attachments/assets/86e4fec8-a511-4211-9fcc-4fe018ec588c" />

> 로컬에서 동일한 키워드 "요리" , "베이킹" 등 interest 관련 키워드 저장 200 ok 확인

## 참고 및 개선사항
- 
