### PR TITLE
fix: Apple 탈퇴 실패 처리 및 소셜 로그인 온보딩 조건 개선

### DIFF
--- a/src/modules/auth/services/apple-auth.service.ts
+++ b/src/modules/auth/services/apple-auth.service.ts
@@ -469,7 +469,6 @@ export class AppleAuthService {
     birthdate: Date;
     introText: string;
     introVoiceUrl: string;
-    profileImageUrl: string;
     code: string | null;
   }) {
     return (
@@ -477,7 +476,6 @@ export class AppleAuthService {
         AppleAuthService.DEFAULT_BIRTHDATE.getTime() ||
       user.introText.trim() === '' ||
       user.introVoiceUrl === AppleAuthService.DEFAULT_INTRO_VOICE_URL ||
-      user.profileImageUrl === AppleAuthService.DEFAULT_PROFILE_IMAGE_URL ||
       user.code === null ||
       user.code === AppleAuthService.DEFAULT_ADDRESS_CODE
     );

--- a/src/modules/auth/services/kakao-auth.service.ts
+++ b/src/modules/auth/services/kakao-auth.service.ts
@@ -187,7 +187,6 @@ export class KakaoAuthService {
     birthdate: Date;
     introText: string;
     introVoiceUrl: string;
-    profileImageUrl: string;
     code: string | null;
   }) {
     return (
@@ -195,7 +194,6 @@ export class KakaoAuthService {
         KakaoAuthService.DEFAULT_BIRTHDATE.getTime() ||
       user.introText.trim() === '' ||
       user.introVoiceUrl === KakaoAuthService.DEFAULT_INTRO_VOICE_URL ||
-      user.profileImageUrl === KakaoAuthService.DEFAULT_PROFILE_IMAGE_URL ||
       user.code === null ||
       user.code === KakaoAuthService.DEFAULT_ADDRESS_CODE
     );

--- a/src/modules/user/services/user/user.service.spec.ts
+++ b/src/modules/user/services/user/user.service.spec.ts
@@ -546,20 +546,18 @@ describe('UserService', () => {
     expect(repositoryMock.createProfileVisitLog).not.toHaveBeenCalled();
   });
 
-  it('Apple 로그인 사용자는 authorization code 없이 계정 삭제를 할 수 없다', async () => {
+  it('Apple authorization code가 없어도 계정 데이터를 삭제한다', async () => {
     repositoryMock.findActiveAuthProviderInfo.mockResolvedValue({
       provider: AuthProvider.APPLE,
       providerUserId: 'apple-sub-123',
     });
+    repositoryMock.deleteAccount.mockResolvedValue({ count: 1 });
 
-    await expect(
-      service.deleteMe(7, AuthProvider.APPLE, {}),
-    ).rejects.toMatchObject({
-      internalCode: 'VALIDATION_REQUIRED_FIELD_MISSING',
-    });
+    const result = await service.deleteMe(7, AuthProvider.APPLE, {});
 
+    expect(result).toBeNull();
     expect(appleAuthServiceMock.revokeAuthorizationCode).not.toHaveBeenCalled();
-    expect(repositoryMock.deleteAccount).not.toHaveBeenCalled();
+    expect(repositoryMock.deleteAccount).toHaveBeenCalledWith(7);
   });
 
   it('Apple 로그인 사용자는 Apple revoke 후 계정 데이터를 삭제한다', async () => {
@@ -578,6 +576,27 @@ describe('UserService', () => {
       'apple-auth-code',
     );
     expect(kakaoAuthServiceMock.unlinkUser).not.toHaveBeenCalled();
+    expect(repositoryMock.deleteAccount).toHaveBeenCalledWith(7);
+  });
+
+  it('Apple token revoke가 실패해도 계정 데이터를 삭제한다', async () => {
+    repositoryMock.findActiveAuthProviderInfo.mockResolvedValue({
+      provider: AuthProvider.APPLE,
+      providerUserId: 'apple-sub-123',
+    });
+    appleAuthServiceMock.revokeAuthorizationCode.mockRejectedValue(
+      new Error('invalid_client'),
+    );
+    repositoryMock.deleteAccount.mockResolvedValue({ count: 1 });
+
+    const result = await service.deleteMe(7, AuthProvider.APPLE, {
+      appleAuthorizationCode: 'apple-auth-code',
+    });
+
+    expect(result).toBeNull();
+    expect(appleAuthServiceMock.revokeAuthorizationCode).toHaveBeenCalledWith(
+      'apple-auth-code',
+    );
     expect(repositoryMock.deleteAccount).toHaveBeenCalledWith(7);
   });
 

--- a/src/modules/user/services/user/user.service.ts
+++ b/src/modules/user/services/user/user.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { AuthProvider } from '@prisma/client';
 import { AppException } from '../../../../common/errors/app.exception';
 import { UserMeResponseDto } from '../../dtos/user-me-response.dto';
@@ -30,6 +30,7 @@ type ProfileVisitorsCursor = {
 export class UserService {
   private static readonly DEFAULT_VISITORS_PAGE_SIZE = 20;
   private static readonly MAX_VISITORS_PAGE_SIZE = 50;
+  private readonly logger = new Logger(UserService.name);
 
   constructor(
     private readonly userRepository: UserRepository,
@@ -421,13 +422,20 @@ export class UserService {
 
     if (effectiveProvider === AuthProvider.APPLE) {
       const authorizationCode = payload.appleAuthorizationCode?.trim();
-      if (!authorizationCode) {
-        throw new AppException('VALIDATION_REQUIRED_FIELD_MISSING', {
-          message:
-            'Apple 로그인 사용자는 탈퇴 전 Apple 재인증 authorization code가 필요합니다.',
-        });
+      if (authorizationCode) {
+        try {
+          await this.appleAuthService.revokeAuthorizationCode(
+            authorizationCode,
+          );
+        } catch {
+          // Apple recommends completing account deletion even when no
+          // revocable credential is available. Never log the authorization
+          // code or upstream response because both may contain credentials.
+          this.logger.warn(
+            `Apple token revocation failed during account deletion. userId=${userId}`,
+          );
+        }
       }
-      await this.appleAuthService.revokeAuthorizationCode(authorizationCode);
     }
 
     if (effectiveProvider === AuthProvider.KAKAO) {


### PR DESCRIPTION
## 이슈 번호
close #327 

## 변경 사항

  ### 1. Apple 계정 탈퇴 안정화

  Apple 로그인 사용자의 계정 탈퇴 과정에서 authorization code가 없거나 Apple token revoke가 실패하더라도 서비스 계정 삭제를 계속 진행하도록 변경

  authorization code 있음
  → Apple token revoke 시도
  → 성공 또는 실패
  → 서비스 계정 및 개인정보 삭제

  authorization code 없음
  → 서비스 계정 및 개인정보 삭제

  Apple revoke 실패 시 authorization code나 외부 API 응답 세부정보는 로그에 기록하지 않고 userId를 포함한 경고만 남기도록

  ### 2. 온보딩 완료 조건 변경

  Apple 및 Kakao 로그인 응답의 onboardingRequired 계산에서 프로필 이미지 조건을 제거

  기존:

  생년월일
  소개글
  음성 소개
  프로필 이미지
  지역

  변경:

  생년월일
  소개글
  음성 소개
  지역

  기본 프로필 이미지를 사용하더라도 나머지 필수 정보가 입력되어 있으면 온보딩이 완료된 것으로 판단

  ## 영향 범위

  - DELETE /api/v1/users/me
  - Apple 로그인 응답의 onboardingRequired
  - Kakao 로그인 응답의 onboardingRequired