### PR TITLE
[EUM-146] chore: CI 의존성 보안 검사를 변경분과 전체 검사로 분리

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,22 @@ permissions:
   contents: read
 
 jobs:
+  dependency-review:
+    name: Dependency Review
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          fail-on-scopes: runtime
+
   quality:
     name: Quality, Unit Tests & Build
     runs-on: ubuntu-latest
@@ -34,9 +50,6 @@ jobs:
 
       - name: Generate Prisma client
         run: npm run prisma:generate
-
-      - name: Audit production dependencies
-        run: npm audit --omit=dev --audit-level=high
 
       - name: Lint
         run: npm run lint

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,43 @@
+name: Dependency Security Audit
+
+on:
+  pull_request:
+    branches: ['main']
+    types: [opened, reopened, synchronize]
+  schedule:
+    # Every Monday at 09:00 Asia/Seoul (GitHub cron uses UTC).
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: dependency-audit-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: Full Production Dependency Audit
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.head.ref == 'dev' &&
+      github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.23.1'
+          cache: npm
+
+      - name: Clean install dependencies
+        run: npm ci
+
+      - name: Audit production dependencies
+        run: npm audit --omit=dev --audit-level=high

--- a/README.md
+++ b/README.md
@@ -214,15 +214,16 @@ GET /api/v1/health/fastapi
 
 * Install (`npm ci`)
 * Prisma generate
-* PR dependency review (runtime 의존성 변경으로 새로 유입되는 `high` 이상 취약점 차단)
+* PR dependency review (runtime 의존성 변경으로 새로 유입되는 `high` 이상 취약점 표시)
 * Lint / typecheck / unit tests + coverage artifact / production build
 * 빈 PostgreSQL(pgvector) DB에 Prisma migration 적용 후 e2e test
 
 **Dependency security audit** (`.github/workflows/dependency-audit.yml`):
 
 * 매주 월요일 09:00(KST) 및 수동 실행 시 전체 production dependency audit
-* `dev` → `main` 릴리스 PR에서 전체 `npm audit --omit=dev --audit-level=high` 통과 필수
-* 일반 PR은 기존 전체 취약점이 아니라 해당 PR이 새로 추가한 취약점만 차단
+* `dev` → `main` 릴리스 PR에서 전체 `npm audit --omit=dev --audit-level=high` 실행
+* 일반 PR은 기존 전체 취약점이 아니라 해당 PR이 새로 추가한 취약점만 검사
+* 보안 검사는 실패 상태를 표시하지만 Ruleset의 필수 체크로 등록하지 않아 머지를 차단하지 않음
 
 **CD** — `dev` push의 CI가 성공하면 검증된 commit SHA를 staging ECS로 자동 배포 (`.github/workflows/cd-staging.yml`):
 

--- a/README.md
+++ b/README.md
@@ -214,9 +214,15 @@ GET /api/v1/health/fastapi
 
 * Install (`npm ci`)
 * Prisma generate
-* Production dependency audit (`high` 이상 차단)
+* PR dependency review (runtime 의존성 변경으로 새로 유입되는 `high` 이상 취약점 차단)
 * Lint / typecheck / unit tests + coverage artifact / production build
 * 빈 PostgreSQL(pgvector) DB에 Prisma migration 적용 후 e2e test
+
+**Dependency security audit** (`.github/workflows/dependency-audit.yml`):
+
+* 매주 월요일 09:00(KST) 및 수동 실행 시 전체 production dependency audit
+* `dev` → `main` 릴리스 PR에서 전체 `npm audit --omit=dev --audit-level=high` 통과 필수
+* 일반 PR은 기존 전체 취약점이 아니라 해당 PR이 새로 추가한 취약점만 차단
 
 **CD** — `dev` push의 CI가 성공하면 검증된 commit SHA를 staging ECS로 자동 배포 (`.github/workflows/cd-staging.yml`):
 

--- a/docs/cd-production-setup.md
+++ b/docs/cd-production-setup.md
@@ -46,19 +46,15 @@ contain only values intentionally shared with staging.
 
 ## 2. GitHub tag and main protection
 
-Protect `main`, require pull requests, and require these checks:
+Protect `main`, require pull requests, and require the CI checks already used by
+`dev`:
 
 - `Quality, Unit Tests & Build`
 - `Database Migration & E2E`
-- `Dependency Review`
-- `Full Production Dependency Audit`
-- `Validate branch name`
 
-`Dependency Review` blocks High-or-higher vulnerabilities introduced by the
-release diff. `Full Production Dependency Audit` runs only for the repository's
-`dev` to `main` release PR and blocks the release while any High-or-higher
-production dependency vulnerability remains. Keep the full audit required on
-`main` only; feature PRs targeting `dev` intentionally do not run it.
+`Dependency Review` and `Full Production Dependency Audit` are intentionally
+informational. Do not add them as required status checks; failed security checks
+remain visible on the release PR without blocking the merge.
 
 Create an active tag ruleset targeting `v*.*.*`. Restrict tag creation to the
 release operators and prevent updates, deletions, and force pushes. Production

--- a/docs/cd-production-setup.md
+++ b/docs/cd-production-setup.md
@@ -46,11 +46,19 @@ contain only values intentionally shared with staging.
 
 ## 2. GitHub tag and main protection
 
-Protect `main`, require pull requests, and require the CI checks already used by
-`dev`:
+Protect `main`, require pull requests, and require these checks:
 
 - `Quality, Unit Tests & Build`
 - `Database Migration & E2E`
+- `Dependency Review`
+- `Full Production Dependency Audit`
+- `Validate branch name`
+
+`Dependency Review` blocks High-or-higher vulnerabilities introduced by the
+release diff. `Full Production Dependency Audit` runs only for the repository's
+`dev` to `main` release PR and blocks the release while any High-or-higher
+production dependency vulnerability remains. Keep the full audit required on
+`main` only; feature PRs targeting `dev` intentionally do not run it.
 
 Create an active tag ruleset targeting `v*.*.*`. Restrict tag creation to the
 release operators and prevent updates, deletions, and force pushes. Production

--- a/docs/cd-staging-setup.md
+++ b/docs/cd-staging-setup.md
@@ -70,14 +70,17 @@ Attach a least-privilege policy allowing:
 
 Under `Settings` -> `Security` -> `Advanced Security`, verify that Dependency
 graph, Dependabot alerts, and Dependabot security updates are enabled before
-making `Dependency Review` required.
+using `Dependency Review`.
 
 Protect `dev`, require pull requests, and require these checks before merge:
 
 - `Quality, Unit Tests & Build`
 - `Database Migration & E2E`
-- `Dependency Review`
 - `Validate branch name`
+
+`Dependency Review` is intentionally informational. Do not add it as a required
+status check; a failed security review should remain visible without blocking
+the merge.
 
 Restrict direct pushes to `dev`. Keep the staging environment without manual approval; production should use a separate protected environment when its pipeline is introduced.
 

--- a/docs/cd-staging-setup.md
+++ b/docs/cd-staging-setup.md
@@ -68,10 +68,15 @@ Attach a least-privilege policy allowing:
 
 ## 3. Branch protection
 
+Under `Settings` -> `Security` -> `Advanced Security`, verify that Dependency
+graph, Dependabot alerts, and Dependabot security updates are enabled before
+making `Dependency Review` required.
+
 Protect `dev`, require pull requests, and require these checks before merge:
 
 - `Quality, Unit Tests & Build`
 - `Database Migration & E2E`
+- `Dependency Review`
 - `Validate branch name`
 
 Restrict direct pushes to `dev`. Keep the staging environment without manual approval; production should use a separate protected environment when its pipeline is introduced.


### PR DESCRIPTION
## 이슈 번호
close #339 

## 주요 변경사항
- 일반 PR의 전체 `npm audit`을 제거하고 신규 runtime High 이상 취약점만 검사하도록 변경
- 매주 월요일 및 수동 실행되는 전체 production 의존성 audit 워크플로 추가
- `dev` → `main` 릴리스 PR에서 전체 의존성 취약점 검사 수행

## 참고 및 개선사항
- 현재 전체 audit이 실패하므로 기존 High 취약점 해결 전까지 릴리스 PR이 차단됩니다.