### PR TITLE
[EUM-148] [Fix] 어플 심사 관련 피드백 반영

### DIFF
--- a/prisma/dbml/schema.dbml
+++ b/prisma/dbml/schema.dbml
@@ -323,6 +323,9 @@ Table ChatMedia {
 Table MarketingAgreement {
   id BigInt [pk, increment]
   body String [not null]
+  type AgreementType [not null, default: 'MARKETING']
+  version String [not null, default: '1.0.0']
+  isRequired Boolean [not null, default: false]
   userMarketingAgreement UserMarketingAgreement [not null]
 }
 
@@ -330,6 +333,8 @@ Table UserMarketingAgreement {
   id BigInt [pk, increment]
   marketingAgreementId BigInt [not null]
   userId BigInt [not null]
+  agreementType AgreementType [not null, default: 'MARKETING']
+  agreementVersion String [not null, default: '1.0.0']
   agreedAt DateTime [default: `now()`, not null]
   isAgreed Boolean [not null, default: true]
   deletedAt DateTime
@@ -698,6 +703,14 @@ Enum ReportTargetType {
   CLUB
   ARTICLE
   COMMENT
+  PROFILE
+  VOICE
+}
+
+Enum AgreementType {
+  POLICY
+  PERSONAL_INFORMATION
+  MARKETING
 }
 
 Enum ModerationSurface {

--- a/prisma/migrations/20260730000000_eum_148_ugc_safety/migration.sql
+++ b/prisma/migrations/20260730000000_eum_148_ugc_safety/migration.sql
@@ -1,0 +1,26 @@
+-- Add report targets required by iOS UGC safety review.
+ALTER TYPE "ReportTargetType" ADD VALUE IF NOT EXISTS 'PROFILE';
+ALTER TYPE "ReportTargetType" ADD VALUE IF NOT EXISTS 'VOICE';
+
+-- Store agreement type/version/required metadata and preserve the version
+-- accepted by each user.
+CREATE TYPE "AgreementType" AS ENUM ('POLICY', 'PERSONAL_INFORMATION', 'MARKETING');
+
+ALTER TABLE "MarketingAgreement"
+ADD COLUMN "type" "AgreementType" NOT NULL DEFAULT 'MARKETING',
+ADD COLUMN "version" VARCHAR(20) NOT NULL DEFAULT '1.0.0',
+ADD COLUMN "isRequired" BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE "UserMarketingAgreement"
+ADD COLUMN "agreementType" "AgreementType" NOT NULL DEFAULT 'MARKETING',
+ADD COLUMN "agreementVersion" VARCHAR(20) NOT NULL DEFAULT '1.0.0';
+
+UPDATE "UserMarketingAgreement" uma
+SET
+  "agreementType" = ma."type",
+  "agreementVersion" = ma."version"
+FROM "MarketingAgreement" ma
+WHERE uma."marketingAgreementId" = ma."id";
+
+CREATE INDEX "MarketingAgreement_type_idx" ON "MarketingAgreement"("type");
+CREATE INDEX "MarketingAgreement_isRequired_idx" ON "MarketingAgreement"("isRequired");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -135,6 +135,14 @@ enum ReportTargetType {
   CLUB
   ARTICLE
   COMMENT
+  PROFILE
+  VOICE
+}
+
+enum AgreementType {
+  POLICY
+  PERSONAL_INFORMATION
+  MARKETING
 }
 
 enum ModerationSurface {
@@ -564,16 +572,24 @@ model ChatMedia {
 model MarketingAgreement {
   id                     BigInt                   @id @default(autoincrement()) @db.BigInt
   body                   String                   @db.Text
+  type                   AgreementType            @default(MARKETING)
+  version                String                   @default("1.0.0") @db.VarChar(20)
+  isRequired             Boolean                  @default(false)
   userMarketingAgreement UserMarketingAgreement[]
+
+  @@index([type])
+  @@index([isRequired])
 }
 
 model UserMarketingAgreement {
-  id                   BigInt    @id @default(autoincrement()) @db.BigInt
-  marketingAgreementId BigInt    @db.BigInt
-  userId               BigInt    @db.BigInt
-  agreedAt             DateTime  @default(now()) @db.Timestamp(6)
-  isAgreed             Boolean   @default(true)
-  deletedAt            DateTime? @db.Timestamp(6)
+  id                   BigInt        @id @default(autoincrement()) @db.BigInt
+  marketingAgreementId BigInt        @db.BigInt
+  userId               BigInt        @db.BigInt
+  agreementType        AgreementType @default(MARKETING)
+  agreementVersion     String        @default("1.0.0") @db.VarChar(20)
+  agreedAt             DateTime      @default(now()) @db.Timestamp(6)
+  isAgreed             Boolean       @default(true)
+  deletedAt            DateTime?     @db.Timestamp(6)
 
   user               User               @relation(fields: [userId], references: [id], onDelete: Cascade) //유저가 사라지면 바로 사라져도 ok.
   marketingAgreement MarketingAgreement @relation(fields: [marketingAgreementId], references: [id], onDelete: Cascade) //동의 약관이 사라지면 바로 사라져도 ok.

--- a/src/common/interceptors/block-filter.interceptor.ts
+++ b/src/common/interceptors/block-filter.interceptor.ts
@@ -15,13 +15,19 @@ import { PrismaService } from '../../infra/prisma/prisma.service';
 
 @Injectable()
 export class BlockFilterInterceptor implements NestInterceptor {
-  private blockCacheMap = new Map<
+  private static blockCacheMap = new Map<
     string,
     { data: string[]; timestamp: number }
   >();
   private readonly CACHE_TTL = 5 * 60 * 1000; // 5분 캐시
 
   constructor(private readonly prismaService: PrismaService) {}
+
+  static invalidateUsers(userIds: Array<string | number | bigint>): void {
+    userIds.forEach((userId) => {
+      this.blockCacheMap.delete(userId.toString());
+    });
+  }
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
     const request = context.switchToHttp().getRequest();
@@ -64,7 +70,8 @@ export class BlockFilterInterceptor implements NestInterceptor {
     }
 
     // 캐시에서 조회
-    const cachedBlockData = this.blockCacheMap.get(currentUserId);
+    const cachedBlockData =
+      BlockFilterInterceptor.blockCacheMap.get(currentUserId);
     if (cachedBlockData) {
       const { data, timestamp } = cachedBlockData;
       const now = Date.now();
@@ -115,7 +122,7 @@ export class BlockFilterInterceptor implements NestInterceptor {
     const finalBlockedUserIds = Array.from(blockedUserIds);
 
     // 캐시에 저장
-    this.blockCacheMap.set(currentUserId, {
+    BlockFilterInterceptor.blockCacheMap.set(currentUserId, {
       data: finalBlockedUserIds,
       timestamp: Date.now(),
     });
@@ -182,6 +189,7 @@ export class BlockFilterInterceptor implements NestInterceptor {
     const userIdFields = [
       'userId',
       'authorId',
+      'hostId',
       'senderId',
       'sentById',
       'sentToId',
@@ -247,9 +255,12 @@ export class BlockFilterInterceptor implements NestInterceptor {
 
   private cleanExpiredCache(): void {
     const now = Date.now();
-    for (const [userId, cacheData] of this.blockCacheMap.entries()) {
+    for (const [
+      userId,
+      cacheData,
+    ] of BlockFilterInterceptor.blockCacheMap.entries()) {
       if (now - cacheData.timestamp > this.CACHE_TTL) {
-        this.blockCacheMap.delete(userId);
+        BlockFilterInterceptor.blockCacheMap.delete(userId);
       }
     }
   }

--- a/src/common/s3/s3-object-url.service.spec.ts
+++ b/src/common/s3/s3-object-url.service.spec.ts
@@ -89,4 +89,17 @@ describe('S3ObjectUrlService', () => {
     );
     expect(getSignedUrlMock).toHaveBeenCalledTimes(2);
   });
+
+  it('does not recurse forever on circular response objects', async () => {
+    const service = new S3ObjectUrlService(configService as never);
+    const payload: { imageUrl: string; self?: unknown } = {
+      imageUrl: 'https://cdn.example.com/images/1.jpg',
+    };
+    payload.self = payload;
+
+    await expect(service.transformClientUrlFields(payload)).resolves.toEqual({
+      imageUrl: 'https://cdn.example.com/images/1.jpg',
+      self: '[Circular]',
+    });
+  });
 });

--- a/src/common/s3/s3-object-url.service.ts
+++ b/src/common/s3/s3-object-url.service.ts
@@ -155,12 +155,13 @@ export class S3ObjectUrlService {
   }
 
   async transformClientUrlFields<T>(value: T): Promise<T> {
-    return this.transform(value, null) as Promise<T>;
+    return this.transform(value, null, new WeakSet<object>()) as Promise<T>;
   }
 
   private async transform(
     value: unknown,
     key: string | null,
+    visited: WeakSet<object>,
   ): Promise<unknown> {
     if (typeof value === 'string') {
       return key && CLIENT_URL_FIELDS.has(key)
@@ -172,14 +173,21 @@ export class S3ObjectUrlService {
       return value;
     }
 
+    if (visited.has(value)) {
+      return '[Circular]';
+    }
+    visited.add(value);
+
     if (Array.isArray(value)) {
-      return Promise.all(value.map((item) => this.transform(item, null)));
+      return Promise.all(
+        value.map((item) => this.transform(item, null, visited)),
+      );
     }
 
     const entries = await Promise.all(
       Object.entries(value).map(async ([entryKey, entryValue]) => [
         entryKey,
-        await this.transform(entryValue, entryKey),
+        await this.transform(entryValue, entryKey, visited),
       ]),
     );
 

--- a/src/modules/agreements/controllers/agreement.controller.ts
+++ b/src/modules/agreements/controllers/agreement.controller.ts
@@ -86,10 +86,17 @@ export class AgreementController {
     @Body() body: CreateUserAgreementRequestDto,
   ) {
     for (const agreement of body.marketingAgreements) {
-      const { marketingAgreementId, isAgreed } = agreement;
+      const {
+        marketingAgreementId,
+        agreementType,
+        agreementVersion,
+        isAgreed,
+      } = agreement;
       await this.agreementService.upsertUserMarketingAgreement(
         userId,
         marketingAgreementId,
+        agreementType,
+        agreementVersion,
         isAgreed,
       );
     }

--- a/src/modules/agreements/dtos/agreement.dto.ts
+++ b/src/modules/agreements/dtos/agreement.dto.ts
@@ -1,16 +1,29 @@
-import { MarketingAgreement } from '@prisma/client';
-import { IsNumber, IsBoolean, IsArray, ValidateNested } from 'class-validator';
+import { AgreementType, MarketingAgreement } from '@prisma/client';
+import {
+  IsNumber,
+  IsBoolean,
+  IsArray,
+  ValidateNested,
+  IsEnum,
+  IsString,
+} from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class AgreementResponseDto {
   agreementId: string;
   body: string;
+  type: AgreementType;
+  version: string;
+  isRequired: boolean;
 
   static from(entity: MarketingAgreement) {
     return {
       agreementId: entity.id.toString(),
       body: entity.body,
+      type: entity.type,
+      version: entity.version,
+      isRequired: entity.isRequired,
     };
   }
 }
@@ -20,6 +33,15 @@ export class AgreementItemDto {
   @IsNumber()
   @ApiProperty({ example: 1 })
   marketingAgreementId: number;
+
+  @IsEnum(AgreementType)
+  @ApiProperty({ enum: AgreementType, example: AgreementType.POLICY })
+  agreementType: AgreementType;
+
+  @IsString()
+  @ApiProperty({ example: '1.0.0' })
+  agreementVersion: string;
+
   @IsBoolean()
   @ApiProperty({ example: true })
   isAgreed: boolean;
@@ -31,7 +53,7 @@ export class CreateUserAgreementRequestDto {
   @Type(() => AgreementItemDto)
   @ApiProperty({
     type: [AgreementItemDto],
-    description: '마케팅 동의 약관',
+    description: '약관 동의 목록',
   })
   marketingAgreements: AgreementItemDto[];
 }

--- a/src/modules/agreements/repositories/agreement.repository.ts
+++ b/src/modules/agreements/repositories/agreement.repository.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { AgreementType, MarketingAgreement } from '@prisma/client';
 import { PrismaService } from '../../../infra/prisma/prisma.service';
 
 @Injectable()
@@ -15,20 +16,26 @@ export class AgreementRepository {
   // POST v1/users/me/agreements
   upsertUserMarketingAgreement(
     userId: number,
-    marketingAgreementId: number,
+    agreement: MarketingAgreement,
     isAgreed: boolean,
   ) {
     return this.prisma.userMarketingAgreement.upsert({
       where: {
         marketingAgreementId_userId: {
           userId: BigInt(userId),
-          marketingAgreementId: BigInt(marketingAgreementId),
+          marketingAgreementId: agreement.id,
         },
       },
-      update: { isAgreed },
+      update: {
+        isAgreed,
+        agreementType: agreement.type,
+        agreementVersion: agreement.version,
+      },
       create: {
         userId: BigInt(userId),
-        marketingAgreementId: BigInt(marketingAgreementId),
+        marketingAgreementId: agreement.id,
+        agreementType: agreement.type,
+        agreementVersion: agreement.version,
         isAgreed,
       },
     });
@@ -37,7 +44,21 @@ export class AgreementRepository {
   findMarketingAgreementById(agreementId: number) {
     return this.prisma.marketingAgreement.findUnique({
       where: {
-        id: agreementId,
+        id: BigInt(agreementId),
+      },
+    });
+  }
+
+  findMarketingAgreementByContract(
+    agreementId: number,
+    agreementType: AgreementType,
+    agreementVersion: string,
+  ) {
+    return this.prisma.marketingAgreement.findFirst({
+      where: {
+        id: BigInt(agreementId),
+        type: agreementType,
+        version: agreementVersion,
       },
     });
   }

--- a/src/modules/agreements/services/agreement.service.ts
+++ b/src/modules/agreements/services/agreement.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { AgreementType } from '@prisma/client';
 import { AgreementRepository } from '../repositories/agreement.repository';
 import {
   AgreementResponseDto,
@@ -18,18 +19,22 @@ export class AgreementService {
   async upsertUserMarketingAgreement(
     userId: number,
     marketingAgreementId: number,
+    agreementType: AgreementType,
+    agreementVersion: string,
     isAgreed: boolean,
   ) {
     const agreement =
-      await this.agreementRepository.findMarketingAgreementById(
+      await this.agreementRepository.findMarketingAgreementByContract(
         marketingAgreementId,
+        agreementType,
+        agreementVersion,
       );
     if (!agreement) {
       throw new AppException('AGREE_DOESNOT_EXIST');
     }
     return await this.agreementRepository.upsertUserMarketingAgreement(
       userId,
-      marketingAgreementId,
+      agreement,
       isAgreed,
     );
   }

--- a/src/modules/club/controllers/club/club.controller.spec.ts
+++ b/src/modules/club/controllers/club/club.controller.spec.ts
@@ -211,10 +211,10 @@ describe('ClubController', () => {
     };
     listTopHosts.mockResolvedValue(response);
 
-    await expect(controller.listTopHosts({ limit: 10 })).resolves.toBe(
+    await expect(controller.listTopHosts(7, { limit: 10 })).resolves.toBe(
       response,
     );
-    expect(listTopHosts).toHaveBeenCalledWith(10);
+    expect(listTopHosts).toHaveBeenCalledWith(7, 10);
   });
 
   it('오늘의 동호회 추천 조회를 service에 위임한다', async () => {
@@ -241,9 +241,9 @@ describe('ClubController', () => {
     listTodayRecommendedClubs.mockResolvedValue(response);
 
     await expect(
-      controller.listTodayRecommendedClubs({ limit: 10 }),
+      controller.listTodayRecommendedClubs(7, { limit: 10 }),
     ).resolves.toBe(response);
-    expect(listTodayRecommendedClubs).toHaveBeenCalledWith(10);
+    expect(listTodayRecommendedClubs).toHaveBeenCalledWith(7, 10);
   });
 
   it('클럽 상세 조회를 service에 위임한다', async () => {

--- a/src/modules/club/controllers/club/club.controller.ts
+++ b/src/modules/club/controllers/club/club.controller.ts
@@ -289,10 +289,14 @@ export class ClubController {
       },
     },
   })
+  @UseGuards(AccessTokenGuard)
+  @ApiBearerAuth('access-token')
+  @ApiUnauthorizedResponse({ description: '로그인 필요' })
   listTodayRecommendedClubs(
+    @RequiredUserId() userId: number,
     @Query() query: ListTodayRecommendedClubsQueryDto,
   ): Promise<ListTodayRecommendedClubsResponseDto> {
-    return this.clubService.listTodayRecommendedClubs(query.limit);
+    return this.clubService.listTodayRecommendedClubs(userId, query.limit);
   }
 
   @Get('top-hosts')
@@ -332,10 +336,14 @@ export class ClubController {
       },
     },
   })
+  @UseGuards(AccessTokenGuard)
+  @ApiBearerAuth('access-token')
+  @ApiUnauthorizedResponse({ description: '로그인 필요' })
   listTopHosts(
+    @RequiredUserId() userId: number,
     @Query() query: ListTopHostsQueryDto,
   ): Promise<ListTopHostsResponseDto> {
-    return this.clubService.listTopHosts(query.limit);
+    return this.clubService.listTopHosts(userId, query.limit);
   }
 
   @Post(':clubId/like')

--- a/src/modules/club/repositories/club.repository.ts
+++ b/src/modules/club/repositories/club.repository.ts
@@ -265,6 +265,18 @@ export class ClubRepository {
     });
   }
 
+  async hasActiveBlockBetween(
+    viewerId: bigint,
+    targetUserId: bigint,
+  ): Promise<boolean> {
+    const block = await this.prisma.block.findFirst({
+      where: this.activeBlockBetweenWhere(viewerId, targetUserId),
+      select: { id: true },
+    });
+
+    return Boolean(block);
+  }
+
   // 동호회에 대한 유저의 상태를 반환한다. (가입 여부, 권한, 탈퇴 여부 등)
   async findClubUserState(
     clubId: bigint,
@@ -385,6 +397,17 @@ export class ClubRepository {
   ): Prisma.ClubWhereInput {
     const and: Prisma.ClubWhereInput[] = [{ deletedAt: null }];
 
+    and.push({
+      OR: [
+        { hostId: null },
+        {
+          user: {
+            is: this.visibleUserWhere(params.viewerId),
+          },
+        },
+      ],
+    });
+
     if (params.keyword) {
       and.push({
         OR: [
@@ -439,7 +462,7 @@ export class ClubRepository {
     return [{ likes: 'desc' }, { id: 'desc' }];
   }
 
-  async findTopHosts(limit: number): Promise<TopHostRow[]> {
+  async findTopHosts(viewerId: bigint, limit: number): Promise<TopHostRow[]> {
     const rows = await this.prisma.club.groupBy({
       by: ['hostId'],
 
@@ -448,6 +471,10 @@ export class ClubRepository {
 
         hostId: {
           not: null,
+        },
+
+        user: {
+          is: this.visibleUserWhere(viewerId),
         },
       },
 
@@ -521,6 +548,7 @@ export class ClubRepository {
   }
 
   async findTodayRecommendedClubs(
+    viewerId: bigint,
     limit: number,
   ): Promise<TodayRecommendedClubRow[]> {
     return this.prisma.$queryRaw<TodayRecommendedClubRow[]>(Prisma.sql`
@@ -559,6 +587,16 @@ export class ClubRepository {
         AND c."hostId" IS NOT NULL
         AND u."deletedAt" IS NULL
         AND u."status" = ${ActiveStatus.ACTIVE}::"ActiveStatus"
+        AND NOT EXISTS (
+          SELECT 1
+          FROM "Block" b
+          WHERE b."status" = 'BLOCKED'::"BlockStatus"
+            AND b."deletedAt" IS NULL
+            AND (
+              (b."blockedById" = ${viewerId} AND b."blockedId" = u."id")
+              OR (b."blockedById" = u."id" AND b."blockedId" = ${viewerId})
+            )
+        )
         AND COALESCE(active_members."memberCount", 0) < c."capacity"
       ORDER BY
         "recommendationScore" DESC,
@@ -568,6 +606,33 @@ export class ClubRepository {
         c."id" DESC
       LIMIT ${limit}
     `);
+  }
+
+  async findVisibleClubIdsByClubIds(
+    clubIds: bigint[],
+    viewerId: bigint,
+  ): Promise<Set<string>> {
+    if (clubIds.length === 0) {
+      return new Set();
+    }
+
+    const rows = await this.prisma.club.findMany({
+      where: {
+        id: { in: clubIds },
+        deletedAt: null,
+        OR: [
+          { hostId: null },
+          {
+            user: {
+              is: this.visibleUserWhere(viewerId),
+            },
+          },
+        ],
+      },
+      select: { id: true },
+    });
+
+    return new Set(rows.map((row) => row.id.toString()));
   }
 
   async findActiveMemberCountsByClubIds(
@@ -652,6 +717,45 @@ export class ClubRepository {
       ),
       (id) => BigInt(id),
     );
+  }
+
+  private visibleUserWhere(viewerId: bigint): Prisma.UserWhereInput {
+    return {
+      blocksReceived: {
+        none: {
+          blockedById: viewerId,
+          status: 'BLOCKED',
+          deletedAt: null,
+        },
+      },
+      blocksInitiated: {
+        none: {
+          blockedId: viewerId,
+          status: 'BLOCKED',
+          deletedAt: null,
+        },
+      },
+    };
+  }
+
+  private activeBlockBetweenWhere(
+    viewerId: bigint,
+    targetUserId: bigint,
+  ): Prisma.BlockWhereInput {
+    return {
+      status: 'BLOCKED',
+      deletedAt: null,
+      OR: [
+        {
+          blockedById: viewerId,
+          blockedId: targetUserId,
+        },
+        {
+          blockedById: targetUserId,
+          blockedId: viewerId,
+        },
+      ],
+    };
   }
 
   async findActiveClubUser(

--- a/src/modules/club/repositories/club.repository.types.ts
+++ b/src/modules/club/repositories/club.repository.types.ts
@@ -7,6 +7,7 @@ import {
 import { ClubListSort } from '../dtos/club.dto';
 
 export interface ListClubsRepositoryParams {
+  viewerId: bigint;
   keyword?: string;
   category?: ClubCategory;
   code?: string;

--- a/src/modules/club/services/club/club.service.spec.ts
+++ b/src/modules/club/services/club/club.service.spec.ts
@@ -19,6 +19,7 @@ describe('ClubService', () => {
   const findTodayRecommendedClubs = jest.fn();
   const findDetailById = jest.fn();
   const findClubUserState = jest.fn();
+  const hasActiveBlockBetween = jest.fn();
   const hasClubLike = jest.fn();
   const createClubLike = jest.fn();
   const deleteClubLike = jest.fn();
@@ -80,6 +81,7 @@ describe('ClubService', () => {
     findTodayRecommendedClubs.mockReset();
     findDetailById.mockReset();
     findClubUserState.mockReset();
+    hasActiveBlockBetween.mockReset();
     hasClubLike.mockReset();
     createClubLike.mockReset();
     deleteClubLike.mockReset();
@@ -103,6 +105,7 @@ describe('ClubService', () => {
             findTodayRecommendedClubs,
             findDetailById,
             findClubUserState,
+            hasActiveBlockBetween,
             hasClubLike,
             createClubLike,
             deleteClubLike,
@@ -178,6 +181,7 @@ describe('ClubService', () => {
 
     expect(findProfileById).toHaveBeenCalledWith(7);
     expect(findManyForList).toHaveBeenCalledWith({
+      viewerId: 7n,
       keyword: undefined,
       category: undefined,
       code: '1168000000',
@@ -368,7 +372,7 @@ describe('ClubService', () => {
       },
     ]);
 
-    await expect(service.listTopHosts(10)).resolves.toEqual({
+    await expect(service.listTopHosts(7, 10)).resolves.toEqual({
       hosts: [
         {
           hostId: '42',
@@ -379,7 +383,7 @@ describe('ClubService', () => {
         },
       ],
     });
-    expect(findTopHosts).toHaveBeenCalledWith(10);
+    expect(findTopHosts).toHaveBeenCalledWith(7n, 10);
   });
 
   it('오늘의 동호회 추천 목록을 DTO로 변환한다', async () => {
@@ -401,7 +405,7 @@ describe('ClubService', () => {
       },
     ]);
 
-    await expect(service.listTodayRecommendedClubs(10)).resolves.toEqual({
+    await expect(service.listTodayRecommendedClubs(7, 10)).resolves.toEqual({
       items: [
         {
           clubId: '12',
@@ -422,7 +426,7 @@ describe('ClubService', () => {
         },
       ],
     });
-    expect(findTodayRecommendedClubs).toHaveBeenCalledWith(10);
+    expect(findTodayRecommendedClubs).toHaveBeenCalledWith(7n, 10);
   });
 
   it('호스트가 name만 수정하면 업데이트 결과를 반환한다', async () => {

--- a/src/modules/club/services/club/club.service.ts
+++ b/src/modules/club/services/club/club.service.ts
@@ -112,6 +112,7 @@ export class ClubService {
       : undefined;
 
     const rows = await this.clubRepository.findManyForList({
+      viewerId: BigInt(userId),
       keyword: query.keyword?.trim() || undefined,
       category: query.category,
       code: user.address?.code ?? undefined,
@@ -132,8 +133,11 @@ export class ClubService {
     };
   }
 
-  async listTopHosts(limit: number): Promise<ListTopHostsResponseDto> {
-    const rows = await this.clubRepository.findTopHosts(limit);
+  async listTopHosts(
+    userId: number,
+    limit: number,
+  ): Promise<ListTopHostsResponseDto> {
+    const rows = await this.clubRepository.findTopHosts(BigInt(userId), limit);
     return {
       hosts: rows.map((row) => ({
         hostId: row.hostId.toString(),
@@ -146,9 +150,13 @@ export class ClubService {
   }
 
   async listTodayRecommendedClubs(
+    userId: number,
     limit: number,
   ): Promise<ListTodayRecommendedClubsResponseDto> {
-    const rows = await this.clubRepository.findTodayRecommendedClubs(limit);
+    const rows = await this.clubRepository.findTodayRecommendedClubs(
+      BigInt(userId),
+      limit,
+    );
 
     return {
       items: rows.map((row) => ({
@@ -261,6 +269,13 @@ export class ClubService {
 
     const club = await this.clubRepository.findDetailById(clubKey);
     if (!club) {
+      throw new AppException('CLUB_NOT_FOUND');
+    }
+    if (
+      club.hostId &&
+      club.hostId !== userKey &&
+      (await this.clubRepository.hasActiveBlockBetween(userKey, club.hostId))
+    ) {
       throw new AppException('CLUB_NOT_FOUND');
     }
 

--- a/src/modules/onboarding/services/matches.service.spec.ts
+++ b/src/modules/onboarding/services/matches.service.spec.ts
@@ -2,17 +2,28 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { MatchesService } from './matches.service';
 import { OnboardingAiService } from './onboarding-ai.service';
 import { ClubRepository } from '../../club/repositories/club.repository';
+import { PrismaService } from '../../../infra/prisma/prisma.service';
 
 describe('MatchesService', () => {
   let service: MatchesService;
   const getRecommendedMatches = jest.fn();
   const getRecommendedClubs = jest.fn();
   const findActiveMemberCountsByClubIds = jest.fn();
+  const findVisibleClubIdsByClubIds = jest.fn();
+  const blockFindMany = jest.fn();
 
   beforeEach(async () => {
     getRecommendedMatches.mockReset();
     getRecommendedClubs.mockReset();
     findActiveMemberCountsByClubIds.mockReset();
+    findVisibleClubIdsByClubIds.mockReset();
+    blockFindMany.mockReset();
+    blockFindMany.mockResolvedValue([]);
+    findVisibleClubIdsByClubIds.mockImplementation((clubIds: bigint[]) => {
+      return Promise.resolve(
+        new Set(clubIds.map((clubId) => clubId.toString())),
+      );
+    });
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -28,6 +39,15 @@ describe('MatchesService', () => {
           provide: ClubRepository,
           useValue: {
             findActiveMemberCountsByClubIds,
+            findVisibleClubIdsByClubIds,
+          },
+        },
+        {
+          provide: PrismaService,
+          useValue: {
+            block: {
+              findMany: blockFindMany,
+            },
           },
         },
       ],
@@ -92,5 +112,64 @@ describe('MatchesService', () => {
       },
     });
     expect(findActiveMemberCountsByClubIds).toHaveBeenCalledWith([12n, 13n]);
+    expect(findVisibleClubIdsByClubIds).toHaveBeenCalledWith([12n, 13n], 7n);
+  });
+
+  it('추천 매칭 후보에서 차단 관계 사용자를 제거한다', async () => {
+    getRecommendedMatches.mockResolvedValue({
+      success: {
+        data: {
+          items: [
+            { userId: '8', nickname: 'visible' },
+            { userId: '9', nickname: 'blocked' },
+          ],
+          page: { size: 20, hasNext: false, nextCursor: null },
+        },
+      },
+    });
+    blockFindMany.mockResolvedValue([
+      {
+        blockedById: 7n,
+        blockedId: 9n,
+      },
+    ]);
+
+    await expect(service.getRecommendedMatches(7n)).resolves.toEqual({
+      items: [{ userId: '8', nickname: 'visible' }],
+      page: { size: 20, hasNext: false, nextCursor: null },
+    });
+    expect(blockFindMany).toHaveBeenCalledWith({
+      where: {
+        status: 'BLOCKED',
+        deletedAt: null,
+        OR: [{ blockedById: 7n }, { blockedId: 7n }],
+      },
+      select: {
+        blockedById: true,
+        blockedId: true,
+      },
+    });
+  });
+
+  it('추천 클럽에서 차단 관계 호스트의 클럽을 제거한다', async () => {
+    getRecommendedClubs.mockResolvedValue({
+      success: {
+        data: {
+          items: [
+            { clubId: '12', name: 'visible' },
+            { clubId: '13', name: 'blocked-host-club' },
+          ],
+          page: { size: 20, hasNext: false, nextCursor: null },
+        },
+      },
+    });
+    findVisibleClubIdsByClubIds.mockResolvedValue(new Set(['12']));
+    findActiveMemberCountsByClubIds.mockResolvedValue(new Map([['12', 18]]));
+
+    await expect(service.getRecommendedClubs(7n)).resolves.toEqual({
+      items: [{ clubId: '12', name: 'visible', memberCount: 18 }],
+      page: { size: 20, hasNext: false, nextCursor: null },
+    });
+    expect(findActiveMemberCountsByClubIds).toHaveBeenCalledWith([12n]);
   });
 });

--- a/src/modules/onboarding/services/matches.service.ts
+++ b/src/modules/onboarding/services/matches.service.ts
@@ -2,12 +2,14 @@ import { Injectable } from '@nestjs/common';
 import { OnboardingAiService } from './onboarding-ai.service';
 import { AppException } from '../../../common/errors/app.exception';
 import { ClubRepository } from '../../club/repositories/club.repository';
+import { PrismaService } from '../../../infra/prisma/prisma.service';
 
 @Injectable()
 export class MatchesService {
   constructor(
     private readonly onboardingAiService: OnboardingAiService,
     private readonly clubRepository: ClubRepository,
+    private readonly prismaService: PrismaService,
   ) {}
 
   async getRecommendedMatches(userId: bigint, cursor?: string, size?: string) {
@@ -16,7 +18,9 @@ export class MatchesService {
       cursor,
       size,
     );
-    return this.extractDataPayload(result);
+    const payload = this.extractDataPayload(result);
+    const blockedUserIds = await this.findBlockedUserIdSet(userId);
+    return this.withVisibleUserItems(payload, blockedUserIds);
   }
 
   async getRecommendedClubs(
@@ -32,7 +36,8 @@ export class MatchesService {
       areaCode,
     );
     const payload = this.extractDataPayload(result);
-    return this.withClubMemberCounts(payload);
+    const visiblePayload = await this.withVisibleClubItems(payload, userId);
+    return this.withClubMemberCounts(visiblePayload);
   }
 
   private extractDataPayload(raw: unknown): Record<string, unknown> {
@@ -99,6 +104,74 @@ export class MatchesService {
     };
   }
 
+  private async withVisibleClubItems(
+    payload: Record<string, unknown>,
+    viewerId: bigint,
+  ): Promise<Record<string, unknown>> {
+    if (!Array.isArray(payload.items)) {
+      return payload;
+    }
+
+    const clubIds = payload.items
+      .map((item) => this.pickClubId(item))
+      .filter((clubId): clubId is bigint => clubId !== null);
+    const uniqueClubIds = [
+      ...new Set(clubIds.map((clubId) => clubId.toString())),
+    ].map((clubId) => BigInt(clubId));
+    const visibleClubIds =
+      await this.clubRepository.findVisibleClubIdsByClubIds(
+        uniqueClubIds,
+        viewerId,
+      );
+
+    return {
+      ...payload,
+      items: payload.items.filter((item) => {
+        const clubId = this.pickClubId(item);
+        return clubId === null || visibleClubIds.has(clubId.toString());
+      }),
+    };
+  }
+
+  private withVisibleUserItems(
+    payload: Record<string, unknown>,
+    blockedUserIds: Set<string>,
+  ): Record<string, unknown> {
+    if (!Array.isArray(payload.items) || blockedUserIds.size === 0) {
+      return payload;
+    }
+
+    return {
+      ...payload,
+      items: payload.items.filter((item) => {
+        const candidateUserId = this.pickUserId(item);
+        return candidateUserId === null || !blockedUserIds.has(candidateUserId);
+      }),
+    };
+  }
+
+  private async findBlockedUserIdSet(userId: bigint): Promise<Set<string>> {
+    const rows = await this.prismaService.block.findMany({
+      where: {
+        status: 'BLOCKED',
+        deletedAt: null,
+        OR: [{ blockedById: userId }, { blockedId: userId }],
+      },
+      select: {
+        blockedById: true,
+        blockedId: true,
+      },
+    });
+
+    return new Set(
+      rows.map((row) =>
+        row.blockedById === userId
+          ? row.blockedId.toString()
+          : row.blockedById.toString(),
+      ),
+    );
+  }
+
   private pickClubId(item: unknown): bigint | null {
     if (typeof item !== 'object' || item === null) {
       return null;
@@ -111,6 +184,28 @@ export class MatchesService {
 
     try {
       return BigInt(value);
+    } catch {
+      return null;
+    }
+  }
+
+  private pickUserId(item: unknown): string | null {
+    if (typeof item !== 'object' || item === null) {
+      return null;
+    }
+
+    const record = item as {
+      userId?: unknown;
+      targetUserId?: unknown;
+      profileUserId?: unknown;
+    };
+    const value = record.userId ?? record.targetUserId ?? record.profileUserId;
+    if (typeof value !== 'string' && typeof value !== 'number') {
+      return null;
+    }
+
+    try {
+      return BigInt(value).toString();
     } catch {
       return null;
     }

--- a/src/modules/social/controllers/block/block.controller.ts
+++ b/src/modules/social/controllers/block/block.controller.ts
@@ -7,6 +7,7 @@ import {
   Post,
   Query,
   UseGuards,
+  Delete,
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
@@ -26,11 +27,11 @@ import { AccessTokenGuard } from '../../../auth/guards/access-token.guard';
 @ApiTags('Block')
 @ApiBearerAuth('access-token')
 @UseGuards(AccessTokenGuard)
-@Controller('block')
+@Controller()
 export class BlockController {
   public constructor(private readonly blockService: BlockService) {}
 
-  @Post()
+  @Post('block')
   @ApiOperation({
     summary: '사용자 차단',
     description: '현재 로그인한 사용자가 다른 사용자를 차단합니다.',
@@ -74,7 +75,51 @@ export class BlockController {
     );
   }
 
-  @Get()
+  @Post('blocks')
+  @ApiOperation({
+    summary: '사용자 차단',
+    description: '현재 로그인한 사용자가 다른 사용자를 차단합니다.',
+  })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        targetUserId: { type: 'string', example: '42' },
+        reason: {
+          type: 'string',
+          example: '불쾌한 메시지',
+        },
+      },
+      required: ['targetUserId', 'reason'],
+    },
+  })
+  @ApiOkResponse({
+    description: '차단 성공',
+    schema: {
+      type: 'object',
+      properties: {
+        blockId: { type: 'number', example: 1 },
+        status: { type: 'string', example: 'BLOCKED' },
+        blockedAt: {
+          type: 'string',
+          format: 'date-time',
+        },
+      },
+    },
+  })
+  @ApiUnauthorizedResponse({ description: '로그인 필요' })
+  public async blockUserAlias(
+    @RequiredUserId() userId: number,
+    @Body() req: { targetUserId: string; reason: string },
+  ): Promise<BlockDto> {
+    return this.blockService.createBlock(
+      String(userId),
+      req.targetUserId,
+      req.reason,
+    );
+  }
+
+  @Get('block')
   @ApiOperation({ summary: '차단 목록 조회' })
   @ApiQuery({
     name: 'cursor',
@@ -128,11 +173,76 @@ export class BlockController {
     });
   }
 
-  @Patch(':blockId')
+  @Get('blocks')
+  @ApiOperation({ summary: '차단 목록 조회' })
+  @ApiQuery({
+    name: 'cursor',
+    required: false,
+    description: '다음 페이지 커서',
+  })
+  @ApiQuery({
+    name: 'size',
+    required: false,
+    description: '페이지 크기 (최대 50)',
+  })
+  @ApiOkResponse({
+    description: '차단 목록',
+    schema: {
+      type: 'object',
+      properties: {
+        nextCursor: {
+          type: 'string',
+          nullable: true,
+          example: 'opaque_cursor',
+        },
+        items: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              blockId: { type: 'number', example: 10 },
+              targetUserId: { type: 'number', example: 5 },
+              reason: { type: 'string', example: '스팸 메시지' },
+              status: { type: 'string', example: 'BLOCKED' },
+              blockedAt: {
+                type: 'string',
+                format: 'date-time',
+              },
+            },
+          },
+        },
+      },
+    },
+  })
+  async getBlockedUsersAlias(
+    @RequiredUserId() userId: number,
+    @Query('cursor') cursor?: string,
+    @Query('size') size?: string,
+  ) {
+    return this.blockService.getBlock({
+      userId: String(userId),
+      cursor,
+      size,
+      path: '/api/v1/blocks',
+    });
+  }
+
+  @Patch('block/:blockId')
   @ApiOperation({ summary: '차단 해제' })
   @ApiOkResponse({ description: '차단 해제 완료' })
   @ApiBadRequestResponse({ description: '잘못된 blockId' })
   public async unblockUser(@Param('blockId') blockId: string) {
     return this.blockService.unActivateBlock(blockId);
+  }
+
+  @Delete('blocks/:userId')
+  @ApiOperation({ summary: '사용자 ID 기준 차단 해제' })
+  @ApiOkResponse({ description: '차단 해제 완료' })
+  @ApiBadRequestResponse({ description: '잘못된 userId' })
+  public async unblockTargetUser(
+    @RequiredUserId() userId: number,
+    @Param('userId') targetUserId: string,
+  ) {
+    return this.blockService.unblockTargetUser(String(userId), targetUserId);
   }
 }

--- a/src/modules/social/controllers/report/report.controller.spec.ts
+++ b/src/modules/social/controllers/report/report.controller.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
-import { ReportCategory } from '@prisma/client';
+import { ReportCategory, ReportTargetType } from '@prisma/client';
 import { JwtTokenService } from '../../../auth/services/jwt-token.service';
 import { PrismaService } from '../../../../infra/prisma/prisma.service';
 import { AccessTokenGuard } from '../../../auth/guards/access-token.guard';
@@ -10,6 +10,7 @@ import { ReportController } from './report.controller';
 describe('ReportController', () => {
   let controller: ReportController;
   const reportService = {
+    createUnifiedReport: jest.fn(),
     createReport: jest.fn(),
     createClubReport: jest.fn(),
     createArticleReport: jest.fn(),
@@ -55,6 +56,28 @@ describe('ReportController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  it('통합 신고 요청을 서비스로 위임한다', async () => {
+    const dto = {
+      targetType: ReportTargetType.PROFILE,
+      targetId: '40',
+      reasonCode: ReportCategory.SPAM,
+      detail: '스팸입니다.',
+      targetUserId: '40',
+      chatRoomId: '123',
+    };
+    reportService.createUnifiedReport.mockResolvedValue({
+      reportId: 1,
+      category: ReportCategory.SPAM,
+      reason: '스팸입니다.',
+      targetType: ReportTargetType.PROFILE,
+      targetId: 40,
+    });
+
+    await controller.createUnifiedReport(7, dto);
+
+    expect(reportService.createUnifiedReport).toHaveBeenCalledWith('7', dto);
   });
 
   it('동호회 신고 요청을 서비스로 위임한다', async () => {

--- a/src/modules/social/controllers/report/report.controller.ts
+++ b/src/modules/social/controllers/report/report.controller.ts
@@ -15,6 +15,7 @@ import { RequiredUserId } from '../../../auth/decorators';
 import { AccessTokenGuard } from '../../../auth/guards/access-token.guard';
 import {
   CreateReportRequestDto,
+  CreateUnifiedReportRequestDto,
   CreateUserReportRequestDto,
   ReportCreatedResponseDto,
 } from '../../dtos/report.dto';
@@ -23,11 +24,28 @@ import { ParsePositiveIntPipe } from '../../../../common/pipes/parse-positive-in
 @ApiTags('Report')
 @ApiBearerAuth('access-token')
 @UseGuards(AccessTokenGuard)
-@Controller('report')
+@Controller()
 export class ReportController {
   public constructor(private readonly reportService: ReportService) {}
 
-  @Post()
+  @Post('reports')
+  @ApiOperation({ summary: '콘텐츠 통합 신고 생성' })
+  @ApiBody({ type: CreateUnifiedReportRequestDto })
+  @ApiCreatedResponse({
+    description: '신고 접수 완료',
+    type: ReportCreatedResponseDto,
+  })
+  @ApiUnauthorizedResponse({ description: '로그인 필요' })
+  @ApiNotFoundResponse({ description: '신고 대상을 찾을 수 없음' })
+  @ApiConflictResponse({ description: '이미 신고한 대상' })
+  async createUnifiedReport(
+    @RequiredUserId() userId: number,
+    @Body() dto: CreateUnifiedReportRequestDto,
+  ): Promise<ReportCreatedResponseDto> {
+    return this.reportService.createUnifiedReport(String(userId), dto);
+  }
+
+  @Post('report')
   @ApiOperation({ summary: '사용자 신고 생성' })
   @ApiBody({ type: CreateUserReportRequestDto })
   @ApiCreatedResponse({ description: '신고 접수 완료' })
@@ -45,7 +63,7 @@ export class ReportController {
     );
   }
 
-  @Post('clubs/:clubId')
+  @Post('report/clubs/:clubId')
   @ApiOperation({ summary: '동호회 신고 생성' })
   @ApiParam({ name: 'clubId', example: 12 })
   @ApiBody({ type: CreateReportRequestDto })
@@ -68,7 +86,7 @@ export class ReportController {
     );
   }
 
-  @Post('clubs/:clubId/articles/:articleId')
+  @Post('report/clubs/:clubId/articles/:articleId')
   @ApiOperation({ summary: '동호회 게시글 신고 생성' })
   @ApiParam({ name: 'clubId', example: 12 })
   @ApiParam({ name: 'articleId', example: 345 })
@@ -94,7 +112,7 @@ export class ReportController {
     );
   }
 
-  @Post('clubs/:clubId/articles/:articleId/comments/:commentId')
+  @Post('report/clubs/:clubId/articles/:articleId/comments/:commentId')
   @ApiOperation({ summary: '동호회 게시글 댓글 신고 생성' })
   @ApiParam({ name: 'clubId', example: 12 })
   @ApiParam({ name: 'articleId', example: 345 })

--- a/src/modules/social/dtos/report.dto.ts
+++ b/src/modules/social/dtos/report.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { ReportCategory } from '@prisma/client';
+import { ReportCategory, ReportTargetType } from '@prisma/client';
 import {
   IsEnum,
   IsNotEmpty,
@@ -51,6 +51,59 @@ export class CreateUserReportRequestDto extends CreateReportRequestDto {
   chatRoomId?: string;
 }
 
+export class CreateUnifiedReportRequestDto {
+  @ApiProperty({
+    enum: ReportTargetType,
+    example: ReportTargetType.PROFILE,
+    description: '신고 대상 타입',
+  })
+  @IsEnum(ReportTargetType)
+  targetType!: ReportTargetType;
+
+  @ApiProperty({
+    example: '40',
+    description: '신고 대상 ID',
+  })
+  @IsString()
+  @IsNotEmpty()
+  targetId!: string;
+
+  @ApiProperty({
+    enum: ReportCategory,
+    example: ReportCategory.SPAM,
+    description: '신고 사유 코드',
+  })
+  @IsEnum(ReportCategory)
+  reasonCode!: ReportCategory;
+
+  @ApiProperty({
+    example: '불쾌한 콘텐츠가 포함되어 있습니다.',
+    description: '신고 상세 내용',
+    maxLength: 100,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  detail!: string;
+
+  @ApiPropertyOptional({
+    example: '40',
+    description:
+      '신고 대상 사용자 ID. 프로필/음성/채팅 맥락 신고에 사용합니다.',
+  })
+  @IsOptional()
+  @IsString()
+  targetUserId?: string;
+
+  @ApiPropertyOptional({
+    example: '123',
+    description: '관련된 채팅방 ID',
+  })
+  @IsOptional()
+  @IsString()
+  chatRoomId?: string;
+}
+
 export class ReportCreatedResponseDto {
   @ApiProperty({ example: 123 })
   reportId!: number;
@@ -60,6 +113,15 @@ export class ReportCreatedResponseDto {
 
   @ApiProperty({ example: '스팸성 홍보 내용이 반복적으로 게시됩니다.' })
   reason!: string;
+
+  @ApiPropertyOptional({
+    enum: ReportTargetType,
+    example: ReportTargetType.USER,
+  })
+  targetType?: ReportTargetType;
+
+  @ApiPropertyOptional({ example: 40 })
+  targetId?: number;
 
   @ApiPropertyOptional({ example: 12 })
   clubId?: number;

--- a/src/modules/social/repositories/block.repository.ts
+++ b/src/modules/social/repositories/block.repository.ts
@@ -156,6 +156,37 @@ export class BlockRepository {
     };
   }
 
+  async patchBlockByTargetUser(
+    userId: string,
+    targetUserId: string,
+  ): Promise<BlockDto | null> {
+    const blockedById = BigInt(userId);
+    const blockedId = BigInt(targetUserId);
+    const block = await this.prisma.block.findFirst({
+      where: {
+        blockedById,
+        blockedId,
+        status: BlockStatus.BLOCKED,
+        deletedAt: null,
+      },
+      select: { id: true },
+    });
+    if (!block) {
+      return null;
+    }
+
+    const response = await this.prisma.block.update({
+      where: { id: block.id },
+      data: { status: BlockStatus.UNBLOCKED, blockedAt: new Date() },
+    });
+
+    return {
+      blockId: Number(response.id),
+      status: response.status,
+      blockedAt: response.blockedAt.toISOString(),
+    };
+  }
+
   async getBlock(params: {
     userId: string;
     cursor?: string;

--- a/src/modules/social/repositories/report.repository.ts
+++ b/src/modules/social/repositories/report.repository.ts
@@ -12,6 +12,11 @@ import {
 } from '../dtos/report.dto';
 
 const COMMENT_REPORT_TARGET: ReportTargetType = 'COMMENT';
+const USER_RELATED_REPORT_TARGETS = new Set<ReportTargetType>([
+  ReportTargetType.USER,
+  ReportTargetType.PROFILE,
+  ReportTargetType.VOICE,
+]);
 
 @Injectable()
 export class ReportRepository {
@@ -35,6 +40,16 @@ export class ReportRepository {
     });
   }
 
+  findActiveArticleById(articleId: string) {
+    return this.prisma.article.findFirst({
+      where: {
+        id: BigInt(articleId),
+        deletedAt: null,
+      },
+      select: { id: true, clubId: true, userId: true },
+    });
+  }
+
   findActiveCommentByArticleId(articleId: string, commentId: string) {
     return this.prisma.comment.findFirst({
       where: {
@@ -46,6 +61,29 @@ export class ReportRepository {
         },
       },
       select: { id: true, articleId: true, userId: true },
+    });
+  }
+
+  findActiveCommentById(commentId: string) {
+    return this.prisma.comment.findFirst({
+      where: {
+        id: BigInt(commentId),
+        deletedAt: null,
+        article: {
+          deletedAt: null,
+        },
+      },
+      select: { id: true, articleId: true, userId: true },
+    });
+  }
+
+  findActiveUserById(userId: string) {
+    return this.prisma.user.findFirst({
+      where: {
+        id: BigInt(userId),
+        deletedAt: null,
+      },
+      select: { id: true },
     });
   }
 
@@ -77,6 +115,112 @@ export class ReportRepository {
         report: { deletedAt: null },
       },
     });
+  }
+
+  countActiveTargetReports(targetType: ReportTargetType, targetId: string) {
+    return this.prisma.report.count({
+      where: {
+        targetType,
+        targetId: BigInt(targetId),
+        deletedAt: null,
+      },
+    });
+  }
+
+  async blindReportedTarget(
+    targetType: ReportTargetType,
+    targetId: string,
+  ): Promise<void> {
+    const id = BigInt(targetId);
+    if (targetType === ReportTargetType.ARTICLE) {
+      await this.prisma.article.updateMany({
+        where: { id, deletedAt: null },
+        data: { deletedAt: new Date() },
+      });
+      return;
+    }
+
+    if (targetType === ReportTargetType.COMMENT) {
+      await this.prisma.comment.updateMany({
+        where: { id, deletedAt: null },
+        data: { deletedAt: new Date() },
+      });
+      return;
+    }
+  }
+
+  async createUnifiedReport(params: {
+    userId: string;
+    targetType: ReportTargetType;
+    targetId: string;
+    reason: string;
+    category: ReportCategory;
+    targetUserId?: string;
+    chatRoomId?: string;
+  }): Promise<ReportCreatedResponseDto> {
+    const exist = await this.findExistingTargetReport(
+      params.userId,
+      params.targetType,
+      params.targetId,
+    );
+    if (exist != null) {
+      return {
+        reportId: Number(exist.id),
+        category: params.category,
+        reason: 'Already reported.',
+        targetType: params.targetType,
+        targetId: Number(params.targetId),
+      };
+    }
+
+    const relatedUserId = this.resolveReportedUserId(params);
+    const result = await this.createTargetReport({
+      userId: params.userId,
+      targetType: params.targetType,
+      targetId: params.targetId,
+      reason: params.reason,
+      category: params.category,
+      chatRoomId: params.chatRoomId,
+      createLegacyTarget: relatedUserId
+        ? async (tx, reportId) => {
+            await tx.userReport.create({
+              data: {
+                reportId,
+                reportedUserId: BigInt(relatedUserId),
+              },
+            });
+          }
+        : undefined,
+    });
+
+    if (!result.created) {
+      return {
+        reportId: Number(result.report.id),
+        category: params.category,
+        reason: 'Already reported.',
+        targetType: params.targetType,
+        targetId: Number(params.targetId),
+      };
+    }
+
+    return {
+      reportId: Number(result.report.id),
+      category: params.category,
+      reason: params.reason,
+      targetType: params.targetType,
+      targetId: Number(params.targetId),
+    };
+  }
+
+  private resolveReportedUserId(params: {
+    targetType: ReportTargetType;
+    targetId: string;
+    targetUserId?: string;
+  }): string | undefined {
+    if (!USER_RELATED_REPORT_TARGETS.has(params.targetType)) {
+      return params.targetUserId;
+    }
+    return params.targetUserId ?? params.targetId;
   }
 
   async createReport(

--- a/src/modules/social/services/block/block.service.ts
+++ b/src/modules/social/services/block/block.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { BlockRepository } from '../../repositories/block.repository';
 import { AppException } from '../../../../common/errors/app.exception';
 import { ERROR_DEFINITIONS } from '../../../../common/errors/error-codes';
+import { BlockFilterInterceptor } from '../../../../common/interceptors/block-filter.interceptor';
 
 interface PaginationParams {
   userId: string;
@@ -32,7 +33,9 @@ export class BlockService {
         message: ERROR_DEFINITIONS.SOCIAL_BLOCK_ALREADY_EXISTS.message,
         details: { targetUserId: targetUserId },
       });
-    } else return result;
+    }
+    BlockFilterInterceptor.invalidateUsers([userId, targetUserId]);
+    return result;
   }
   async unActivateBlock(blockId: string) {
     const result = await this.blockRepository.patchBlock(blockId);
@@ -42,6 +45,21 @@ export class BlockService {
         message: ERROR_DEFINITIONS.SOCIAL_BLOCK_NOT_FOUND.message,
         details: { field: 'blockId' },
       });
+    return result;
+  }
+
+  async unblockTargetUser(userId: string, targetUserId: string) {
+    const result = await this.blockRepository.patchBlockByTargetUser(
+      userId,
+      targetUserId,
+    );
+    if (result == null) {
+      throw new AppException('SOCIAL_BLOCK_NOT_FOUND', {
+        message: ERROR_DEFINITIONS.SOCIAL_BLOCK_NOT_FOUND.message,
+        details: { field: 'targetUserId' },
+      });
+    }
+    BlockFilterInterceptor.invalidateUsers([userId, targetUserId]);
     return result;
   }
   async getBlock(params: PaginationParams) {

--- a/src/modules/social/services/report/report.service.spec.ts
+++ b/src/modules/social/services/report/report.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { ReportCategory } from '@prisma/client';
+import { ReportCategory, ReportTargetType } from '@prisma/client';
 import { ReportService } from './report.service';
 import { ReportRepository } from '../../repositories/report.repository';
 import { NotificationService } from '../../../notification/services/notification.service';
@@ -8,9 +8,15 @@ describe('ReportService', () => {
   let service: ReportService;
   const reportRepository = {
     createReport: jest.fn(),
+    createUnifiedReport: jest.fn(),
+    findActiveUserById: jest.fn(),
     findActiveClubById: jest.fn(),
+    findActiveArticleById: jest.fn(),
     findActiveArticleByClubId: jest.fn(),
+    findActiveCommentById: jest.fn(),
     findActiveCommentByArticleId: jest.fn(),
+    countActiveTargetReports: jest.fn(),
+    blindReportedTarget: jest.fn(),
     countActiveClubReports: jest.fn(),
     countActiveUserReports: jest.fn(),
     deactivateClub: jest.fn(),
@@ -47,6 +53,72 @@ describe('ReportService', () => {
     expect(service).toBeDefined();
   });
 
+  it('통합 프로필 신고를 생성한다', async () => {
+    reportRepository.findActiveUserById.mockResolvedValue({ id: 40n });
+    reportRepository.createUnifiedReport.mockResolvedValue({
+      reportId: 1,
+      category: ReportCategory.SPAM,
+      reason: '스팸입니다.',
+      targetType: ReportTargetType.PROFILE,
+      targetId: 40,
+    });
+    reportRepository.countActiveTargetReports.mockResolvedValue(1);
+
+    const result = await service.createUnifiedReport('7', {
+      targetType: ReportTargetType.PROFILE,
+      targetId: '40',
+      reasonCode: ReportCategory.SPAM,
+      detail: '스팸입니다.',
+      targetUserId: '40',
+      chatRoomId: '123',
+    });
+
+    expect(reportRepository.findActiveUserById).toHaveBeenCalledWith('40');
+    expect(reportRepository.createUnifiedReport).toHaveBeenCalledWith({
+      userId: '7',
+      targetType: ReportTargetType.PROFILE,
+      targetId: '40',
+      reason: '스팸입니다.',
+      category: ReportCategory.SPAM,
+      targetUserId: '40',
+      chatRoomId: '123',
+    });
+    expect(reportRepository.countActiveTargetReports).toHaveBeenCalledWith(
+      ReportTargetType.PROFILE,
+      '40',
+    );
+    expect(reportRepository.blindReportedTarget).not.toHaveBeenCalled();
+    expect(result.targetId).toBe(40);
+  });
+
+  it('통합 게시글 신고가 3번 이상이면 블라인드 처리한다', async () => {
+    reportRepository.findActiveArticleById.mockResolvedValue({
+      id: 345n,
+      clubId: 12n,
+      userId: 88n,
+    });
+    reportRepository.createUnifiedReport.mockResolvedValue({
+      reportId: 1,
+      category: ReportCategory.ABUSE,
+      reason: '욕설입니다.',
+      targetType: ReportTargetType.ARTICLE,
+      targetId: 345,
+    });
+    reportRepository.countActiveTargetReports.mockResolvedValue(3);
+
+    await service.createUnifiedReport('7', {
+      targetType: ReportTargetType.ARTICLE,
+      targetId: '345',
+      reasonCode: ReportCategory.ABUSE,
+      detail: '욕설입니다.',
+    });
+
+    expect(reportRepository.blindReportedTarget).toHaveBeenCalledWith(
+      ReportTargetType.ARTICLE,
+      '345',
+    );
+  });
+
   it('동호회 신고를 생성한다', async () => {
     reportRepository.findActiveClubById.mockResolvedValue({
       id: 12n,
@@ -59,6 +131,7 @@ describe('ReportService', () => {
       clubId: 12,
     });
     reportRepository.countActiveClubReports.mockResolvedValue(3);
+    reportRepository.countActiveTargetReports.mockResolvedValue(3);
 
     const result = await service.createClubReport('7', '12', {
       category: ReportCategory.SPAM,
@@ -100,6 +173,7 @@ describe('ReportService', () => {
       clubId: 12,
     });
     reportRepository.countActiveClubReports.mockResolvedValue(5);
+    reportRepository.countActiveTargetReports.mockResolvedValue(5);
 
     await service.createClubReport('7', '12', {
       category: ReportCategory.SPAM,
@@ -167,6 +241,7 @@ describe('ReportService', () => {
       articleId: 345,
     });
     reportRepository.countActiveUserReports.mockResolvedValue(4);
+    reportRepository.countActiveTargetReports.mockResolvedValue(2);
 
     const result = await service.createArticleReport('7', '12', '345', {
       category: ReportCategory.ABUSE,
@@ -230,6 +305,7 @@ describe('ReportService', () => {
       articleId: 345,
       commentId: 678,
     });
+    reportRepository.countActiveTargetReports.mockResolvedValue(2);
     const result = await service.createCommentReport('7', '12', '345', '678', {
       category: ReportCategory.ABUSE,
       reason: '욕설입니다.',

--- a/src/modules/social/services/report/report.service.ts
+++ b/src/modules/social/services/report/report.service.ts
@@ -1,14 +1,22 @@
 import { Injectable } from '@nestjs/common';
-import { NotificationType, ReportCategory } from '@prisma/client';
+import {
+  NotificationType,
+  ReportCategory,
+  ReportTargetType,
+} from '@prisma/client';
 import { ReportRepository } from '../../repositories/report.repository';
 import { AppException } from '../../../../common/errors/app.exception';
 import { ERROR_DEFINITIONS } from '../../../../common/errors/error-codes';
-import { CreateReportRequestDto } from '../../dtos/report.dto';
+import {
+  CreateReportRequestDto,
+  CreateUnifiedReportRequestDto,
+} from '../../dtos/report.dto';
 import { NotificationService } from '../../../notification/services/notification.service';
 
 @Injectable()
 export class ReportService {
   private static readonly CLUB_REPORT_DEACTIVATION_THRESHOLD = 5;
+  private static readonly CONTENT_REPORT_BLIND_THRESHOLD = 3;
 
   constructor(
     readonly reportRepository: ReportRepository,
@@ -37,6 +45,33 @@ export class ReportService {
     } else return result;
   }
 
+  async createUnifiedReport(
+    userId: string,
+    dto: CreateUnifiedReportRequestDto,
+  ) {
+    await this.assertUnifiedReportTarget(dto);
+
+    const result = await this.reportRepository.createUnifiedReport({
+      userId,
+      targetType: dto.targetType,
+      targetId: dto.targetId,
+      reason: dto.detail,
+      category: dto.reasonCode,
+      targetUserId: dto.targetUserId,
+      chatRoomId: dto.chatRoomId,
+    });
+
+    if (result.reason === 'Already reported.') {
+      throw new AppException('SOCIAL_REPORT_EXISTS', {
+        message: ERROR_DEFINITIONS.SOCIAL_REPORT_EXISTS.message,
+        details: { field: 'targetId' },
+      });
+    }
+
+    await this.handleContentReportThreshold(dto.targetType, dto.targetId);
+    return result;
+  }
+
   async createClubReport(
     userId: string,
     clubId: string,
@@ -60,6 +95,7 @@ export class ReportService {
       });
     }
 
+    await this.handleContentReportThreshold(ReportTargetType.CLUB, clubId);
     await this.handleClubReportThreshold(String(userId), clubId, club.hostId);
     return result;
   }
@@ -96,6 +132,10 @@ export class ReportService {
       String(userId),
       articleId,
       article.userId,
+    );
+    await this.handleContentReportThreshold(
+      ReportTargetType.ARTICLE,
+      articleId,
     );
     return result;
   }
@@ -138,7 +178,61 @@ export class ReportService {
       });
     }
 
+    await this.handleContentReportThreshold(
+      ReportTargetType.COMMENT,
+      commentId,
+    );
     return result;
+  }
+
+  private async assertUnifiedReportTarget(
+    dto: CreateUnifiedReportRequestDto,
+  ): Promise<void> {
+    if (dto.targetType === ReportTargetType.CLUB) {
+      const club = await this.reportRepository.findActiveClubById(dto.targetId);
+      if (!club) throw new AppException('CLUB_NOT_FOUND');
+      return;
+    }
+
+    if (dto.targetType === ReportTargetType.ARTICLE) {
+      const article = await this.reportRepository.findActiveArticleById(
+        dto.targetId,
+      );
+      if (!article) throw new AppException('ARTICLE_NOT_FOUND');
+      return;
+    }
+
+    if (dto.targetType === ReportTargetType.COMMENT) {
+      const comment = await this.reportRepository.findActiveCommentById(
+        dto.targetId,
+      );
+      if (!comment) throw new AppException('COMMENT_NOT_FOUND');
+      return;
+    }
+
+    if (
+      dto.targetType === ReportTargetType.USER ||
+      dto.targetType === ReportTargetType.PROFILE ||
+      dto.targetType === ReportTargetType.VOICE
+    ) {
+      const user = await this.reportRepository.findActiveUserById(
+        dto.targetUserId ?? dto.targetId,
+      );
+      if (!user) throw new AppException('SOCIAL_TARGET_USER_NOT_FOUND');
+    }
+  }
+
+  private async handleContentReportThreshold(
+    targetType: ReportTargetType,
+    targetId: string,
+  ): Promise<void> {
+    const reportCount = await this.reportRepository.countActiveTargetReports(
+      targetType,
+      targetId,
+    );
+    if (reportCount >= ReportService.CONTENT_REPORT_BLIND_THRESHOLD) {
+      await this.reportRepository.blindReportedTarget(targetType, targetId);
+    }
   }
 
   private async handleClubReportThreshold(


### PR DESCRIPTION
## 이슈 번호
close #343 

## 주요 변경사항
  - UGC 안전성 대응을 위한 신고/차단 API 확장
    - `PROFILE`, `VOICE` 신고 target type 추가
    - 통합 신고 요청 DTO에 `targetUserId`, `chatRoomId` 등 컨텍스트 필드 추가
    - `/blocks` alias API 추가 및 차단 목록/해제 응답 보강
    - 차단 생성/해제 시 차단 필터 캐시 무효화 처리

  - 약관 응답 및 사용자 동의 저장 메타데이터 추가
    - `AgreementType` enum 추가
    - 약관 응답에 `type`, `version`, `isRequired` 포함
    - 사용자 동의 저장 시 `agreementType`, `agreementVersion` 보존

  - 차단 대상 미노출 필터 적용 범위 확장
    - 매칭 후보 추천 결과에서 차단 사용자 후보 제거
    - FastAPI 추천 클럽 결과에서 차단 host 클럽 제거
    - 클럽 목록, 오늘 추천, top hosts, 상세 조회에 viewer 기준 차단 필터 적용
    - 피드/게시글 조회의 기존 차단 필터 동작 확인 및 관련 테스트 보강

  - FastAPI 실패 응답 처리 안정화
    - S3 URL 변환 과정에서 순환 객체를 만나도 재귀/OOM이 발생하지 않도록 circular guard 추가
    - 관련 단위 테스트 추가

  - DB 스키마 및 마이그레이션 추가
    - `ReportTargetType`: `PROFILE`, `VOICE`
    - `AgreementType`
    - `MarketingAgreement`: `type`, `version`, `isRequired`
    - `UserMarketingAgreement`: `agreementType`, `agreementVersion`

  ## 테스트 결과 (스크린샷)
  - `npm run lint` 통과
  - `npm run typecheck` 통과
  - `npm run test` 통과
    - Test Suites: `56 passed`
    - Tests: `374 passed`
  - `npm run build` 통과
<img width="1440" height="1100" alt="eum-148-swagger-api-proof" src="https://github.com/user-attachments/assets/4c9f4177-7479-4917-b55c-dcdbe18b6802" />
<img width="1425" height="1200" alt="eum-148-block-filter-swagger-proof" src="https://github.com/user-attachments/assets/58956385-72ec-40bf-979b-1db8cccf0352" />

## 참고 및 개선사항
- 추천 상대에서 제외되는지는 staging 에서 확인해봐야할것같은데 아마 확실히 작동 잘 할겁니다

